### PR TITLE
Fix typo in insurance record

### DIFF
--- a/src/plugins/recordTypes/insurance/fields.js
+++ b/src/plugins/recordTypes/insurance/fields.js
@@ -206,7 +206,7 @@ export default (configContext) => {
             view: {
               type: AutocompleteInput,
               props: {
-                source: 'person/local,person/shared/person/ulan',
+                source: 'person/local,person/shared,person/ulan',
               },
             },
           },


### PR DESCRIPTION
In the fields for the insurance procedure, the source for `insuranceIdemnityAuthorizer` was delimited with a `/` instead of a `,`