### PR TITLE
DRYD-1008: Add null check in flatten

### DIFF
--- a/src/helpers/objectHelpers.js
+++ b/src/helpers/objectHelpers.js
@@ -25,7 +25,9 @@ export const flatten = (object, maxDepth, parentPath, currentDepth = 1) => {
     const path = parentPath ? `${parentPath}.${key}` : key;
     const value = object[key];
 
-    if (typeof value === 'object' && (typeof maxDepth === 'undefined' || currentDepth < maxDepth)) {
+    if (value !== null
+      && typeof value === 'object'
+      && (typeof maxDepth === 'undefined' || currentDepth < maxDepth)) {
       Object.assign(flattened, flatten(value, maxDepth, path, currentDepth + 1));
     } else {
       flattened[path] = value;

--- a/test/specs/helpers/objectHelpers.spec.js
+++ b/test/specs/helpers/objectHelpers.spec.js
@@ -192,5 +192,30 @@ describe('objectHelpers', () => {
         'key4.key6': true,
       });
     });
+
+    it('should handle null values', () => {
+      const obj1 = {
+        key1: 'foo',
+        key2: null,
+        key3: {
+          key4: 'bar',
+          key5: null,
+        },
+      };
+
+      const obj2 = {
+        key1: 'foo',
+        key2: null,
+        key3: {
+          key4: 'baz',
+          key5: 'boz',
+        },
+      };
+
+      diff(obj1, obj2).should.deep.equal({
+        'key3.key4': true,
+        'key3.key5': true,
+      });
+    });
   });
 });


### PR DESCRIPTION
Jira: https://collectionspace.atlassian.net/browse/DRYD-1008

* Add check to avoid recursive operations with null values

# Notes

The error in the search api came up with nested `BooleanConditionInputs` which assign their path a null value. This eventually causes an error when calling `Object.keys` w/ a null object during comparison of the search descriptors. I was initially considering removing the path from the class but it's used in a few places where I wasn't sure if there were any implications on removing it.

Also for replication of the issue, after executing the search I had to revise the search and update the terms. This way the search reducer will always run a diff on the given searchDescriptor and mostRecentSearchDescriptor.