### PR TITLE
DRYD-1175 Add dataType elements to new fields 

### DIFF
--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -4059,6 +4059,7 @@ export default (configContext) => {
             },
             significanceAssignedDate: {
               [config]: {
+                dataType: DATA_TYPE_DATE,
                 messages: defineMessages({
                   fullName: {
                     id: 'field.collectionobjects_common.significanceAssignedDate.fullName',
@@ -5633,6 +5634,7 @@ export default (configContext) => {
             },
             checksumDate: {
               [config]: {
+                dataType: DATA_TYPE_DATE,
                 messages: defineMessages({
                   fullName: {
                     id: 'field.collectionobjects_common.checksumDate.fullName',
@@ -5745,6 +5747,7 @@ export default (configContext) => {
             },
             rightBeginDate: {
               [config]: {
+                dataType: DATA_TYPE_DATE,
                 messages: defineMessages({
                   name: {
                     id: 'field.collectionobjects_common.rightBeginDate.name',
@@ -5758,6 +5761,7 @@ export default (configContext) => {
             },
             rightEndDate: {
               [config]: {
+                dataType: DATA_TYPE_DATE,
                 messages: defineMessages({
                   name: {
                     id: 'field.collectionobjects_common.rightEndDate.name',
@@ -5872,6 +5876,7 @@ export default (configContext) => {
             },
             rightInBeginDate: {
               [config]: {
+                dataType: DATA_TYPE_DATE,
                 messages: defineMessages({
                   name: {
                     id: 'field.collectionobjects_common.rightInBeginDate.name',
@@ -5885,6 +5890,7 @@ export default (configContext) => {
             },
             rightInEndDate: {
               [config]: {
+                dataType: DATA_TYPE_DATE,
                 messages: defineMessages({
                   name: {
                     id: 'field.collectionobjects_common.rightInEndDate.name',
@@ -5898,6 +5904,7 @@ export default (configContext) => {
             },
             agreementSent: {
               [config]: {
+                dataType: DATA_TYPE_DATE,
                 messages: defineMessages({
                   fullName: {
                     id: 'field.collectionobjects_common.agreementSent.fullName',
@@ -5915,6 +5922,7 @@ export default (configContext) => {
             },
             agreementReceived: {
               [config]: {
+                dataType: DATA_TYPE_DATE,
                 messages: defineMessages({
                   fullName: {
                     id: 'field.collectionobjects_common.agreementReceived.fullName',
@@ -5932,6 +5940,7 @@ export default (configContext) => {
             },
             agreementSigned: {
               [config]: {
+                dataType: DATA_TYPE_DATE,
                 messages: defineMessages({
                   fullName: {
                     id: 'field.collectionobjects_common.agreementSigned.fullName',

--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -1876,6 +1876,10 @@ export default (configContext) => {
                     id: 'field.collectionobjects_common.inscriptionContentDateGroup.fullName',
                     defaultMessage: 'Textual inscription date',
                   },
+                  groupName: {
+                    id: 'field.collectionobjects_common.inscriptionContentDateGroup.groupName',
+                    defaultMessage: 'Date',
+                  },
                   name: {
                     id: 'field.collectionobjects_common.inscriptionContentDateGroup.name',
                     defaultMessage: 'Date',
@@ -2089,6 +2093,10 @@ export default (configContext) => {
                   fullName: {
                     id: 'field.collectionobjects_common.inscriptionDescriptionDateGroup.fullName',
                     defaultMessage: 'Non-textual inscription date',
+                  },
+                  groupName: {
+                    id: 'field.collectionobjects_common.inscriptionDescriptionDateGroup.groupName',
+                    defaultMessage: 'Date',
                   },
                   name: {
                     id: 'field.collectionobjects_common.inscriptionDescriptionDateGroup.name',

--- a/src/plugins/recordTypes/iterationreport/fields.js
+++ b/src/plugins/recordTypes/iterationreport/fields.js
@@ -114,6 +114,7 @@ export default (configContext) => {
             },
             actionStartDate: {
               [config]: {
+                dataType: DATA_TYPE_DATE,
                 messages: defineMessages({
                   fullName: {
                     id: 'field.iterationreports_common.actionStartDate.fullName',
@@ -131,6 +132,7 @@ export default (configContext) => {
             },
             actionEndDate: {
               [config]: {
+                dataType: DATA_TYPE_DATE,
                 messages: defineMessages({
                   fullName: {
                     id: 'field.iterationreports_common.actionEndDate.fullName',
@@ -571,6 +573,7 @@ export default (configContext) => {
             },
             approvalDate: {
               [config]: {
+                dataType: DATA_TYPE_DATE,
                 messages: defineMessages({
                   fullName: {
                     id: 'field.iterationreports_common.approvalDate.fullName',
@@ -669,6 +672,7 @@ export default (configContext) => {
             },
             exhibitionApprovalDate: {
               [config]: {
+                dataType: DATA_TYPE_DATE,
                 messages: defineMessages({
                   fullName: {
                     id: 'field.iterationreports_common.exhibitionApprovalDate.fullName',
@@ -747,6 +751,7 @@ export default (configContext) => {
             },
             installedEquipmentApprovalDate: {
               [config]: {
+                dataType: DATA_TYPE_DATE,
                 messages: defineMessages({
                   fullName: {
                     id: 'field.iterationreports_common.installedEquipmentApprovalDate.fullName',
@@ -825,6 +830,7 @@ export default (configContext) => {
             },
             technicalSetupApprovalDate: {
               [config]: {
+                dataType: DATA_TYPE_DATE,
                 messages: defineMessages({
                   fullName: {
                     id: 'field.iterationreports_common.technicalSetupApprovalDate.fullName',
@@ -903,6 +909,7 @@ export default (configContext) => {
             },
             modificationApprovalDate: {
               [config]: {
+                dataType: DATA_TYPE_DATE,
                 messages: defineMessages({
                   fullName: {
                     id: 'field.iterationreports_common.modificationApprovalDate.fullName',
@@ -981,6 +988,7 @@ export default (configContext) => {
             },
             installationApprovalDate: {
               [config]: {
+                dataType: DATA_TYPE_DATE,
                 messages: defineMessages({
                   fullName: {
                     id: 'field.iterationreports_common.installationApprovalDate.fullName',
@@ -1082,6 +1090,7 @@ export default (configContext) => {
             },
             maintenanceDate: {
               [config]: {
+                dataType: DATA_TYPE_DATE,
                 messages: defineMessages({
                   fullName: {
                     id: 'field.iterationreports_common.maintenanceDate.fullName',
@@ -1180,6 +1189,7 @@ export default (configContext) => {
             },
             securityApprovalDate: {
               [config]: {
+                dataType: DATA_TYPE_DATE,
                 messages: defineMessages({
                   fullName: {
                     id: 'field.iterationreports_common.securityApprovalDate.fullName',

--- a/src/plugins/recordTypes/media/fields.js
+++ b/src/plugins/recordTypes/media/fields.js
@@ -450,6 +450,7 @@ export default (configContext) => {
             },
             checksumDate: {
               [config]: {
+                dataType: DATA_TYPE_DATE,
                 messages: defineMessages({
                   fullName: {
                     id: 'field.media_common.checksumDate.fullName',


### PR DESCRIPTION
This adds dataType elements to non-string fields added to: 
- collectionobject
- media
- iterationreport

Since @mikejritter is already working in the fields.js for person for DRYD-1172, I didn't mess with those fields, to avoid conflicts

It also adds a groupName element to two structured date fields within repeating field groups that did not have that element. 