### PR TITLE
For local run check env for KARMA_BROWSERS

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -76,13 +76,13 @@ module.exports = function karma(config) {
       ];
     }
   } else {
-    // This is a local run. Use Chrome.
+    // This is a local run.
+    const karmaBrowsers = process.env.KARMA_BROWSERS;
+    const localBrowsers = karmaBrowsers ? karmaBrowsers.split(',') : ['Chrome'];
 
     console.log('Running locally.');
 
-    browsers = [
-      'Chrome',
-    ];
+    browsers = localBrowsers;
   }
 
   let testDirs = [


### PR DESCRIPTION
Current default is "Chrome", but on Linux Chrome is not available
by default. Allow use of KARMA_BROWSERS env var to specify which
browser(s) to use. For example:

export KARMA_BROWSERS=Firefox
export KARMA_BROWSERS=Chrome,Firefox (run both)