### PR TITLE
DRYD-1223, DRYD-1227: Add Firefox to CI builds.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   check:
     name: Check build
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     steps:
       - name: Checkout
@@ -37,8 +37,7 @@ jobs:
         run: npm run lint
 
       - name: Test
-        # Use xvfb-run to allow the browser to run headlessly.
-        run: xvfb-run -a npm test
+        run: npm test
 
       - name: Generate coverage report
         run: npm run coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
       - name: Install Chrome
         uses: browser-actions/setup-chrome@v1
 
+      - name: Install Firefox
+        uses: browser-actions/setup-firefox@v1
+
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -35,6 +35,8 @@ module.exports = function karma(config) {
 
   config.set({
     browsers,
+    concurrency: 1,
+
     files: [
       { pattern: 'mockServiceWorker.js', included: false, served: true },
       ...getTestFiles(config),

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -13,7 +13,7 @@ const getTestFiles = (config) => {
 
 module.exports = function karma(config) {
   const localBrowsers = ['Chrome'];
-  const githubBrowsers = ['Chrome'];
+  const githubBrowsers = ['Chrome', 'Firefox'];
 
   let browsers;
 

--- a/test/specs/actions/account.spec.js
+++ b/test/specs/actions/account.spec.js
@@ -30,7 +30,11 @@ describe('account action creator', () => {
   const mockStore = configureMockStore([thunk]);
   const worker = setupWorker();
 
-  before(() => worker.start({ quiet: true }));
+  before(async function setup() {
+    this.timeout(3000);
+
+    await worker.start({ quiet: true });
+  });
 
   after(() => {
     worker.stop();

--- a/test/specs/actions/authority.spec.js
+++ b/test/specs/actions/authority.spec.js
@@ -23,7 +23,11 @@ const mockStore = configureMockStore([thunk]);
 describe('authority action creator', () => {
   const worker = setupWorker();
 
-  before(() => worker.start({ quiet: true }));
+  before(async function setup() {
+    this.timeout(3000);
+
+    await worker.start({ quiet: true });
+  });
 
   after(() => {
     worker.stop();

--- a/test/specs/actions/authz.spec.js
+++ b/test/specs/actions/authz.spec.js
@@ -24,7 +24,11 @@ import {
 describe('authz action creator', () => {
   const worker = setupWorker();
 
-  before(() => worker.start({ quiet: true }));
+  before(async function setup() {
+    this.timeout(3000);
+
+    await worker.start({ quiet: true });
+  });
 
   after(() => {
     worker.stop();

--- a/test/specs/actions/batch.spec.js
+++ b/test/specs/actions/batch.spec.js
@@ -55,7 +55,11 @@ const mockStore = configureMockStore([thunk]);
 describe('batch action creator', () => {
   const worker = setupWorker();
 
-  before(() => worker.start({ quiet: true }));
+  before(async function setup() {
+    this.timeout(3000);
+
+    await worker.start({ quiet: true });
+  });
 
   after(() => {
     worker.stop();

--- a/test/specs/actions/cspace.spec.js
+++ b/test/specs/actions/cspace.spec.js
@@ -36,7 +36,11 @@ const mockStore = configureMockStore([thunk]);
 describe('cspace action creator', () => {
   const worker = setupWorker();
 
-  before(() => worker.start({ quiet: true }));
+  before(async function setup() {
+    this.timeout(3000);
+
+    await worker.start({ quiet: true });
+  });
 
   after(() => {
     worker.stop();

--- a/test/specs/actions/export.spec.js
+++ b/test/specs/actions/export.spec.js
@@ -53,7 +53,11 @@ const mockStore = configureMockStore([thunk]);
 describe('export action creator', () => {
   const worker = setupWorker();
 
-  before(() => worker.start({ quiet: true }));
+  before(async function setup() {
+    this.timeout(3000);
+
+    await worker.start({ quiet: true });
+  });
 
   after(() => {
     worker.stop();

--- a/test/specs/actions/idGenerator.spec.js
+++ b/test/specs/actions/idGenerator.spec.js
@@ -36,7 +36,11 @@ chai.should();
 describe('ID generator action creator', () => {
   const worker = setupWorker();
 
-  before(() => worker.start({ quiet: true }));
+  before(async function setup() {
+    this.timeout(3000);
+
+    await worker.start({ quiet: true });
+  });
 
   after(() => {
     worker.stop();

--- a/test/specs/actions/login.spec.js
+++ b/test/specs/actions/login.spec.js
@@ -44,7 +44,11 @@ chai.should();
 describe('login action creator', () => {
   const worker = setupWorker();
 
-  before(() => worker.start({ quiet: true }));
+  before(async function setup() {
+    this.timeout(3000);
+
+    await worker.start({ quiet: true });
+  });
 
   after(() => {
     worker.stop();

--- a/test/specs/actions/logout.spec.js
+++ b/test/specs/actions/logout.spec.js
@@ -28,7 +28,11 @@ chai.should();
 describe('logout action creator', () => {
   const worker = setupWorker();
 
-  before(() => worker.start({ quiet: true }));
+  before(async function setup() {
+    this.timeout(3000);
+
+    await worker.start({ quiet: true });
+  });
 
   after(() => {
     worker.stop();

--- a/test/specs/actions/partialTermSearch.spec.js
+++ b/test/specs/actions/partialTermSearch.spec.js
@@ -28,7 +28,11 @@ chai.should();
 describe('partialTermSearch action creator', () => {
   const worker = setupWorker();
 
-  before(() => worker.start({ quiet: true }));
+  before(async function setup() {
+    this.timeout(3000);
+
+    await worker.start({ quiet: true });
+  });
 
   after(() => {
     worker.stop();

--- a/test/specs/actions/record.spec.js
+++ b/test/specs/actions/record.spec.js
@@ -98,7 +98,11 @@ chai.should();
 describe('record action creator', () => {
   const worker = setupWorker();
 
-  before(() => worker.start({ quiet: true }));
+  before(async function setup() {
+    this.timeout(3000);
+
+    await worker.start({ quiet: true });
+  });
 
   after(() => {
     worker.stop();

--- a/test/specs/actions/relation.spec.js
+++ b/test/specs/actions/relation.spec.js
@@ -63,7 +63,11 @@ const config = {
 describe('relation action creator', () => {
   const worker = setupWorker();
 
-  before(() => worker.start({ quiet: true }));
+  before(async function setup() {
+    this.timeout(3000);
+
+    await worker.start({ quiet: true });
+  });
 
   after(() => {
     worker.stop();

--- a/test/specs/actions/report.spec.js
+++ b/test/specs/actions/report.spec.js
@@ -57,7 +57,11 @@ const mockStore = configureMockStore([thunk]);
 describe('report action creator', () => {
   const worker = setupWorker();
 
-  before(() => worker.start({ quiet: true }));
+  before(async function setup() {
+    this.timeout(3000);
+
+    await worker.start({ quiet: true });
+  });
 
   after(() => {
     worker.stop();

--- a/test/specs/actions/search.spec.js
+++ b/test/specs/actions/search.spec.js
@@ -50,7 +50,11 @@ const mockStore = configureMockStore([thunk]);
 describe('search action creator', () => {
   const worker = setupWorker();
 
-  before(() => worker.start({ quiet: true }));
+  before(async function setup() {
+    this.timeout(3000);
+
+    await worker.start({ quiet: true });
+  });
 
   after(() => {
     worker.stop();

--- a/test/specs/actions/structuredDate.spec.js
+++ b/test/specs/actions/structuredDate.spec.js
@@ -18,7 +18,11 @@ chai.should();
 describe('structured date action creator', () => {
   const worker = setupWorker();
 
-  before(() => worker.start({ quiet: true }));
+  before(async function setup() {
+    this.timeout(3000);
+
+    await worker.start({ quiet: true });
+  });
 
   after(() => {
     worker.stop();

--- a/test/specs/actions/vocabulary.spec.js
+++ b/test/specs/actions/vocabulary.spec.js
@@ -26,7 +26,11 @@ chai.should();
 describe('vocabulary action creator', () => {
   const worker = setupWorker();
 
-  before(() => worker.start({ quiet: true }));
+  before(async function setup() {
+    this.timeout(3000);
+
+    await worker.start({ quiet: true });
+  });
 
   after(() => {
     worker.stop();

--- a/test/specs/components/record/RecordBrowser.spec.jsx
+++ b/test/specs/components/record/RecordBrowser.spec.jsx
@@ -207,7 +207,7 @@ describe('RecordBrowser', () => {
         replacementUrl.should.equal(`/record/collectionobject/${createdCsid}`);
 
         resolve();
-      }, 200);
+      }, 500);
     });
   });
 

--- a/test/specs/components/record/RecordBrowser.spec.jsx
+++ b/test/specs/components/record/RecordBrowser.spec.jsx
@@ -91,10 +91,14 @@ const config = {
 describe('RecordBrowser', () => {
   const worker = setupWorker();
 
-  before(() => Promise.all([
-    worker.start({ quiet: true }),
-    store.dispatch(configureCSpace()).then(() => store.clearActions()),
-  ]));
+  before(async function setup() {
+    this.timeout(3000);
+
+    await Promise.all([
+      worker.start({ quiet: true }),
+      store.dispatch(configureCSpace()).then(() => store.clearActions()),
+    ]);
+  });
 
   beforeEach(function before() {
     this.container = createTestContainer(this);

--- a/test/specs/components/record/RelatedRecordBrowser.spec.jsx
+++ b/test/specs/components/record/RelatedRecordBrowser.spec.jsx
@@ -417,7 +417,7 @@ describe('RelatedRecordBrowser', () => {
         });
 
         resolve();
-      }, 200);
+      }, 500);
     });
   });
 

--- a/test/specs/components/record/RelatedRecordBrowser.spec.jsx
+++ b/test/specs/components/record/RelatedRecordBrowser.spec.jsx
@@ -133,10 +133,14 @@ const config = {
 describe('RelatedRecordBrowser', () => {
   const worker = setupWorker();
 
-  before(() => Promise.all([
-    worker.start({ quiet: true }),
-    store.dispatch(configureCSpace()).then(() => store.clearActions()),
-  ]));
+  before(async function setup() {
+    this.timeout(3000);
+
+    await Promise.all([
+      worker.start({ quiet: true }),
+      store.dispatch(configureCSpace()).then(() => store.clearActions()),
+    ]);
+  });
 
   beforeEach(function before() {
     this.container = createTestContainer(this);

--- a/test/specs/containers/invocable/InvocationModalContainer.spec.jsx
+++ b/test/specs/containers/invocable/InvocationModalContainer.spec.jsx
@@ -50,10 +50,14 @@ const config = {
 describe('InvocationModalContainer', () => {
   const worker = setupWorker();
 
-  before(() => Promise.all([
-    worker.start({ quiet: true }),
-    store.dispatch(configureCSpace()).then(() => store.clearActions()),
-  ]));
+  before(async function setup() {
+    this.timeout(3000);
+
+    await Promise.all([
+      worker.start({ quiet: true }),
+      store.dispatch(configureCSpace()).then(() => store.clearActions()),
+    ]);
+  });
 
   afterEach(() => {
     worker.resetHandlers();

--- a/test/specs/containers/pages/ContentViewerPageContainer.spec.jsx
+++ b/test/specs/containers/pages/ContentViewerPageContainer.spec.jsx
@@ -22,10 +22,14 @@ const store = mockStore({
 describe('ContentViewerPageContainer', () => {
   const worker = setupWorker();
 
-  before(() => Promise.all([
-    worker.start({ quiet: true }),
-    store.dispatch(configureCSpace()).then(() => store.clearActions()),
-  ]));
+  before(async function setup() {
+    this.timeout(3000);
+
+    await Promise.all([
+      worker.start({ quiet: true }),
+      store.dispatch(configureCSpace()).then(() => store.clearActions()),
+    ]);
+  });
 
   afterEach(() => {
     store.clearActions();

--- a/test/specs/containers/pages/ExportViewerPageContainer.spec.jsx
+++ b/test/specs/containers/pages/ExportViewerPageContainer.spec.jsx
@@ -29,10 +29,14 @@ const store = mockStore({
 describe('ExportViewerPageContainer', () => {
   const worker = setupWorker();
 
-  before(() => Promise.all([
-    worker.start({ quiet: true }),
-    store.dispatch(configureCSpace()).then(() => store.clearActions()),
-  ]));
+  before(async function setup() {
+    this.timeout(3000);
+
+    await Promise.all([
+      worker.start({ quiet: true }),
+      store.dispatch(configureCSpace()).then(() => store.clearActions()),
+    ]);
+  });
 
   afterEach(() => {
     store.clearActions();

--- a/test/specs/containers/pages/ReportViewerPageContainer.spec.jsx
+++ b/test/specs/containers/pages/ReportViewerPageContainer.spec.jsx
@@ -23,10 +23,14 @@ const store = mockStore({
 describe('ReportViewerPageContainer', () => {
   const worker = setupWorker();
 
-  before(() => Promise.all([
-    worker.start({ quiet: true }),
-    store.dispatch(configureCSpace()).then(() => store.clearActions()),
-  ]));
+  before(async function setup() {
+    this.timeout(3000);
+
+    await Promise.all([
+      worker.start({ quiet: true }),
+      store.dispatch(configureCSpace()).then(() => store.clearActions()),
+    ]);
+  });
 
   afterEach(() => {
     store.clearActions();

--- a/test/specs/containers/record/RecordEditorContainer.spec.jsx
+++ b/test/specs/containers/record/RecordEditorContainer.spec.jsx
@@ -130,10 +130,14 @@ describe('RecordEditorContainer', () => {
     store,
   };
 
-  before(() => Promise.all([
-    worker.start({ quiet: true }),
-    store.dispatch(configureCSpace()).then(() => store.clearActions()),
-  ]));
+  before(async function setup() {
+    this.timeout(3000);
+
+    await Promise.all([
+      worker.start({ quiet: true }),
+      store.dispatch(configureCSpace()).then(() => store.clearActions()),
+    ]);
+  });
 
   afterEach(() => {
     store.clearActions();


### PR DESCRIPTION
**What does this do?**

This adds Firefox to the browsers used for testing CI builds. Currently, only Chrome is used. It also increases the timeouts on some tests to reduce flakiness on Firefox, and changes the runner to Mac OS instead of Linux.

**Why are we doing this? (with JIRA link)**

This partially restores the CI functionality we had on TravisCI/SauceLabs, now running on GitHub. Since Firefox is a supported browser, we should ensure that all tests succeed in it. It's more likely that users will be on Mac than Linux, so changing the runner to Mac creates a test environment that is more similar to an actual runtime environment.

https://collectionspace.atlassian.net/browse/DRYD-1223
https://collectionspace.atlassian.net/browse/DRYD-1227

**How should this be tested? Do these changes have associated tests?**

The Check build job in the CI workflow should succeed when this is merged. The log should show that tests ran in both Chrome and Firefox, and that the runner was Mac OS.

**Dependencies for merging? Releasing to production?**

 None.

**Has the application documentation been updated for these changes?**

There is a passing mention of CI builds in the developer documentation, and it is still accurate.

**Did someone actually run this code to verify it works?**

@ray-lee ran a few builds.