### PR TITLE
DRYD-999: Audit Record Sidebar Panel

### DIFF
--- a/src/components/record/AuditedRecordPanel.jsx
+++ b/src/components/record/AuditedRecordPanel.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Immutable from 'immutable';
 import PropTypes from 'prop-types';
 import { FormattedMessage, defineMessages } from 'react-intl';
+import { OP_EQ } from '../../constants/searchOperators';
 import SearchPanelContainer from '../../containers/search/SearchPanelContainer';
 
 const propTypes = {
@@ -50,12 +51,16 @@ export default class AuditedRecordPanel extends React.Component {
     const auditedType = recordData.getIn(['ns3:audit_common', 'resourceType']);
     const formattedType = auditedType.toLowerCase();
 
+    const advSearch = Immutable.Map()
+      .set('op', OP_EQ)
+      .set('path', 'ecm:name')
+      .set('value', auditedCsid);
+
     const searchDescriptor = Immutable.fromJS({
       recordType: formattedType,
       searchQuery: {
-        csid: auditedCsid,
-        p: 0,
-        size: 0,
+        as: advSearch,
+        size: 1,
       },
     });
 

--- a/src/components/record/AuditedRecordPanel.jsx
+++ b/src/components/record/AuditedRecordPanel.jsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import Immutable from 'immutable';
+import PropTypes from 'prop-types';
+import { FormattedMessage, defineMessages } from 'react-intl';
+import SearchPanelContainer from '../../containers/search/SearchPanelContainer';
+
+const propTypes = {
+  collapsed: PropTypes.bool,
+  color: PropTypes.string,
+  config: PropTypes.object,
+  columnSetName: PropTypes.string,
+  csid: PropTypes.string,
+  listType: PropTypes.string,
+  name: PropTypes.string,
+  recordType: PropTypes.string,
+  recordData: PropTypes.instanceOf(Immutable.Map),
+};
+
+const messages = defineMessages({
+  title: {
+    id: 'auditedRecordPanel.title',
+    defaultMessage: 'Audited Record',
+  },
+});
+
+export default class AuditedRecordPanel extends React.Component {
+  // eslint-disable-next-line class-methods-use-this
+  renderTitle() {
+    return (
+      <FormattedMessage {...messages.title} />
+    );
+  }
+
+  render() {
+    const {
+      collapsed,
+      color,
+      columnSetName,
+      config,
+      listType,
+      name,
+      recordData,
+    } = this.props;
+
+    // don't render if recordData isn't loaded
+    if (!recordData) {
+      return null;
+    }
+
+    // get csid and type of the audited record
+    const auditedCsid = recordData.getIn(['ns3:audit_common', 'resourceCSID']);
+    const auditedType = recordData.getIn(['ns3:audit_common', 'resourceType']);
+
+    console.log(`auditedCsid: ${auditedCsid}`);
+    console.log(`auditedType: ${auditedType}`);
+
+    const searchDescriptor = Immutable.fromJS({
+      recordType: 'all',
+      searchQuery: {
+        csid: auditedCsid,
+        p: 0,
+        size: 0,
+      },
+    });
+
+    return (
+      <SearchPanelContainer
+        collapsed={collapsed}
+        color={color}
+        columnSetName={columnSetName}
+        config={config}
+        csid={auditedCsid}
+        listType={listType}
+        name={name}
+        recordType={auditedType}
+        searchDescriptor={searchDescriptor}
+        title={this.renderTitle()}
+        showAddButton={false}
+        showCheckboxColumn={false}
+      />
+    );
+  }
+}
+
+AuditedRecordPanel.propTypes = propTypes;

--- a/src/components/record/AuditedRecordPanel.jsx
+++ b/src/components/record/AuditedRecordPanel.jsx
@@ -10,7 +10,6 @@ const propTypes = {
   config: PropTypes.object,
   columnSetName: PropTypes.string,
   csid: PropTypes.string,
-  listType: PropTypes.string,
   name: PropTypes.string,
   recordType: PropTypes.string,
   recordData: PropTypes.instanceOf(Immutable.Map),
@@ -37,7 +36,6 @@ export default class AuditedRecordPanel extends React.Component {
       color,
       columnSetName,
       config,
-      listType,
       name,
       recordData,
     } = this.props;
@@ -50,12 +48,10 @@ export default class AuditedRecordPanel extends React.Component {
     // get csid and type of the audited record
     const auditedCsid = recordData.getIn(['ns3:audit_common', 'resourceCSID']);
     const auditedType = recordData.getIn(['ns3:audit_common', 'resourceType']);
-
-    console.log(`auditedCsid: ${auditedCsid}`);
-    console.log(`auditedType: ${auditedType}`);
+    const formattedType = auditedType.toLowerCase();
 
     const searchDescriptor = Immutable.fromJS({
-      recordType: 'all',
+      recordType: formattedType,
       searchQuery: {
         csid: auditedCsid,
         p: 0,
@@ -70,11 +66,11 @@ export default class AuditedRecordPanel extends React.Component {
         columnSetName={columnSetName}
         config={config}
         csid={auditedCsid}
-        listType={listType}
         name={name}
-        recordType={auditedType}
+        recordType={formattedType}
         searchDescriptor={searchDescriptor}
         title={this.renderTitle()}
+        showFooter={false}
         showAddButton={false}
         showCheckboxColumn={false}
       />

--- a/src/components/record/RecordSidebar.jsx
+++ b/src/components/record/RecordSidebar.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import get from 'lodash/get';
 import upperFirst from 'lodash/upperFirst';
+import AuditedRecordPanelContainer from '../../containers/record/AuditedRecordPanelContainer';
 import MediaSnapshotPanelContainer from '../../containers/record/MediaSnapshotPanelContainer';
 import RelatedRecordPanelContainer from '../../containers/record/RelatedRecordPanelContainer';
 import RecordBatchPanelContainer from '../../containers/record/RecordBatchPanelContainer';
@@ -73,6 +74,7 @@ export default function RecordSidebar(props) {
 
   let mediaSnapshot = null;
   let altMediaSnapshot = null;
+  let auditedRecord = null;
   let relatedRecords = null;
   let audit = null;
   let usedBy = null;
@@ -155,6 +157,16 @@ export default function RecordSidebar(props) {
         listType="audit"
       />
     );
+  } else {
+    auditedRecord = (
+      <AuditedRecordPanelContainer
+        color={panelColor}
+        csid={csid}
+        columnSetName="narrow"
+        config={config}
+        name="auditedRecord"
+      />
+    );
   }
 
   if (!isUtility) {
@@ -206,6 +218,7 @@ export default function RecordSidebar(props) {
       {reports}
       {batchJobs}
       {audit}
+      {auditedRecord}
     </div>
   );
 }

--- a/src/components/search/SearchPanel.jsx
+++ b/src/components/search/SearchPanel.jsx
@@ -52,6 +52,7 @@ const propTypes = {
   showAddButton: PropTypes.bool,
   showSearchButton: PropTypes.bool,
   showCheckboxColumn: PropTypes.bool,
+  showFooter: PropTypes.bool,
   renderCheckbox: PropTypes.func,
   renderTableHeader: PropTypes.func,
   search: PropTypes.func,
@@ -67,6 +68,7 @@ const defaultProps = {
   listType: 'common',
   pageSizeOptionListName: 'searchPanelPageSizes',
   showSearchButton: true,
+  showFooter: true,
 };
 
 const contextTypes = {
@@ -317,9 +319,10 @@ export default class SearchPanel extends Component {
       config,
       listType,
       pageSizeOptionListName,
+      showFooter,
     } = this.props;
 
-    if (searchResult) {
+    if (showFooter && searchResult) {
       const listTypeConfig = config.listTypes[listType];
       const list = searchResult.get(listTypeConfig.listNodeName);
 

--- a/src/containers/record/AuditedRecordPanelContainer.js
+++ b/src/containers/record/AuditedRecordPanelContainer.js
@@ -1,0 +1,15 @@
+import { connect } from 'react-redux';
+import AuditRecordPanel from '../../components/record/AuditedRecordPanel';
+import { getRecordData } from '../../reducers';
+
+const mapStateToProps = (state, ownProps) => {
+  const {
+    csid,
+  } = ownProps;
+
+  return {
+    recordData: getRecordData(state, csid),
+  };
+};
+
+export default connect(mapStateToProps)(AuditRecordPanel);

--- a/src/helpers/searchHelpers.js
+++ b/src/helpers/searchHelpers.js
@@ -449,7 +449,7 @@ export const pathToNXQL = (fieldDescriptor, path) => {
 
   const nxqlPath = nxqlPathInPartArray.join('/');
 
-  return `${nxqlPartName}:${nxqlPath}`;
+  return nxqlPath ? `${nxqlPartName}:${nxqlPath}` : nxqlPartName;
 };
 
 export const operatorToNXQL = (operator) => operatorToNXQLMap[operator];


### PR DESCRIPTION
Resolves: https://collectionspace.atlassian.net/browse/DRYD-999

* Create sidebar panel for navigating back to the record for an audit

## Notes

* The header for the related record is not the same as what is in the wireframes. I set `narrow` as the column set which seems to have made it the same as other search results.
* I just saw there was a request to add the `Open` button back in, need to set the SearchPanel to show the search button