### PR TITLE
DRYD-1081: set all vocabularies to disableAltTerms: true

### DIFF
--- a/src/plugins/recordTypes/citation/vocabularies.js
+++ b/src/plugins/recordTypes/citation/vocabularies.js
@@ -23,6 +23,7 @@ export default {
       servicePath: '_ALL_',
     },
     type: 'all',
+    disableAltTerms: true,
   },
   local: {
     messages: defineMessages({
@@ -46,6 +47,7 @@ export default {
       servicePath: 'urn:cspace:name(citation)',
     },
     sortOrder: 0,
+    disableAltTerms: true,
   },
   worldcat: {
     messages: defineMessages({
@@ -68,5 +70,6 @@ export default {
     serviceConfig: {
       servicePath: 'urn:cspace:name(worldcat)',
     },
+    disableAltTerms: true,
   },
 };

--- a/src/plugins/recordTypes/concept/vocabularies.js
+++ b/src/plugins/recordTypes/concept/vocabularies.js
@@ -23,6 +23,7 @@ export default {
       servicePath: '_ALL_',
     },
     type: 'all',
+    disableAltTerms: true,
   },
   associated: {
     messages: defineMessages({
@@ -45,6 +46,7 @@ export default {
     serviceConfig: {
       servicePath: 'urn:cspace:name(concept)',
     },
+    disableAltTerms: true,
   },
   activity: {
     messages: defineMessages({
@@ -67,6 +69,7 @@ export default {
     serviceConfig: {
       servicePath: 'urn:cspace:name(activity)',
     },
+    disableAltTerms: true,
   },
   material: {
     messages: defineMessages({
@@ -89,6 +92,7 @@ export default {
     serviceConfig: {
       servicePath: 'urn:cspace:name(material_ca)',
     },
+    disableAltTerms: true,
   },
   nomenclature: {
     messages: defineMessages({
@@ -111,6 +115,7 @@ export default {
     serviceConfig: {
       servicePath: 'urn:cspace:name(nomenclature)',
     },
+    disableAltTerms: true,
   },
   occasion: {
     messages: defineMessages({
@@ -133,5 +138,6 @@ export default {
     serviceConfig: {
       servicePath: 'urn:cspace:name(occasion)',
     },
+    disableAltTerms: true,
   },
 };

--- a/src/plugins/recordTypes/location/vocabularies.js
+++ b/src/plugins/recordTypes/location/vocabularies.js
@@ -23,6 +23,7 @@ export default {
       servicePath: '_ALL_',
     },
     type: 'all',
+    disableAltTerms: true,
   },
   local: {
     messages: defineMessages({
@@ -46,6 +47,7 @@ export default {
       servicePath: 'urn:cspace:name(location)',
     },
     sortOrder: 0,
+    disableAltTerms: true,
   },
   offsite: {
     messages: defineMessages({
@@ -68,5 +70,6 @@ export default {
     serviceConfig: {
       servicePath: 'urn:cspace:name(offsite_sla)',
     },
+    disableAltTerms: true,
   },
 };

--- a/src/plugins/recordTypes/organization/vocabularies.js
+++ b/src/plugins/recordTypes/organization/vocabularies.js
@@ -23,6 +23,7 @@ export default {
       servicePath: '_ALL_',
     },
     type: 'all',
+    disableAltTerms: true,
   },
   local: {
     messages: defineMessages({
@@ -46,6 +47,7 @@ export default {
       servicePath: 'urn:cspace:name(organization)',
     },
     sortOrder: 0,
+    disableAltTerms: true,
   },
   ulan: {
     messages: defineMessages({
@@ -68,5 +70,6 @@ export default {
     serviceConfig: {
       servicePath: 'urn:cspace:name(ulan_oa)',
     },
+    disableAltTerms: true,
   },
 };

--- a/src/plugins/recordTypes/person/vocabularies.js
+++ b/src/plugins/recordTypes/person/vocabularies.js
@@ -23,6 +23,7 @@ export default {
       servicePath: '_ALL_',
     },
     type: 'all',
+    disableAltTerms: true,
   },
   local: {
     messages: defineMessages({
@@ -46,6 +47,7 @@ export default {
       servicePath: 'urn:cspace:name(person)',
     },
     sortOrder: 0,
+    disableAltTerms: true,
   },
   ulan: {
     messages: defineMessages({
@@ -68,5 +70,6 @@ export default {
     serviceConfig: {
       servicePath: 'urn:cspace:name(ulan_pa)',
     },
+    disableAltTerms: true,
   },
 };

--- a/src/plugins/recordTypes/place/vocabularies.js
+++ b/src/plugins/recordTypes/place/vocabularies.js
@@ -23,6 +23,7 @@ export default {
       servicePath: '_ALL_',
     },
     type: 'all',
+    disableAltTerms: true,
   },
   local: {
     messages: defineMessages({
@@ -46,6 +47,7 @@ export default {
       servicePath: 'urn:cspace:name(place)',
     },
     sortOrder: 0,
+    disableAltTerms: true,
   },
   tgn: {
     messages: defineMessages({
@@ -68,5 +70,6 @@ export default {
     serviceConfig: {
       servicePath: 'urn:cspace:name(tgn_place)',
     },
+    disableAltTerms: true,
   },
 };

--- a/src/plugins/recordTypes/work/vocabularies.js
+++ b/src/plugins/recordTypes/work/vocabularies.js
@@ -23,6 +23,7 @@ export default {
       servicePath: '_ALL_',
     },
     type: 'all',
+    disableAltTerms: true,
   },
   local: {
     messages: defineMessages({
@@ -46,6 +47,7 @@ export default {
       servicePath: 'urn:cspace:name(work)',
     },
     sortOrder: 0,
+    disableAltTerms: true,
   },
   cona: {
     messages: defineMessages({
@@ -68,5 +70,6 @@ export default {
     serviceConfig: {
       servicePath: 'urn:cspace:name(cona_work)',
     },
+    disableAltTerms: true,
   },
 };


### PR DESCRIPTION
https://collectionspace.atlassian.net/browse/DRYD-1081

As per [this](https://github.com/collectionspace/cspace-ui.js/blob/49bcee61891e02b3b2accd7194ea3c6604397d4b/docs/configuration/VocabularyConfiguration.md#disablealtterms) I'm guessing the reason we didn't act on this before is that it requires adding `disableAltTerms: true` to every vocabulary definition. 

It looks like the process for spinning up test/dev environment has changed, but the instructions haven't been updated (?), so I'm not sure how to test locally. 

If this looks right, I can go through the other profiles and update any authorities defined in them.