### PR TITLE
Show build numbers in footer.

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,6 +1,7 @@
 /* eslint no-console: "off" */
 
 const path = require('path');
+const webpack = require('webpack');
 
 const getTestFiles = (config) => {
   if (config.file) {
@@ -99,6 +100,15 @@ module.exports = function karma(config) {
           },
         ],
       },
+      plugins: [
+        new webpack.DefinePlugin({
+          'cspaceUI.isProduction': false,
+          'cspaceUI.packageName': '"cspace-ui"',
+          'cspaceUI.packageVersion': '"0.0.1-test.1"',
+          'cspaceUI.buildNum': '"1234567"',
+          'cspaceUI.repositoryUrl': '"https://github.com/collectionspace/cspace-ui.js.git"',
+        }),
+      ],
       resolve: {
         extensions: ['.js', '.jsx'],
       },

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -102,6 +102,7 @@ module.exports = function karma(config) {
       },
       plugins: [
         new webpack.DefinePlugin({
+          // Set dummy values for tests.
           'cspaceUI.isProduction': false,
           'cspaceUI.packageName': '"cspace-ui"',
           'cspaceUI.packageVersion': '"0.0.1-test.1"',

--- a/src/components/sections/Footer.jsx
+++ b/src/components/sections/Footer.jsx
@@ -1,5 +1,5 @@
 /* global cspaceUI */
-/* The cspaceUI global variable is set by webpack (in non-test builds). See webpack.config.js. */
+/* The cspaceUI global variable is set by webpack. See webpack.config.js and karma.conf.js. */
 
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/src/components/sections/Footer.jsx
+++ b/src/components/sections/Footer.jsx
@@ -79,7 +79,11 @@ const renderServicesReleaseVersion = (systemInfo) => {
       <>
         {' '}
         (
-        <a href={`https://github.com/collectionspace/services/commits/${commitHash}`}>
+        <a
+          href={`https://github.com/collectionspace/services/commits/${commitHash}`}
+          target="_blank"
+          rel="noreferrer"
+        >
           {commitHash}
         </a>
         )
@@ -110,7 +114,11 @@ const renderUIVersion = (systemInfo) => {
       <>
         {' '}
         (
-        <a href={`${repoUrl}/commits/${commitHash}`}>
+        <a
+          href={`${repoUrl}/commits/${commitHash}`}
+          target="_blank"
+          rel="noreferrer"
+        >
           {commitHash}
         </a>
         )
@@ -141,7 +149,7 @@ const renderPluginVersion = (systemInfo, pluginInfo) => {
     const repoUrl = repositoryUrl ? repositoryUrl.replace(/\.git$/, '') : '';
 
     const commitLink = repoUrl
-      ? <a href={`${repoUrl}/commits/${commitHash}`}>{commitHash}</a>
+      ? <a href={`${repoUrl}/commits/${commitHash}`} target="_blank" rel="noreferrer">{commitHash}</a>
       : commitHash;
 
     buildLink = (

--- a/styles/cspace-ui/Footer.css
+++ b/styles/cspace-ui/Footer.css
@@ -13,7 +13,7 @@
   padding: 0 10px;
 }
 
-.common, .common > ul > li > a {
+.common, .common a {
   color: rgb(160, 160, 160);
 }
 

--- a/test/specs/components/sections/Footer.spec.jsx
+++ b/test/specs/components/sections/Footer.spec.jsx
@@ -42,7 +42,7 @@ describe('Footer', () => {
           major: '5',
           minor: '1',
           patch: '0',
-          build: '1',
+          build: '5678',
         },
       },
     });
@@ -56,7 +56,7 @@ describe('Footer', () => {
     const lists = this.container.querySelectorAll('ul');
     const items = lists[1].querySelectorAll('li');
 
-    items[0].textContent.should.equal('Release 5.1');
+    items[0].textContent.should.equal('Release 5.1.0 (5678)');
   });
 
   it('should render no version number if it is not present in system info', function test() {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,11 +1,14 @@
 /* eslint import/no-extraneous-dependencies: "off" */
 
+const { execSync } = require('child_process');
 const path = require('path');
 const webpack = require('webpack');
 
 const library = 'cspaceUI';
 const isProduction = process.env.NODE_ENV === 'production';
 const filename = `${library}${isProduction ? '.min' : ''}.js`;
+const buildNum = execSync('git rev-parse --short=7 HEAD').toString().trim();
+const repositoryUrl = JSON.parse(execSync('npm pkg get repository.url').toString().trim());
 
 const config = {
   mode: isProduction ? 'production' : 'development',
@@ -52,8 +55,11 @@ const config = {
   },
   plugins: [
     new webpack.DefinePlugin({
+      [`${library}.isProduction`]: isProduction,
       [`${library}.packageName`]: JSON.stringify(process.env.npm_package_name),
       [`${library}.packageVersion`]: JSON.stringify(process.env.npm_package_version),
+      [`${library}.buildNum`]: JSON.stringify(buildNum),
+      [`${library}.repositoryUrl`]: JSON.stringify(repositoryUrl),
     }),
   ],
   resolve: {


### PR DESCRIPTION
**What does this do?**

This displays build numbers (git commit hashes) along with the version information in the footer under certain conditions. The build numbers are displayed when the version of the services layer (as reported by the systeminfo endpoint) ends with "-SNAPSHOT", indicating that it is a development build. The build numbers are also displayed, regardless of the services version, in development builds of cspace-ui (such as when using `npm run devserver`).

**Why are we doing this? (with JIRA link)**

This complements https://github.com/collectionspace/services/pull/320. When the services layer is configured to clone and build UI packages from source, it will be important to know the commit hash that is deployed, since the version number may not change.

**How should this be tested? Do these changes have associated tests?**

Run the app using `npm run devserver`. Verify that the footer displays build numbers for the services and for the UI, next to the version numbers. Clicking on the build numbers should open a browser tab to GitHub, showing the commits up to that hash.

**Dependencies for merging? Releasing to production?**

None.

**Has the application documentation been updated for these changes?**

I don't think there's any developer documentation that needs to cover this. It won't be visible to most end users, who would only be using production releases.

**Did someone actually run this code to verify it works?**

@ray-lee ran this against SNAPSHOT and non-SNAPSHOT releases of the services layer, using production and development builds of cspace-ui.
