### PR TITLE
personTitles and genders option list updates

### DIFF
--- a/src/plugins/recordTypes/person/optionLists.js
+++ b/src/plugins/recordTypes/person/optionLists.js
@@ -93,7 +93,7 @@ export default {
       'Mrs',
       'Ms',
       'Prince',
-      'Princess'
+      'Princess',
       'Professor',
       'Queen',
       'Reverend',

--- a/src/plugins/recordTypes/person/optionLists.js
+++ b/src/plugins/recordTypes/person/optionLists.js
@@ -232,6 +232,7 @@ export default {
       'pansexual',
       'polygender',
       'questioning',
+      'transgender',
       'two-spirit'
     ],
     messages: defineMessages({
@@ -294,6 +295,10 @@ export default {
       questioning: {
         id: 'option.genders.questioning',
         defaultMessage: 'questioning',
+      },
+      transgender: {
+        id: 'option.genders.transgender',
+        defaultMessage: 'transgender',
       },
       'two-spirit': {
         id: 'option.genders.two-spirit',

--- a/src/plugins/recordTypes/person/optionLists.js
+++ b/src/plugins/recordTypes/person/optionLists.js
@@ -219,7 +219,7 @@ export default {
     values: [
       'agender',
       'bigender',
-      'dyadic'
+      'dyadic',
       'female',
       'feminine',
       'gender-fluid',
@@ -234,7 +234,7 @@ export default {
       'questioning',
       'transgender',
       'transsexual',
-      'two-spirit'
+      'two-spirit',
     ],
     messages: defineMessages({
       agender: {

--- a/src/plugins/recordTypes/person/optionLists.js
+++ b/src/plugins/recordTypes/person/optionLists.js
@@ -233,6 +233,7 @@ export default {
       'polygender',
       'questioning',
       'transgender',
+      'transsexual',
       'two-spirit'
     ],
     messages: defineMessages({
@@ -299,6 +300,10 @@ export default {
       transgender: {
         id: 'option.genders.transgender',
         defaultMessage: 'transgender',
+      },
+      transsexual: {
+        id: 'option.genders.transsexual',
+        defaultMessage: 'transsexual',
       },
       'two-spirit': {
         id: 'option.genders.two-spirit',

--- a/src/plugins/recordTypes/person/optionLists.js
+++ b/src/plugins/recordTypes/person/optionLists.js
@@ -217,17 +217,87 @@ export default {
   },
   genders: {
     values: [
+      'agender',
+      'bigender',
+      'dyadic'
       'female',
+      'feminine',
+      'gender-fluid',
+      'gender-neutral',
+      'gender-non-binary',
+      'genderqueer',
+      'intersex',
       'male',
+      'masculine',
+      'pansexual',
+      'polygender',
+      'questioning',
+      'two-spirit'
     ],
     messages: defineMessages({
+      agender: {
+        id: 'option.genders.agender',
+        defaultMessage: 'agender',
+      },
+      bigender: {
+        id: 'option.genders.bigender',
+        defaultMessage: 'bigender',
+      },
+      dyadic: {
+        id: 'option.genders.dyadic',
+        defaultMessage: 'dyadic',
+      },
       female: {
         id: 'option.genders.female',
         defaultMessage: 'female',
       },
+      feminine: {
+        id: 'option.genders.feminine',
+        defaultMessage: 'feminine',
+      },
+      'gender-fluid': {
+        id: 'option.genders.gender-fluid',
+        defaultMessage: 'gender-fluid',
+      },
+      'gender-neutral': {
+        id: 'option.genders.gender-neutral',
+        defaultMessage: 'gender-neutral',
+      },
+      'gender-non-binary': {
+        id: 'option.genders.gender-non-binary',
+        defaultMessage: 'gender non-binary',
+      },
+      genderqueer: {
+        id: 'option.genders.genderqueer',
+        defaultMessage: 'genderqueer',
+      },
+      intersex: {
+        id: 'option.genders.intersex',
+        defaultMessage: 'intersex',
+      },
       male: {
         id: 'option.genders.male',
         defaultMessage: 'male',
+      },
+      masculine: {
+        id: 'option.genders.masculine',
+        defaultMessage: 'masculine',
+      },
+      pansexual: {
+        id: 'option.genders.pansexual',
+        defaultMessage: 'pansexual',
+      },
+      polygender: {
+        id: 'option.genders.polygender',
+        defaultMessage: 'polygender',
+      },
+      questioning: {
+        id: 'option.genders.questioning',
+        defaultMessage: 'questioning',
+      },
+      'two-spirit': {
+        id: 'option.genders.two-spirit',
+        defaultMessage: 'two-spirit',
       },
     }),
   },

--- a/src/plugins/recordTypes/person/optionLists.js
+++ b/src/plugins/recordTypes/person/optionLists.js
@@ -85,7 +85,7 @@ export default {
       'Governor',
       'Honorable',
       'Judge',
-      'King', 
+      'King',
       'Lady',
       'Lord',
       'Miss',

--- a/src/plugins/recordTypes/person/optionLists.js
+++ b/src/plugins/recordTypes/person/optionLists.js
@@ -71,20 +71,108 @@ export default {
   },
   personTitles: {
     values: [
+      'Admiral',
+      'Baron',
+      'Baroness',
+      'Captain',
+      'Commander',
+      'Commodore',
+      'Count',
+      'Countess',
+      'Dame',
+      'Dr',
+      'General',
+      'Governor',
+      'Honorable',
+      'Judge',
+      'King', 
+      'Lady',
+      'Lord',
+      'Miss',
       'Mr',
       'Mrs',
       'Ms',
-      'Miss',
-      'Dr',
+      'Prince',
+      'Princess'
       'Professor',
+      'Queen',
+      'Reverend',
+      'Saint',
       'Sir',
-      'Dame',
-      'Baron',
-      'Baroness',
-      'Lord',
-      'Lady',
     ],
     messages: defineMessages({
+      Admiral: {
+        id: 'option.personTitles.Admiral',
+        defaultMessage: 'Admiral',
+      },
+      Baron: {
+        id: 'option.personTitles.Baron',
+        defaultMessage: 'Baron',
+      },
+      Baroness: {
+        id: 'option.personTitles.Baroness',
+        defaultMessage: 'Baroness',
+      },
+      Captain: {
+        id: 'option.personTitles.Captain',
+        defaultMessage: 'Captain',
+      },
+      Commander: {
+        id: 'option.personTitles.Commander',
+        defaultMessage: 'Commander',
+      },
+      Commodore: {
+        id: 'option.personTitles.Commodore',
+        defaultMessage: 'Commodore',
+      },
+      Count: {
+        id: 'option.personTitles.Count',
+        defaultMessage: 'Count',
+      },
+      Countess: {
+        id: 'option.personTitles.Countess',
+        defaultMessage: 'Countess',
+      },
+      Dame: {
+        id: 'option.personTitles.Dame',
+        defaultMessage: 'Dame',
+      },
+      Dr: {
+        id: 'option.personTitles.Dr',
+        defaultMessage: 'Dr',
+      },
+      General: {
+        id: 'option.personTitles.General',
+        defaultMessage: 'General',
+      },
+      Governor: {
+        id: 'option.personTitles.Governor',
+        defaultMessage: 'Governor',
+      },
+      Honorable: {
+        id: 'option.personTitles.Honorable',
+        defaultMessage: 'Honorable',
+      },
+      Judge: {
+        id: 'option.personTitles.Judge',
+        defaultMessage: 'Judge',
+      },
+      King: {
+        id: 'option.personTitles.King',
+        defaultMessage: 'King',
+      },
+      Lady: {
+        id: 'option.personTitles.Lady',
+        defaultMessage: 'Lady',
+      },
+      Lord: {
+        id: 'option.personTitles.Lord',
+        defaultMessage: 'Lord',
+      },
+      Miss: {
+        id: 'option.personTitles.Miss',
+        defaultMessage: 'Miss',
+      },
       Mr: {
         id: 'option.personTitles.Mr',
         defaultMessage: 'Mr',
@@ -97,41 +185,33 @@ export default {
         id: 'option.personTitles.Ms',
         defaultMessage: 'Ms',
       },
-      Miss: {
-        id: 'option.personTitles.Miss',
-        defaultMessage: 'Miss',
+      Prince: {
+        id: 'option.personTitles.Prince',
+        defaultMessage: 'Prince',
       },
-      Dr: {
-        id: 'option.personTitles.Dr',
-        defaultMessage: 'Dr',
+      Princess: {
+        id: 'option.personTitles.Princess',
+        defaultMessage: 'Princess',
       },
       Professor: {
         id: 'option.personTitles.Professor',
         defaultMessage: 'Professor',
       },
+      Queen: {
+        id: 'option.personTitles.Queen',
+        defaultMessage: 'Queen',
+      },
+      Reverend: {
+        id: 'option.personTitles.Reverend',
+        defaultMessage: 'Reverend',
+      },
+      Saint: {
+        id: 'option.personTitles.Saint',
+        defaultMessage: 'Saint',
+      },
       Sir: {
         id: 'option.personTitles.Sir',
         defaultMessage: 'Sir',
-      },
-      Dame: {
-        id: 'option.personTitles.Dame',
-        defaultMessage: 'Dame',
-      },
-      Baron: {
-        id: 'option.personTitles.Baron',
-        defaultMessage: 'Baron',
-      },
-      Baroness: {
-        id: 'option.personTitles.Baroness',
-        defaultMessage: 'Baroness',
-      },
-      Lord: {
-        id: 'option.personTitles.Lord',
-        defaultMessage: 'Lord',
-      },
-      Lady: {
-        id: 'option.personTitles.Lady',
-        defaultMessage: 'Lady',
       },
     }),
   },


### PR DESCRIPTION
**personTitles**

- Adds a number of English honorifics/titles to personTitles optionList. Base list of added terms is from a migration client's data, but all terms are generally applicable, so will be added to the base UI.

- Puts all values in alphabetical order, given current length of list making any other order seem somewhat chaotic. Megan okayed changing the order of this list. 

**genders**
Updates the genders optionList, as per https://collectionspace.atlassian.net/browse/DRYD-884

Adds [the gender terms from Art & Architecture Thesaurus](http://www.getty.edu/vow/AATHierarchy?find=&logic=AND&note=&page=1&subjectid=300411835). Also adds "transgender" and "transsexual" based on recommendations from [Billey & Drabinski (2017). Cataloging Gender and RDA Instruction 9.7](http://downloads.alcts.ala.org/ce/20170315_Cataloging_Gender_RDA9.7_Slides.pdf)

(Note to myself... when this is merged, update https://collectionspace.atlassian.net/wiki/spaces/COL/pages/666274922/Name+Authority+Schema to reflect them.)