### PR TITLE
Audit record form

### DIFF
--- a/src/components/record/RecordSidebar.jsx
+++ b/src/components/record/RecordSidebar.jsx
@@ -79,7 +79,7 @@ export default function RecordSidebar(props) {
   let reports = null;
   let batchJobs = null;
 
-  if (!isAuthority && !isUtility) {
+  if (!isAuthority && !isUtility && !isAudit) {
     mediaSnapshot = (
       <MediaSnapshotPanelContainer
         color={panelColor}

--- a/src/components/record/RecordTitleBar.jsx
+++ b/src/components/record/RecordTitleBar.jsx
@@ -76,7 +76,8 @@ export default function RecordTitleBar(props, context) {
 
   let nav;
 
-  if (searchDescriptor) {
+  const isAudit = recordType === 'audit';
+  if (searchDescriptor && !isAudit) {
     nav = (
       <SearchResultTraverserContainer
         config={config}

--- a/src/containers/input/DateTimeInputContainer.jsx
+++ b/src/containers/input/DateTimeInputContainer.jsx
@@ -27,10 +27,13 @@ export function IntlAwareDateTimeInput(props) {
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...remainingProps}
       formatValue={(timestamp) => {
-        const date = intl.formatDate(timestamp, { day: 'numeric', month: 'short', year: 'numeric' });
-        const time = intl.formatTime(timestamp, { hour: 'numeric', minute: 'numeric', second: 'numeric' });
+        if (timestamp) {
+          const date = intl.formatDate(timestamp, { day: 'numeric', month: 'short', year: 'numeric' });
+          const time = intl.formatTime(timestamp, { hour: 'numeric', minute: 'numeric', second: 'numeric' });
+          return intl.formatMessage(messages.value, { date, time });
+        }
 
-        return intl.formatMessage(messages.value, { date, time });
+        return timestamp;
       }}
     />
   );

--- a/src/containers/input/FieldTextInputContainer.jsx
+++ b/src/containers/input/FieldTextInputContainer.jsx
@@ -1,0 +1,51 @@
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { components as inputComponents } from 'cspace-input';
+import { injectIntl, intlShape } from 'react-intl';
+import get from 'lodash/get';
+import { formatRecordTypeSourceField } from '../../helpers/formatHelpers';
+import withConfig from '../../enhancers/withConfig';
+import withCsid from '../../enhancers/withCsid';
+import { getRecordData } from '../../reducers';
+
+const { TextInput } = inputComponents;
+
+const propTypes = {
+  csid: PropTypes.string,
+  intl: intlShape,
+  config: PropTypes.object,
+  value: PropTypes.string,
+};
+
+const mapStateToProps = (state, ownProps) => {
+  const {
+    intl,
+    csid,
+    config,
+    value,
+  } = ownProps;
+
+  console.log(`Formatting value for csid: ${csid} intl:${intl} config:${config} ${value}`);
+  let formattedValue = value;
+  const recordData = getRecordData(state, csid);
+  if (recordData && value) {
+    const auditedType = recordData.getIn(['ns3:audit_common', 'resourceType']).toLowerCase();
+    console.log(`formatted value = ${formatRecordTypeSourceField(auditedType, value, { intl, config })}`);
+    const recordTypeConfig = config.recordTypes[auditedType];
+    console.log(`descriptor = ${get(recordTypeConfig, ['fields', 'ns3:audit_common'])}`);
+    // const partDescriptor = get(recordTypeConfig, ['fields', 'document', `${NS_PREFIX}:${partName}`]);
+    formattedValue = formatRecordTypeSourceField(auditedType, value, { intl, config });
+  }
+
+  return {
+    value: formattedValue,
+  };
+};
+
+export const ConnectedFieldTextContainer = connect(mapStateToProps)(TextInput);
+
+const EnhancedFieldTextContainer = injectIntl(withConfig(withCsid(ConnectedFieldTextContainer)));
+
+EnhancedFieldTextContainer.propTypes = propTypes;
+
+export default EnhancedFieldTextContainer;

--- a/src/containers/input/FieldTextInputContainer.jsx
+++ b/src/containers/input/FieldTextInputContainer.jsx
@@ -66,6 +66,7 @@ const mergeProps = (stateProps, _dispatchProps, ownProps) => {
     intl,
     csid,
     config,
+    value,
     ...remainingProps
   } = ownProps;
 

--- a/src/containers/input/FieldTextInputContainer.jsx
+++ b/src/containers/input/FieldTextInputContainer.jsx
@@ -17,7 +17,20 @@ const propTypes = {
 };
 
 export const formatHumanReadable = (type, value, context) => {
-  const formatted = formatRecordTypeSourceField(type, value, context);
+  let formatted;
+
+  // the key is created with schema:fieldName:listIndex
+  // we have 3 outcomes -- an array of index 1 (unqualified), 2 (qualified), or 3 (qualified list)
+  // see: AuditDocumentHandler.java
+  const parts = value.split(':');
+  if (parts.length === 2) {
+    formatted = formatRecordTypeSourceField(type, value, context);
+  } else if (parts.length === 3) {
+    // todo: get child of the key
+    formatted = formatRecordTypeSourceField(type, `${parts[0]}:${parts[1]}`, context);
+  } else {
+    formatted = value;
+  }
 
   // when the fieldConfig isn't found, the return is of the form [${fieldName}], which is
   // less readable than the value itself
@@ -34,6 +47,7 @@ const mapStateToProps = (state, ownProps) => {
 
   let formattedValue;
   const recordData = getRecordData(state, csid);
+
   if (recordData && value) {
     const auditedType = recordData.getIn(['ns3:audit_common', 'resourceType']).toLowerCase();
     formattedValue = formatHumanReadable(auditedType, value, { intl, config });
@@ -44,7 +58,24 @@ const mapStateToProps = (state, ownProps) => {
   };
 };
 
-export const ConnectedFieldTextContainer = connect(mapStateToProps)(TextInput);
+/**
+ * trim out props not needed for TextInput
+ */
+const mergeProps = (stateProps, _dispatchProps, ownProps) => {
+  const {
+    intl,
+    csid,
+    config,
+    ...remainingProps
+  } = ownProps;
+
+  return {
+    ...stateProps,
+    ...remainingProps,
+  };
+};
+
+export const ConnectedFieldTextContainer = connect(mapStateToProps, null, mergeProps)(TextInput);
 
 const EnhancedFieldTextContainer = injectIntl(withConfig(withCsid(ConnectedFieldTextContainer)));
 

--- a/src/containers/input/FieldTextInputContainer.jsx
+++ b/src/containers/input/FieldTextInputContainer.jsx
@@ -16,6 +16,14 @@ const propTypes = {
   value: PropTypes.string,
 };
 
+export const formatHumanReadable = (type, value, context) => {
+  const formatted = formatRecordTypeSourceField(type, value, context);
+
+  // when the fieldConfig isn't found, the return is of the form [${fieldName}], which is
+  // less readable than the value itself
+  return formatted[0] === '[' ? value : formatted;
+};
+
 const mapStateToProps = (state, ownProps) => {
   const {
     intl,
@@ -28,13 +36,7 @@ const mapStateToProps = (state, ownProps) => {
   const recordData = getRecordData(state, csid);
   if (recordData && value) {
     const auditedType = recordData.getIn(['ns3:audit_common', 'resourceType']).toLowerCase();
-    const formatted = formatRecordTypeSourceField(auditedType, value, { intl, config });
-
-    // when the fieldConfig isn't found, the return is of the form [${fieldName}], which is
-    // less readable than the value itself
-    if (formatted[0] !== ('[')) {
-      formattedValue = formatted;
-    }
+    formattedValue = formatHumanReadable(auditedType, value, { intl, config });
   }
 
   return {

--- a/src/containers/input/FieldTextInputContainer.jsx
+++ b/src/containers/input/FieldTextInputContainer.jsx
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { components as inputComponents } from 'cspace-input';
 import { injectIntl, intlShape } from 'react-intl';
-import get from 'lodash/get';
 import { formatRecordTypeSourceField } from '../../helpers/formatHelpers';
 import withConfig from '../../enhancers/withConfig';
 import withCsid from '../../enhancers/withCsid';
@@ -25,20 +24,21 @@ const mapStateToProps = (state, ownProps) => {
     value,
   } = ownProps;
 
-  console.log(`Formatting value for csid: ${csid} intl:${intl} config:${config} ${value}`);
-  let formattedValue = value;
+  let formattedValue;
   const recordData = getRecordData(state, csid);
   if (recordData && value) {
     const auditedType = recordData.getIn(['ns3:audit_common', 'resourceType']).toLowerCase();
-    console.log(`formatted value = ${formatRecordTypeSourceField(auditedType, value, { intl, config })}`);
-    const recordTypeConfig = config.recordTypes[auditedType];
-    console.log(`descriptor = ${get(recordTypeConfig, ['fields', 'ns3:audit_common'])}`);
-    // const partDescriptor = get(recordTypeConfig, ['fields', 'document', `${NS_PREFIX}:${partName}`]);
-    formattedValue = formatRecordTypeSourceField(auditedType, value, { intl, config });
+    const formatted = formatRecordTypeSourceField(auditedType, value, { intl, config });
+
+    // when the fieldConfig isn't found, the return is of the form [${fieldName}], which is
+    // less readable than the value itself
+    if (formatted[0] !== ('[')) {
+      formattedValue = formatted;
+    }
   }
 
   return {
-    value: formattedValue,
+    value: formattedValue || value,
   };
 };
 

--- a/src/helpers/configContextInputs.js
+++ b/src/helpers/configContextInputs.js
@@ -9,6 +9,7 @@ import URLInputComponent from '../components/record/URLInput';
 import WorkflowStateInputComponent from '../components/record/WorkflowStateInput';
 import DateInputContainer from '../containers/input/DateInputContainer';
 import DateTimeInputContainer from '../containers/input/DateTimeInputContainer';
+import FieldTextInputContainer from '../containers/input/FieldTextInputContainer';
 import HierarchyInputContainer from '../containers/record/HierarchyInputContainer';
 import IDGeneratorInputContainer from '../containers/input/IDGeneratorInputContainer';
 import OptionPickerInputContainer from '../containers/record/OptionPickerInputContainer';
@@ -43,6 +44,9 @@ DateInput.toJSON = () => 'DateInput';
 
 export const DateTimeInput = DateTimeInputContainer;
 DateTimeInput.toJSON = () => 'DateTimeInput';
+
+export const FieldTextInput = FieldTextInputContainer;
+FieldTextInput.toJSON = () => 'FieldTextInput';
 
 export const HierarchyInput = withCsid(HierarchyInputContainer);
 HierarchyInput.toJSON = () => 'HierarchyInput';

--- a/src/plugins/listTypes/audit.js
+++ b/src/plugins/listTypes/audit.js
@@ -19,7 +19,11 @@ export default () => ({
           defaultMessage: 'Finding audit records...',
         },
       }),
-      getItemLocationPath: () => null,
+      getItemLocationPath: (item) => {
+        const csid = item.get('csid');
+
+        return `/record/audit/${csid}`;
+      },
     },
   },
 });

--- a/src/plugins/recordTypes/audit/fields.js
+++ b/src/plugins/recordTypes/audit/fields.js
@@ -2,6 +2,10 @@ import { defineMessages } from 'react-intl';
 
 export default (configContext) => {
   const {
+    CompoundInput,
+  } = configContext.inputComponents;
+
+  const {
     DATA_TYPE_DATETIME,
   } = configContext.dataTypes;
 
@@ -56,6 +60,26 @@ export default (configContext) => {
           }),
         },
       },
+      saveMessage: {
+        [config]: {
+          messages: defineMessages({
+            name: {
+              id: 'field.audit_common.saveMessage.name',
+              defaultMessage: 'Save message',
+            },
+          }),
+        },
+      },
+      eventComment: {
+        [config]: {
+          messages: {
+            name: {
+              id: 'field.audit_common.eventComment.name',
+              defaultMessage: 'Event comment',
+            },
+          },
+        },
+      },
       eventType: {
         [config]: {
           messages: defineMessages({
@@ -85,6 +109,73 @@ export default (configContext) => {
               defaultMessage: 'Event date',
             },
           }),
+        },
+      },
+      fieldChangedGroupList: {
+        [config]: {
+          view: {
+            type: CompoundInput,
+          },
+        },
+        fieldChangedGroup: {
+          [config]: {
+            messages: defineMessages({
+              name: {
+                id: 'field.audit_common.fieldChangedGroup.name',
+                defaultMessage: 'Field changed',
+              },
+            }),
+          },
+          key: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.audit_common.key.name',
+                  defaultMessage: 'Key',
+                },
+              }),
+            },
+          },
+          fieldName: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.audit_common.fieldName.name',
+                  defaultMessage: 'Field name',
+                },
+              }),
+            },
+          },
+          originalValue: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.audit_common.originalValue.name',
+                  defaultMessage: 'Original value',
+                },
+              }),
+            },
+          },
+          newValue: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.audit_common.newValue.name',
+                  defaultMessage: 'New value',
+                },
+              }),
+            },
+          },
+          changeReason: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.audit_common.changeReason.name',
+                  defaultMessage: 'Change reason',
+                },
+              }),
+            },
+          },
         },
       },
     },

--- a/src/plugins/recordTypes/audit/fields.js
+++ b/src/plugins/recordTypes/audit/fields.js
@@ -6,6 +6,7 @@ export default (configContext) => {
     DateTimeInput,
     ObjectNameInput,
     OptionPickerInput,
+    FieldTextInput,
     TextInput,
   } = configContext.inputComponents;
 
@@ -203,7 +204,7 @@ export default (configContext) => {
                 },
               }),
               view: {
-                type: TextInput,
+                type: FieldTextInput,
                 props: {
                   readOnly: true,
                 },
@@ -237,6 +238,7 @@ export default (configContext) => {
               view: {
                 type: TextInput,
                 props: {
+                  multiline: true,
                   readOnly: true,
                 },
               },
@@ -253,6 +255,7 @@ export default (configContext) => {
               view: {
                 type: TextInput,
                 props: {
+                  multiline: true,
                   readOnly: true,
                 },
               },

--- a/src/plugins/recordTypes/audit/fields.js
+++ b/src/plugins/recordTypes/audit/fields.js
@@ -5,6 +5,7 @@ export default (configContext) => {
     CompoundInput,
     DateTimeInput,
     ObjectNameInput,
+    OptionPickerInput,
     TextInput,
   } = configContext.inputComponents;
 
@@ -139,8 +140,9 @@ export default (configContext) => {
             },
           }),
           view: {
-            type: TextInput,
+            type: OptionPickerInput,
             props: {
+              source: 'eventTypes',
               readOnly: true,
             },
           },

--- a/src/plugins/recordTypes/audit/fields.js
+++ b/src/plugins/recordTypes/audit/fields.js
@@ -3,6 +3,8 @@ import { defineMessages } from 'react-intl';
 export default (configContext) => {
   const {
     CompoundInput,
+    DateInput,
+    TextInput,
   } = configContext.inputComponents;
 
   const {
@@ -19,35 +21,64 @@ export default (configContext) => {
         service: {
           ns: 'http://collectionspace.org/services/audit',
         },
+        view: {
+          type: CompoundInput,
+        },
       },
       csid: {
         [config]: {
           messages: defineMessages({
             name: {
               id: 'field.audit_common.csid.name',
-              defaultMessage: 'CSID',
+              defaultMessage: 'Audit record identifier',
             },
           }),
+          view: {
+            type: TextInput,
+            props: {
+              readOnly: true,
+            },
+          },
         },
       },
       idNumber: {
         [config]: {
           messages: defineMessages({
+            fullName: {
+              id: 'field.audit_common.idNumber.fullName',
+              defaultMessage: 'Audit record id',
+            },
             name: {
               id: 'field.audit_common.idNumber.name',
-              defaultMessage: 'Id Number',
+              defaultMessage: 'Id',
             },
           }),
+          view: {
+            type: TextInput,
+            props: {
+              readOnly: true,
+            },
+          },
         },
       },
       resourceType: {
         [config]: {
           messages: defineMessages({
+            fullName: {
+              id: 'field.audit_common.resourceType.fullName',
+              defaultMessage: 'Related record type',
+            },
             name: {
               id: 'field.audit_common.resourceType.name',
-              defaultMessage: 'Resource type',
+              defaultMessage: 'Record type',
             },
           }),
+          view: {
+            type: TextInput,
+            props: {
+              readOnly: true,
+            },
+          },
         },
       },
       resourceCSID: {
@@ -55,9 +86,15 @@ export default (configContext) => {
           messages: defineMessages({
             name: {
               id: 'field.audit_common.resourceCSID.name',
-              defaultMessage: 'Resource CSID',
+              defaultMessage: 'Audited record identifier',
             },
           }),
+          view: {
+            type: TextInput,
+            props: {
+              readOnly: true,
+            },
+          },
         },
       },
       saveMessage: {
@@ -68,6 +105,12 @@ export default (configContext) => {
               defaultMessage: 'Save message',
             },
           }),
+          view: {
+            type: TextInput,
+            props: {
+              readOnly: true,
+            },
+          },
         },
       },
       eventComment: {
@@ -78,6 +121,12 @@ export default (configContext) => {
               defaultMessage: 'Event comment',
             },
           },
+          view: {
+            type: TextInput,
+            props: {
+              readOnly: true,
+            },
+          },
         },
       },
       eventType: {
@@ -85,9 +134,15 @@ export default (configContext) => {
           messages: defineMessages({
             name: {
               id: 'field.audit_common.eventType.name',
-              defaultMessage: 'Event type',
+              defaultMessage: 'Audit event type',
             },
           }),
+          view: {
+            type: TextInput,
+            props: {
+              readOnly: true,
+            },
+          },
         },
       },
       principal: {
@@ -95,9 +150,15 @@ export default (configContext) => {
           messages: defineMessages({
             name: {
               id: 'field.audit_common.principal.name',
-              defaultMessage: 'Principal',
+              defaultMessage: 'Updated by',
             },
           }),
+          view: {
+            type: TextInput,
+            props: {
+              readOnly: true,
+            },
+          },
         },
       },
       eventDate: {
@@ -106,9 +167,15 @@ export default (configContext) => {
           messages: defineMessages({
             name: {
               id: 'field.audit_common.eventDate.name',
-              defaultMessage: 'Event date',
+              defaultMessage: 'Updated at',
             },
           }),
+          view: {
+            type: DateInput,
+            props: {
+              readOnly: true,
+            },
+          },
         },
       },
       fieldChangedGroupList: {
@@ -119,12 +186,10 @@ export default (configContext) => {
         },
         fieldChangedGroup: {
           [config]: {
-            messages: defineMessages({
-              name: {
-                id: 'field.audit_common.fieldChangedGroup.name',
-                defaultMessage: 'Field changed',
-              },
-            }),
+            repeating: true,
+            view: {
+              type: CompoundInput,
+            },
           },
           key: {
             [config]: {
@@ -134,6 +199,12 @@ export default (configContext) => {
                   defaultMessage: 'Key',
                 },
               }),
+              view: {
+                type: TextInput,
+                props: {
+                  readOnly: true,
+                },
+              },
             },
           },
           fieldName: {
@@ -141,9 +212,15 @@ export default (configContext) => {
               messages: defineMessages({
                 name: {
                   id: 'field.audit_common.fieldName.name',
-                  defaultMessage: 'Field name',
+                  defaultMessage: 'Field',
                 },
               }),
+              view: {
+                type: TextInput,
+                props: {
+                  readOnly: true,
+                },
+              },
             },
           },
           originalValue: {
@@ -154,6 +231,12 @@ export default (configContext) => {
                   defaultMessage: 'Original value',
                 },
               }),
+              view: {
+                type: TextInput,
+                props: {
+                  readOnly: true,
+                },
+              },
             },
           },
           newValue: {
@@ -164,6 +247,12 @@ export default (configContext) => {
                   defaultMessage: 'New value',
                 },
               }),
+              view: {
+                type: TextInput,
+                props: {
+                  readOnly: true,
+                },
+              },
             },
           },
           changeReason: {
@@ -174,6 +263,12 @@ export default (configContext) => {
                   defaultMessage: 'Change reason',
                 },
               }),
+              view: {
+                type: TextInput,
+                props: {
+                  readOnly: true,
+                },
+              },
             },
           },
         },

--- a/src/plugins/recordTypes/audit/fields.js
+++ b/src/plugins/recordTypes/audit/fields.js
@@ -3,7 +3,8 @@ import { defineMessages } from 'react-intl';
 export default (configContext) => {
   const {
     CompoundInput,
-    DateInput,
+    DateTimeInput,
+    ObjectNameInput,
     TextInput,
   } = configContext.inputComponents;
 
@@ -74,7 +75,7 @@ export default (configContext) => {
             },
           }),
           view: {
-            type: TextInput,
+            type: ObjectNameInput,
             props: {
               readOnly: true,
             },
@@ -171,7 +172,7 @@ export default (configContext) => {
             },
           }),
           view: {
-            type: DateInput,
+            type: DateTimeInput,
             props: {
               readOnly: true,
             },

--- a/src/plugins/recordTypes/audit/forms/default.jsx
+++ b/src/plugins/recordTypes/audit/forms/default.jsx
@@ -34,7 +34,7 @@ const template = (configContext) => {
       <Panel name="change" collapsible>
         <Field name="fieldChangedGroupList">
           <Field name="fieldChangedGroup">
-            <Field name="fieldName" />
+            <Field name="key" />
             <Field name="originalValue" />
             <Field name="newValue" />
           </Field>

--- a/src/plugins/recordTypes/audit/forms/default.jsx
+++ b/src/plugins/recordTypes/audit/forms/default.jsx
@@ -1,0 +1,55 @@
+import { defineMessages } from 'react-intl';
+
+const template = (configContext) => {
+  const {
+    React,
+  } = configContext.lib;
+
+  const {
+    Col,
+    Cols,
+    Panel,
+  } = configContext.layoutComponents;
+
+  const {
+    Field,
+  } = configContext.recordComponents;
+
+  return (
+    <Field name="document">
+      <Panel name="info" collapsible>
+        <Cols>
+          <Col>
+            <Field name="csid" />
+            <Field name="resourceType" />
+            <Field name="resourceCSID" />
+          </Col>
+          <Col>
+            <Field name="principal" />
+            <Field name="eventDate" />
+            <Field name="eventType" />
+          </Col>
+        </Cols>
+      </Panel>
+      <Panel name="change" collapsible>
+        <Field name="fieldChangedGroupList">
+          <Field name="fieldChangedGroup">
+            <Field name="fieldName" />
+            <Field name="originalValue" />
+            <Field name="newValue" />
+          </Field>
+        </Field>
+      </Panel>
+    </Field>
+  );
+};
+
+export default (configContext) => ({
+  messages: defineMessages({
+    name: {
+      id: 'form.audit.default.name',
+      defaultMessage: 'Standard Template',
+    },
+  }),
+  template: template(configContext),
+});

--- a/src/plugins/recordTypes/audit/forms/index.js
+++ b/src/plugins/recordTypes/audit/forms/index.js
@@ -1,0 +1,5 @@
+import defaultForm from './default';
+
+export default (configContext) => ({
+  default: defaultForm(configContext),
+});

--- a/src/plugins/recordTypes/audit/index.js
+++ b/src/plugins/recordTypes/audit/index.js
@@ -1,5 +1,7 @@
 import columns from './columns';
 import fields from './fields';
+import forms from './forms';
+import title from './title';
 import messages from './messages';
 import serviceConfig from './serviceConfig';
 
@@ -9,7 +11,9 @@ export default () => (configContext) => ({
       messages,
       serviceConfig,
       fields: fields(configContext),
+      forms: forms(configContext),
       columns: columns(configContext),
+      title: title(configContext),
     },
   },
 });

--- a/src/plugins/recordTypes/audit/index.js
+++ b/src/plugins/recordTypes/audit/index.js
@@ -3,9 +3,11 @@ import fields from './fields';
 import forms from './forms';
 import title from './title';
 import messages from './messages';
+import optionLists from './optionLists';
 import serviceConfig from './serviceConfig';
 
 export default () => (configContext) => ({
+  optionLists,
   recordTypes: {
     audit: {
       messages,

--- a/src/plugins/recordTypes/audit/messages.js
+++ b/src/plugins/recordTypes/audit/messages.js
@@ -13,4 +13,14 @@ export default {
       defaultMessage: 'Audits',
     },
   }),
+  panel: defineMessages({
+    info: {
+      id: 'panel.audit.info',
+      defaultMessage: 'Audit Information',
+    },
+    change: {
+      id: 'panel.audit.change',
+      defaultMessage: 'Record Change Information',
+    },
+  }),
 };

--- a/src/plugins/recordTypes/audit/optionLists.js
+++ b/src/plugins/recordTypes/audit/optionLists.js
@@ -1,0 +1,28 @@
+import { defineMessages } from 'react-intl';
+
+// see: https://github.com/nuxeo/nuxeo/blob/master/modules/core/nuxeo-core-api/src/main/java/org/nuxeo/ecm/core/api/event/DocumentEventTypes.java
+// and: https://doc.nuxeo.com/nxdoc/audit/#event
+// for potential event types to add
+export default {
+  eventTypes: {
+    values: [
+      'beforeDocumentModification',
+      'documentCreated',
+      'lifecycle_transition_event',
+    ],
+    messages: defineMessages({
+      beforeDocumentModification: {
+        id: 'option.eventTypes.beforeDocumentModification',
+        defaultMessage: 'Document modification',
+      },
+      documentCreated: {
+        id: 'option.eventTypes.documentCreated',
+        defaultMessage: 'Document created',
+      },
+      lifecycle_transition_event: {
+        id: 'option.eventTypes.lifecycle_transition_event',
+        defaultMessage: 'Lifecycle transition',
+      },
+    }),
+  },
+};

--- a/src/plugins/recordTypes/audit/title.js
+++ b/src/plugins/recordTypes/audit/title.js
@@ -1,0 +1,16 @@
+export default () => (data) => {
+  if (!data) {
+    return '';
+  }
+
+  const common = data.get('ns3:audit_common');
+
+  if (!common) {
+    return '';
+  }
+
+  const resource = common.get('resourceCSID');
+  const date = common.get('eventDate');
+
+  return [resource, date].filter((part) => !!part).join(' – ');
+};

--- a/styles/cspace-ui/CreatePagePanel.css
+++ b/styles/cspace-ui/CreatePagePanel.css
@@ -35,6 +35,12 @@
   content: ' | ';
 }
 
+.audit {
+  composes: common;
+  background-color: #F0F5FB;
+  color: #305A8D;
+}
+
 .object {
   composes: common;
   background-color: #F0F5FB;

--- a/styles/cspace-ui/MiniView.css
+++ b/styles/cspace-ui/MiniView.css
@@ -14,6 +14,11 @@
   background-color: #F3EDF6;
 }
 
+.audit {
+  composes: common;
+  background-color: #F0F5FB;
+}
+
 .procedure {
   composes: common;
   background-color: #F0F5FB;

--- a/styles/cspace-ui/RecordBrowserNavBar.css
+++ b/styles/cspace-ui/RecordBrowserNavBar.css
@@ -1,7 +1,7 @@
 .common {
 }
 
-.object, .procedure, .utility {
+.audit, .object, .procedure, .utility {
   composes: common;
   color: #305A8D;
 }

--- a/styles/cspace-ui/RecordPage.css
+++ b/styles/cspace-ui/RecordPage.css
@@ -1,4 +1,4 @@
-.object, .procedure, .utility {
+.audit, .object, .procedure, .utility {
   background-color: #F0F5FB;
 }
 

--- a/styles/cspace-ui/RecordSidebar.css
+++ b/styles/cspace-ui/RecordSidebar.css
@@ -17,6 +17,10 @@
   font-size: 12px;
 }
 
+.audit {
+  composes: common;
+}
+
 .object {
   composes: common;
 }
@@ -33,6 +37,7 @@
   composes: common;
 }
 
+.audit :global(.cspace-layout-Panel--common),
 .object :global(.cspace-layout-Panel--common),
 .procedure :global(.cspace-layout-Panel--common),
 .utility :global(.cspace-layout-Panel--common) {

--- a/styles/cspace-ui/TitleBar.css
+++ b/styles/cspace-ui/TitleBar.css
@@ -40,6 +40,7 @@
   text-align: right;
 }
 
+.audit > div > div > aside > h2,
 .object > div > div > aside > h2,
 .procedure > div > div > aside > h2,
 .utility > div > div > aside > h2 {

--- a/test/specs/containers/input/FieldTextInputContainer.spec.jsx
+++ b/test/specs/containers/input/FieldTextInputContainer.spec.jsx
@@ -1,0 +1,57 @@
+import { defineMessages } from 'react-intl';
+import { configKey } from '../../../../src/helpers/configHelpers';
+import { formatHumanReadable } from '../../../../src/containers/input/FieldTextInputContainer';
+
+chai.should();
+
+const intl = {
+  formatDate: () => null,
+  formatTime: () => null,
+  formatRelative: () => null,
+  formatNumber: () => null,
+  formatPlural: () => null,
+  formatMessage: (message) => `${message.defaultMessage}`,
+  formatHTMLMessage: () => null,
+  now: () => null,
+};
+
+const recordType = 'collectionobject';
+
+const objectNumberConfig = {
+  messages: defineMessages({
+    name: {
+      id: 'field.collectionobjects_common.objectNumber.name',
+      defaultMessage: 'Identification number',
+    },
+  }),
+};
+
+const config = {
+  recordTypes: {
+    collectionobject: {
+      fields: {
+        document: {
+          'ns2:collectionobjects_common': {
+            objectNumber: {
+              [configKey]: objectNumberConfig,
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+describe('FieldTextInputContainer', () => {
+  it('should return human readable input when available', () => {
+    const field = 'collectionobjects_common:objectNumber';
+    const formatted = formatHumanReadable(recordType, field, { intl, config });
+    formatted.should.equal('Identification number');
+  });
+
+  it('should return the field when formatting is not available', () => {
+    const field = 'collectionspace_core:uri';
+    const formatted = formatHumanReadable(recordType, field, { intl, config });
+    formatted.should.equal(field);
+  });
+});

--- a/test/specs/plugins/recordTypes/audit/columns.spec.js
+++ b/test/specs/plugins/recordTypes/audit/columns.spec.js
@@ -1,0 +1,13 @@
+import createColumns from '../../../../../src/plugins/recordTypes/audit/columns';
+import createConfigContext from '../../../../../src/helpers/createConfigContext';
+
+chai.should();
+
+describe('audit record columns', () => {
+  const configContext = createConfigContext();
+  const columns = createColumns(configContext);
+
+  it('should have the correct shape', () => {
+    columns.should.have.property('default').that.is.an('object');
+  });
+});

--- a/test/specs/plugins/recordTypes/audit/forms/default.spec.js
+++ b/test/specs/plugins/recordTypes/audit/forms/default.spec.js
@@ -1,0 +1,14 @@
+import Field from '../../../../../../src/components/record/Field';
+import form from '../../../../../../src/plugins/recordTypes/audit/forms/default';
+import createConfigContext from '../../../../../../src/helpers/createConfigContext';
+
+chai.should();
+
+describe('audit record default form', () => {
+  it('should be a Field', () => {
+    const configContext = createConfigContext();
+    const { template } = form(configContext);
+
+    template.type.should.equal(Field);
+  });
+});

--- a/test/specs/plugins/recordTypes/audit/index.spec.js
+++ b/test/specs/plugins/recordTypes/audit/index.spec.js
@@ -1,0 +1,29 @@
+import auditRecordTypePluginFactory from '../../../../../src/plugins/recordTypes/audit';
+import createConfigContext from '../../../../../src/helpers/createConfigContext';
+
+chai.should();
+
+describe('audit record plugin', () => {
+  const config = {};
+  const auditRecordTypePlugin = auditRecordTypePluginFactory(config);
+  const configContext = createConfigContext();
+
+  it('should have the correct shape', () => {
+    const pluginConfigContribution = auditRecordTypePlugin(configContext);
+
+    pluginConfigContribution.should.have.property('optionLists').that.is.an('object');
+
+    const {
+      recordTypes,
+    } = pluginConfigContribution;
+
+    const auditRecordType = recordTypes.audit;
+
+    auditRecordType.should.have.property('messages').that.is.an('object');
+    auditRecordType.should.have.property('serviceConfig').that.is.an('object');
+    auditRecordType.should.have.property('fields').that.is.an('object');
+    auditRecordType.should.have.property('forms').that.is.an('object');
+    auditRecordType.should.have.property('columns').that.is.an('object');
+    auditRecordType.should.have.property('title').that.is.a('function');
+  });
+});

--- a/test/specs/plugins/recordTypes/audit/optionLists.spec.js
+++ b/test/specs/plugins/recordTypes/audit/optionLists.spec.js
@@ -1,0 +1,17 @@
+import optionsList from '../../../../../src/plugins/recordTypes/audit/optionLists';
+
+chai.should();
+
+describe('audit record optionLists', () => {
+  it('should contain event types', () => {
+    optionsList.should.be.an('object');
+
+    Object.keys(optionsList).forEach((option) => {
+      const eventTypes = optionsList[option];
+      eventTypes.should.contain.all.keys([
+        'values',
+        'messages',
+      ]);
+    });
+  });
+});

--- a/test/specs/plugins/recordTypes/audit/serviceConfig.spec.js
+++ b/test/specs/plugins/recordTypes/audit/serviceConfig.spec.js
@@ -1,0 +1,9 @@
+import serviceConfig from '../../../../../src/plugins/recordTypes/audit/serviceConfig';
+
+chai.should();
+
+describe('audit record serviceConfig', () => {
+  it('should have servicePath property', () => {
+    serviceConfig.should.have.property('servicePath').that.is.a('string');
+  });
+});

--- a/test/specs/plugins/recordTypes/audit/title.spec.js
+++ b/test/specs/plugins/recordTypes/audit/title.spec.js
@@ -1,0 +1,46 @@
+import Immutable from 'immutable';
+import createTitleGetter from '../../../../../src/plugins/recordTypes/audit/title';
+import createConfigContext from '../../../../../src/helpers/createConfigContext';
+
+chai.should();
+
+describe('audit record title', () => {
+  const configContext = createConfigContext();
+  const title = createTitleGetter(configContext);
+
+  it('should concat the resourceCSID and date', () => {
+    const data = Immutable.fromJS({
+      'ns3:audit_common': {
+        resourceCSID: '1234',
+        eventDate: 'Date',
+      },
+    });
+
+    title(data).should.equal('1234 – Date');
+  });
+
+  it('should return the resourceCSID when the date is empty', () => {
+    const data = Immutable.fromJS({
+      'ns3:audit_common': {
+        resourceCSID: '1234',
+      },
+    });
+
+    title(data).should.equal('1234');
+  });
+
+  it('should return the date when the csid is empty', () => {
+    const data = Immutable.fromJS({
+      'ns3:audit_common': {
+        eventDate: 'Date',
+      },
+    });
+
+    title(data).should.equal('Date');
+  });
+
+  it('should return an empty string if no data is passed', () => {
+    title(null).should.equal('');
+    title(undefined).should.equal('');
+  });
+});


### PR DESCRIPTION
Resolves: https://collectionspace.atlassian.net/browse/DRYD-998

* Add a read only form for viewing Audit records
* Finish defining fields for Audit
* Start adding event types to optionLists for human readable output
* Create wrapper around TextInput for formatting Field names in audit responses

## Notes

I'm not exactly sure of all the changes to the audit record between #133 and this, I know 133 only has what is necessary to get the record displayed on the sidebar.

I used the `AuditDocumentHandler` to inform parsing of the `key` field in the changed fields list, as it is used when creating the response in the services layer. There's still some work to do in order to get lists in a more human readable state and deciding what to do with other fields (e.g. `scalarValuesComputer`).  