### PR TITLE
DRYD-1172: Rename supplied birth date fields

### DIFF
--- a/src/plugins/recordTypes/person/fields.js
+++ b/src/plugins/recordTypes/person/fields.js
@@ -740,7 +740,7 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.persons_common.declinedToAnswerPronoun.fullName',
-                    defaultMessage: 'Pronoun declined to answer',
+                    defaultMessage: 'Pronoun supplied declined to answer',
                   },
                   name: {
                     id: 'field.persons_common.declinedToAnswerPronoun.name',
@@ -785,7 +785,7 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.persons_common.useRestrictionPronoun.fullName',
-                    defaultMessage: 'Pronoun use restriction',
+                    defaultMessage: 'Pronoun supplied use restriction',
                   },
                   name: {
                     id: 'field.persons_common.useRestrictionPronoun.name',
@@ -827,7 +827,7 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.persons_common.declinedToAnswerGender.fullName',
-                    defaultMessage: 'Gender declined to answer',
+                    defaultMessage: 'Gender supplied declined to answer',
                   },
                   name: {
                     id: 'field.persons_common.declinedToAnswerGender.name',
@@ -872,7 +872,7 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.persons_common.useRestrictionGender.fullName',
-                    defaultMessage: 'Gender use restriction',
+                    defaultMessage: 'Gender supplied use restriction',
                   },
                   name: {
                     id: 'field.persons_common.useRestrictionGender.name',
@@ -914,7 +914,7 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.persons_common.declinedToAnswerRace.fullName',
-                    defaultMessage: 'Race declined to answer',
+                    defaultMessage: 'Race supplied declined to answer',
                   },
                   name: {
                     id: 'field.persons_common.declinedToAnswerRace.name',
@@ -959,7 +959,7 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.persons_common.useRestrictionRace.fullName',
-                    defaultMessage: 'Race use restriction',
+                    defaultMessage: 'Race supplied use restriction',
                   },
                   name: {
                     id: 'field.persons_common.useRestrictionRace.name',
@@ -1001,7 +1001,7 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.persons_common.declinedToAnswerEthnicity.fullName',
-                    defaultMessage: 'Ethnicity declined to answer',
+                    defaultMessage: 'Ethnicity supplied declined to answer',
                   },
                   name: {
                     id: 'field.persons_common.declinedToAnswerEthnicity.name',
@@ -1046,7 +1046,7 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.persons_common.useRestrictionEthnicity.fullName',
-                    defaultMessage: 'Ethnicity use restriction',
+                    defaultMessage: 'Ethnicity supplied use restriction',
                   },
                   name: {
                     id: 'field.persons_common.useRestrictionEthnicity.name',
@@ -1088,7 +1088,7 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.persons_common.declinedToAnswerSexuality.fullName',
-                    defaultMessage: 'Sexuality declined to answer',
+                    defaultMessage: 'Sexuality supplied declined to answer',
                   },
                   name: {
                     id: 'field.persons_common.declinedToAnswerSexuality.name',
@@ -1133,7 +1133,7 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.persons_common.useRestrictionSexuality.fullName',
-                    defaultMessage: 'Sexuality use restriction',
+                    defaultMessage: 'Sexuality supplied use restriction',
                   },
                   name: {
                     id: 'field.persons_common.useRestrictionSexuality.name',
@@ -1175,7 +1175,7 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.persons_common.declinedToAnswerBirthPlace.fullName',
-                    defaultMessage: 'Birth place declined to answer',
+                    defaultMessage: 'Birth place supplied declined to answer',
                   },
                   name: {
                     id: 'field.persons_common.declinedToAnswerBirthPlace.name',
@@ -1212,7 +1212,7 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.persons_common.useRestrictionBirthPlace.fullName',
-                    defaultMessage: 'Birth place use restriction',
+                    defaultMessage: 'Birth place supplied use restriction',
                   },
                   name: {
                     id: 'field.persons_common.useRestrictionBirthPlace.name',
@@ -1258,7 +1258,7 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.persons_common.declinedToAnswerBirthDate.fullName',
-                    defaultMessage: 'Supplied birth date declined to answer',
+                    defaultMessage: 'Birth date supplied declined to answer',
                   },
                   name: {
                     id: 'field.persons_common.declinedToAnswerBirthDate.name',
@@ -1276,7 +1276,7 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.persons_common.suppliedStructuredBirthDateGroup.fullName',
-                    defaultMessage: 'Supplied structured birth date',
+                    defaultMessage: 'Birth date supplied',
                   },
                   groupName: {
                     id: 'field.persons_common.suppliedStructuredBirthDateGroup.groupName',
@@ -1298,7 +1298,7 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.persons_common.useRestrictionBirthDate.fullName',
-                    defaultMessage: 'Supplied birth date use restriction',
+                    defaultMessage: 'Birth date supplied use restriction',
                   },
                   name: {
                     id: 'field.persons_common.useRestrictionBirthDate.name',

--- a/src/plugins/recordTypes/person/fields.js
+++ b/src/plugins/recordTypes/person/fields.js
@@ -1199,7 +1199,6 @@ export default (configContext) => {
                     defaultMessage: 'Supplied',
                   },
                 }),
-                repeating: true,
                 view: {
                   type: AutocompleteInput,
                   props: {
@@ -1288,7 +1287,6 @@ export default (configContext) => {
                     defaultMessage: 'Supplied',
                   },
                 }),
-                repeating: true,
                 view: {
                   type: StructuredDateInput,
                 },

--- a/src/plugins/recordTypes/person/fields.js
+++ b/src/plugins/recordTypes/person/fields.js
@@ -1223,17 +1223,21 @@ export default (configContext) => {
             },
           },
         },
-        birthDateGroupList: {
+        suppliedBirthDateGroupList: {
           [config]: {
             view: {
               type: CompoundInput,
             },
           },
-          birthDateGroup: {
+          suppliedBirthDateGroup: {
             [config]: {
               messages: defineMessages({
+                fullName: {
+                  id: 'field.persons_common.suppliedBirthDateGroup.fullName',
+                  defaultMessage: 'Supplied birth date',
+                },
                 name: {
-                  id: 'field.persons_common.birthDateGroup.name',
+                  id: 'field.persons_common.suppliedBirthDateGroup.name',
                   defaultMessage: 'Birth date',
                 },
               }),
@@ -1247,7 +1251,7 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.persons_common.declinedToAnswerBirthDate.fullName',
-                    defaultMessage: 'Birth date declined to answer',
+                    defaultMessage: 'Supplied birth date declined to answer',
                   },
                   name: {
                     id: 'field.persons_common.declinedToAnswerBirthDate.name',
@@ -1259,15 +1263,20 @@ export default (configContext) => {
                 },
               },
             },
-            suppliedBirthDate: {
+            suppliedStructuredBirthDateGroup: {
               [config]: {
+                dataType: DATA_TYPE_STRUCTURED_DATE,
                 messages: defineMessages({
                   fullName: {
-                    id: 'field.persons_common.suppliedBirthDate.fullName',
-                    defaultMessage: 'Birth date supplied',
+                    id: 'field.persons_common.suppliedStructuredBirthDateGroup.fullName',
+                    defaultMessage: 'Supplied structured birth date',
+                  },
+                  groupName: {
+                    id: 'field.persons_common.suppliedStructuredBirthDateGroup.groupName',
+                    defaultMessage: 'Date',
                   },
                   name: {
-                    id: 'field.persons_common.suppliedBirthDate.name',
+                    id: 'field.persons_common.suppliedStructuredBirthDateGroup.name',
                     defaultMessage: 'Supplied',
                   },
                 }),
@@ -1275,15 +1284,15 @@ export default (configContext) => {
                 view: {
                   type: StructuredDateInput,
                 },
-                ...extensions.structuredDate.fields,
               },
+              ...extensions.structuredDate.fields,
             },
             useRestrictionBirthDate: {
               [config]: {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.persons_common.useRestrictionBirthDate.fullName',
-                    defaultMessage: 'Birth date use restriction',
+                    defaultMessage: 'Supplied birth date use restriction',
                   },
                   name: {
                     id: 'field.persons_common.useRestrictionBirthDate.name',

--- a/src/plugins/recordTypes/person/fields.js
+++ b/src/plugins/recordTypes/person/fields.js
@@ -1280,7 +1280,7 @@ export default (configContext) => {
                   },
                   groupName: {
                     id: 'field.persons_common.suppliedStructuredBirthDateGroup.groupName',
-                    defaultMessage: 'Date',
+                    defaultMessage: 'Supplied',
                   },
                   name: {
                     id: 'field.persons_common.suppliedStructuredBirthDateGroup.name',

--- a/src/plugins/recordTypes/person/fields.js
+++ b/src/plugins/recordTypes/person/fields.js
@@ -23,6 +23,7 @@ export default (configContext) => {
 
   const {
     DATA_TYPE_BOOL,
+    DATA_TYPE_DATE,
     DATA_TYPE_STRUCTURED_DATE,
   } = configContext.dataTypes;
 
@@ -735,6 +736,7 @@ export default (configContext) => {
             },
             declinedToAnswerPronoun: {
               [config]: {
+                dataType: DATA_TYPE_BOOL,
                 messages: defineMessages({
                   fullName: {
                     id: 'field.persons_common.declinedToAnswerPronoun.fullName',
@@ -821,6 +823,7 @@ export default (configContext) => {
             },
             declinedToAnswerGender: {
               [config]: {
+                dataType: DATA_TYPE_BOOL,
                 messages: defineMessages({
                   fullName: {
                     id: 'field.persons_common.declinedToAnswerGender.fullName',
@@ -907,6 +910,7 @@ export default (configContext) => {
             },
             declinedToAnswerRace: {
               [config]: {
+                dataType: DATA_TYPE_BOOL,
                 messages: defineMessages({
                   fullName: {
                     id: 'field.persons_common.declinedToAnswerRace.fullName',
@@ -993,6 +997,7 @@ export default (configContext) => {
             },
             declinedToAnswerEthnicity: {
               [config]: {
+                dataType: DATA_TYPE_BOOL,
                 messages: defineMessages({
                   fullName: {
                     id: 'field.persons_common.declinedToAnswerEthnicity.fullName',
@@ -1079,6 +1084,7 @@ export default (configContext) => {
             },
             declinedToAnswerSexuality: {
               [config]: {
+                dataType: DATA_TYPE_BOOL,
                 messages: defineMessages({
                   fullName: {
                     id: 'field.persons_common.declinedToAnswerSexuality.fullName',
@@ -1165,6 +1171,7 @@ export default (configContext) => {
             },
             declinedToAnswerBirthPlace: {
               [config]: {
+                dataType: DATA_TYPE_BOOL,
                 messages: defineMessages({
                   fullName: {
                     id: 'field.persons_common.declinedToAnswerBirthPlace.fullName',
@@ -1248,6 +1255,7 @@ export default (configContext) => {
             },
             declinedToAnswerBirthDate: {
               [config]: {
+                dataType: DATA_TYPE_BOOL,
                 messages: defineMessages({
                   fullName: {
                     id: 'field.persons_common.declinedToAnswerBirthDate.fullName',
@@ -1350,6 +1358,7 @@ export default (configContext) => {
             },
             informationDate: {
               [config]: {
+                dataType: DATA_TYPE_DATE,
                 messages: defineMessages({
                   fullName: {
                     id: 'field.persons_common.informationDate.fullName',

--- a/src/plugins/recordTypes/person/forms/default.jsx
+++ b/src/plugins/recordTypes/person/forms/default.jsx
@@ -174,12 +174,12 @@ const template = (configContext) => {
             </Panel>
           </Field>
         </Field>
-        <Field name="birthDateGroupList">
-          <Field name="birthDateGroup">
+        <Field name="suppliedBirthDateGroupList">
+          <Field name="suppliedBirthDateGroup">
             <Panel>
               <Row>
                 <Field name="declinedToAnswerBirthDate" />
-                <Field name="suppliedBirthDate" />
+                <Field name="suppliedStructuredBirthDateGroup" />
                 <Field name="useRestrictionBirthDate" />
               </Row>
             </Panel>


### PR DESCRIPTION
Jira: https://collectionspace.atlassian.net/browse/DRYD-1172

* Rename supplied birthDate fields to avoid conflicts with previously defined fields
* Update messages for supplied birth date fields better indicate what they are in search
* Add groupName message for birth date structured date input
* Fix import of structured date fields for suppliedStructuredBirthDate
* Add missing dataType definitions
* Remove errant repeat declarations for suppliedStructuredBirthDate and suppliedBirthPlace