### PR TITLE
DRYD-955: LMI Record not saving without identification number

### DIFF
--- a/src/actions/search.js
+++ b/src/actions/search.js
@@ -271,7 +271,7 @@ export const findFirst = (config, recordType, asFieldName, asValue) => {
     return Promise.reject();
   }
 
-  const value = asValue.replaceAll('"', '\\"');
+  const value = (typeof asValue === 'undefined') ? undefined : asValue.replaceAll('"', '\\"');
 
   const requestConfig = {
     params: {


### PR DESCRIPTION
Resolves: https://collectionspace.atlassian.net/browse/DRYD-955

* Check if `asValue` is undefined when searching for first instance of a record

-------------------

I wasn't actually sure where to put the logic for this as it could go in a few places (`movement/fields.js`, `helpers/validationHelpers.js`) so I settled on `findFirst` as it could be called from multiple places. Also wasn't sure of the _best_ way to handle this as propagating an undefined value feels problematic, but rejecting the Promise caused the same behavior described in the issue with an error message.