### PR TITLE
Use max-width for logo.

### DIFF
--- a/styles/cspace-ui/Logo.css
+++ b/styles/cspace-ui/Logo.css
@@ -7,5 +7,5 @@
 }
 
 .common > a > img {
-  width: 100%;
+  max-width: 100%;
 }


### PR DESCRIPTION
Otherwise can distort image by stretching it to fill space.