### PR TITLE
Update readme badges.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # cspace-ui
 
 [![npm package](https://img.shields.io/npm/v/cspace-ui.svg)](https://www.npmjs.com/package/cspace-ui)
-<!-- [![build status](https://travis-ci.org/collectionspace/cspace-ui.js.svg?branch=master)](https://travis-ci.org/collectionspace/cspace-ui.js) -->
-<!-- [![coverage status](https://coveralls.io/repos/github/collectionspace/cspace-ui.js/badge.svg?branch=master)](https://coveralls.io/github/collectionspace/cspace-ui.js?branch=master) -->
+[![continuous integration](https://github.com/collectionspace/cspace-ui.js/actions/workflows/ci.yml/badge.svg?branch=master&event=push)](https://github.com/collectionspace/cspace-ui.js/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/collectionspace/cspace-ui.js/branch/master/graph/badge.svg?token=rQ8jLRZlXs)](https://codecov.io/gh/collectionspace/cspace-ui.js)
 
 The CollectionSpace user interface for web browsers.
 


### PR DESCRIPTION
**What does this do?**

This adds badges for CI build status and code coverage status back to the readme, now using GitHub Actions and Codecov instead of TravisCI and Coveralls.

**Why are we doing this? (with JIRA link)**

This PR is mostly here to test the Codecov status checks on PRs. It also adds some useful information to the readme.

**How should this be tested? Do these changes have associated tests?**

The CI status and Coverage status badges should appear on the readme.

**Dependencies for merging? Releasing to production?**

None.

**Has the application documentation been updated for these changes?**

This is an update to the docs!

**Did someone actually run this code to verify it works?**

@ray-lee checked that the badges look good, and that the codecov status checks and comment are working.