### PR TITLE
DRYD-1185: Error on save when pivoting to record

### DIFF
--- a/src/actions/record.js
+++ b/src/actions/record.js
@@ -1305,9 +1305,10 @@ export const detachSubrecord = (config, csid, csidField, subrecordName, subrecor
   },
 });
 
-export const clearRecord = (csid) => ({
+export const clearRecord = (csid, clearSubrecords) => ({
   type: CLEAR_RECORD,
   meta: {
     csid,
+    clearSubrecords,
   },
 });

--- a/src/components/pages/RecordPage.jsx
+++ b/src/components/pages/RecordPage.jsx
@@ -141,7 +141,7 @@ export default class RecordPage extends Component {
       // relations will be included.
 
       if (clearRecord) {
-        clearRecord(dataCsid);
+        clearRecord(dataCsid, true);
       }
 
       history.replace({

--- a/src/reducers/record.js
+++ b/src/reducers/record.js
@@ -405,6 +405,14 @@ const handleRecordSaveFulfilled = (state, action) => {
     });
   }
 
+  // avoid clearing any subrecords for the current page
+  const recordPageSubrecord = nextState.getIn([recordPagePrimaryCsid, 'subrecord']);
+  if (recordPageSubrecord) {
+    recordPageSubrecord.valueSeq().forEach((subrecordCsid) => {
+      persistCsids.push(subrecordCsid);
+    });
+  }
+
   persistCsids = new Set(persistCsids.filter(
     (value) => (value !== null && typeof value !== 'undefined'),
   ));

--- a/src/reducers/record.js
+++ b/src/reducers/record.js
@@ -65,7 +65,7 @@ const setCurrentData = (state, csid, data) => state.setIn([csid, 'data', 'curren
 const getBaselineData = (state, csid) => state.getIn([csid, 'data', 'baseline']);
 const setBaselineData = (state, csid, data) => state.setIn([csid, 'data', 'baseline'], data);
 
-const clear = (state, csid) => {
+const clear = (state, csid, clearSubrecords = false) => {
   const recordState = state.get(csid);
 
   if (!recordState) {
@@ -76,9 +76,13 @@ const clear = (state, csid) => {
 
   const subrecord = recordState.get('subrecord');
 
-  if (subrecord) {
+  if (clearSubrecords && subrecord) {
     nextState = subrecord.reduce(
-      (reducedState, subrecordCsid) => clear(reducedState, subrecordCsid), nextState,
+      (reducedState, subrecordCsid) => clear(
+        reducedState,
+        subrecordCsid,
+        clearSubrecords,
+      ), nextState,
     );
   }
 
@@ -828,7 +832,7 @@ export default (state = Immutable.Map(), action) => {
     case DETACH_SUBRECORD:
       return detachSubrecord(state, action);
     case CLEAR_RECORD:
-      return clear(state, action.meta.csid);
+      return clear(state, action.meta.csid, action.meta.clearSubrecords);
     case LOGIN_FULFILLED:
       return handleLoginFulfilled(state, action);
     case LOGOUT_FULFILLED:

--- a/test/specs/actions/record.spec.js
+++ b/test/specs/actions/record.spec.js
@@ -401,12 +401,14 @@ describe('record action creator', () => {
   describe('clearRecord', () => {
     it('should return a CLEAR_RECORD action', () => {
       const csid = '1234';
+      const clearSubrecords = true;
 
-      clearRecord(csid).should
+      clearRecord(csid, true).should
         .deep.equal({
           type: CLEAR_RECORD,
           meta: {
             csid,
+            clearSubrecords,
           },
         });
     });

--- a/test/specs/reducers/record.spec.js
+++ b/test/specs/reducers/record.spec.js
@@ -2230,6 +2230,7 @@ describe('record reducer', () => {
     it('should clear state for any subrecords', () => {
       const csid = '1234';
       const subrecordCsid = 'abcd';
+      const clearSubrecords = true;
 
       const state = reducer(Immutable.fromJS({
         [csid]: {
@@ -2249,6 +2250,7 @@ describe('record reducer', () => {
         type: CLEAR_RECORD,
         meta: {
           csid,
+          clearSubrecords,
         },
       });
 


### PR DESCRIPTION
Jira: https://collectionspace.atlassian.net/browse/DRYD-1185

* Add subrecords of primary page csid to filter
* Prevent subrecords from being cleared by default

# Testing

* Create a `person` authority with a `contact`
* Create a `collectionobject` with the `person` assigned to one of its fields
* Edit the `collectionobject` and pivot to the `person` with the mouse over using save and continue
* Check that the `contact` has been loaded for the `person` and that the `person` can be saved without error

# Notes

This prevents necessary subrecord data from being removed from the redux store after records are saved. I added a boolean to `clear` for the case when we need to clear subrecord data there, otherwise any subrecords that are safe to clear are handled in `clearFiltered` during the iteration of the store data.