### PR TITLE
DRYD-966: Add options to acquisitionMethods optionList

### DIFF
--- a/src/plugins/recordTypes/acquisition/optionLists.js
+++ b/src/plugins/recordTypes/acquisition/optionLists.js
@@ -3,13 +3,29 @@ import { defineMessages } from 'react-intl';
 export default {
   acquisitionMethods: {
     values: [
+      'bequest',
+      'commission',
+      'found in collection',
       'gift',
       'purchase',
       'exchange',
       'transfer',
       'treasure',
+      'unknown',
     ],
     messages: defineMessages({
+      bequest: {
+        id: 'option.acquisitionMethods.bequest',
+        defaultMessage: 'bequest',
+      },
+      commission: {
+        id: 'option.acquisitionMethods.commission',
+        defaultMessage: 'commission',
+      },
+      'found in collection': {
+        id: 'option.acquisitionMethods.found in collection',
+        defaultMessage: 'found in collection',
+      },
       gift: {
         id: 'option.acquisitionMethods.gift',
         defaultMessage: 'gift',
@@ -29,6 +45,10 @@ export default {
       treasure: {
         id: 'option.acquisitionMethods.treasure',
         defaultMessage: 'treasure',
+      unknown: {
+        id: 'option.acquisitionMethods.unknown',
+        defaultMessage: 'unknown',
+      },
       },
     }),
   },


### PR DESCRIPTION
**What does this do?**
Adds the following options to the acquisitionMethods optionList:

* bequest
* commission
* found in collection
* unknown

**Why are we doing this? (with JIRA link)**
Frequently used terms across different types of CS user
https://collectionspace.atlassian.net/browse/DRYD-966

**How should this be tested? Do these changes have associated tests?**
?

**Dependencies for merging? Releasing to production?**
I don't think so. To be safe, let me verify this situation, related to our hosted clients:

Here is [one client's customization of the acquisitionMethods optionList](https://github.com/lyrasis/collectionspace-playbook/blob/78379a5469061e3f5ce2bad27d2786aa8f028c11/files/docker/breman/index.ui.html#L29).

My understanding of what will happen here, is that this client will not be affected by the changes, since we have defined all the existing-at-the-time of customization options in the `values`. That is, on the good side, they are not going to end up with two "found in collection" options in their dropdown list (with `foundincollection` and `found in collection` as the underlying data values). While, on the maybe not-so-great side, clients for whom we have customized an optionList never get the new options unless we manually update their configs.

**Has the application documentation been updated for these changes?**
I don't think there is relevant application documentation.

At some point, when these changes are deployed to sites in use by CSV Importer users, I will need to:
* regenerate CSV Importer templates (so that the new options are listed as usable values for the acquistionMethod field)
* regenerate CSV Importer mappers (so that using the new options does not cause an "Unknown option value" warning during processing)

**Did someone actually run this code to verify it works?**
not yet...
