### PR TITLE
Remove test timeouts that were set to 3 seconds.

### DIFF
--- a/test/specs/actions/account.spec.js
+++ b/test/specs/actions/account.spec.js
@@ -30,7 +30,7 @@ describe('account action creator', () => {
   const mockStore = configureMockStore([thunk]);
   const worker = setupWorker();
 
-  before(async function setup() {
+  before(async () => {
     await worker.start({ quiet: true });
   });
 

--- a/test/specs/actions/account.spec.js
+++ b/test/specs/actions/account.spec.js
@@ -31,8 +31,6 @@ describe('account action creator', () => {
   const worker = setupWorker();
 
   before(async function setup() {
-    this.timeout(3000);
-
     await worker.start({ quiet: true });
   });
 

--- a/test/specs/actions/authority.spec.js
+++ b/test/specs/actions/authority.spec.js
@@ -24,8 +24,6 @@ describe('authority action creator', () => {
   const worker = setupWorker();
 
   before(async function setup() {
-    this.timeout(3000);
-
     await worker.start({ quiet: true });
   });
 

--- a/test/specs/actions/authority.spec.js
+++ b/test/specs/actions/authority.spec.js
@@ -23,7 +23,7 @@ const mockStore = configureMockStore([thunk]);
 describe('authority action creator', () => {
   const worker = setupWorker();
 
-  before(async function setup() {
+  before(async () => {
     await worker.start({ quiet: true });
   });
 

--- a/test/specs/actions/authz.spec.js
+++ b/test/specs/actions/authz.spec.js
@@ -24,7 +24,7 @@ import {
 describe('authz action creator', () => {
   const worker = setupWorker();
 
-  before(async function setup() {
+  before(async () => {
     await worker.start({ quiet: true });
   });
 

--- a/test/specs/actions/authz.spec.js
+++ b/test/specs/actions/authz.spec.js
@@ -25,8 +25,6 @@ describe('authz action creator', () => {
   const worker = setupWorker();
 
   before(async function setup() {
-    this.timeout(3000);
-
     await worker.start({ quiet: true });
   });
 

--- a/test/specs/actions/batch.spec.js
+++ b/test/specs/actions/batch.spec.js
@@ -55,7 +55,7 @@ const mockStore = configureMockStore([thunk]);
 describe('batch action creator', () => {
   const worker = setupWorker();
 
-  before(async function setup() {
+  before(async () => {
     await worker.start({ quiet: true });
   });
 

--- a/test/specs/actions/batch.spec.js
+++ b/test/specs/actions/batch.spec.js
@@ -56,8 +56,6 @@ describe('batch action creator', () => {
   const worker = setupWorker();
 
   before(async function setup() {
-    this.timeout(3000);
-
     await worker.start({ quiet: true });
   });
 

--- a/test/specs/actions/cspace.spec.js
+++ b/test/specs/actions/cspace.spec.js
@@ -37,8 +37,6 @@ describe('cspace action creator', () => {
   const worker = setupWorker();
 
   before(async function setup() {
-    this.timeout(3000);
-
     await worker.start({ quiet: true });
   });
 

--- a/test/specs/actions/cspace.spec.js
+++ b/test/specs/actions/cspace.spec.js
@@ -36,7 +36,7 @@ const mockStore = configureMockStore([thunk]);
 describe('cspace action creator', () => {
   const worker = setupWorker();
 
-  before(async function setup() {
+  before(async () => {
     await worker.start({ quiet: true });
   });
 

--- a/test/specs/actions/export.spec.js
+++ b/test/specs/actions/export.spec.js
@@ -53,7 +53,7 @@ const mockStore = configureMockStore([thunk]);
 describe('export action creator', () => {
   const worker = setupWorker();
 
-  before(async function setup() {
+  before(async () => {
     await worker.start({ quiet: true });
   });
 

--- a/test/specs/actions/export.spec.js
+++ b/test/specs/actions/export.spec.js
@@ -54,8 +54,6 @@ describe('export action creator', () => {
   const worker = setupWorker();
 
   before(async function setup() {
-    this.timeout(3000);
-
     await worker.start({ quiet: true });
   });
 

--- a/test/specs/actions/idGenerator.spec.js
+++ b/test/specs/actions/idGenerator.spec.js
@@ -36,7 +36,7 @@ chai.should();
 describe('ID generator action creator', () => {
   const worker = setupWorker();
 
-  before(async function setup() {
+  before(async () => {
     await worker.start({ quiet: true });
   });
 

--- a/test/specs/actions/idGenerator.spec.js
+++ b/test/specs/actions/idGenerator.spec.js
@@ -37,8 +37,6 @@ describe('ID generator action creator', () => {
   const worker = setupWorker();
 
   before(async function setup() {
-    this.timeout(3000);
-
     await worker.start({ quiet: true });
   });
 

--- a/test/specs/actions/login.spec.js
+++ b/test/specs/actions/login.spec.js
@@ -44,7 +44,7 @@ chai.should();
 describe('login action creator', () => {
   const worker = setupWorker();
 
-  before(async function setup() {
+  before(async () => {
     await worker.start({ quiet: true });
   });
 

--- a/test/specs/actions/login.spec.js
+++ b/test/specs/actions/login.spec.js
@@ -45,8 +45,6 @@ describe('login action creator', () => {
   const worker = setupWorker();
 
   before(async function setup() {
-    this.timeout(3000);
-
     await worker.start({ quiet: true });
   });
 

--- a/test/specs/actions/logout.spec.js
+++ b/test/specs/actions/logout.spec.js
@@ -29,8 +29,6 @@ describe('logout action creator', () => {
   const worker = setupWorker();
 
   before(async function setup() {
-    this.timeout(3000);
-
     await worker.start({ quiet: true });
   });
 

--- a/test/specs/actions/logout.spec.js
+++ b/test/specs/actions/logout.spec.js
@@ -28,7 +28,7 @@ chai.should();
 describe('logout action creator', () => {
   const worker = setupWorker();
 
-  before(async function setup() {
+  before(async () => {
     await worker.start({ quiet: true });
   });
 

--- a/test/specs/actions/partialTermSearch.spec.js
+++ b/test/specs/actions/partialTermSearch.spec.js
@@ -28,7 +28,7 @@ chai.should();
 describe('partialTermSearch action creator', () => {
   const worker = setupWorker();
 
-  before(async function setup() {
+  before(async () => {
     await worker.start({ quiet: true });
   });
 

--- a/test/specs/actions/partialTermSearch.spec.js
+++ b/test/specs/actions/partialTermSearch.spec.js
@@ -29,8 +29,6 @@ describe('partialTermSearch action creator', () => {
   const worker = setupWorker();
 
   before(async function setup() {
-    this.timeout(3000);
-
     await worker.start({ quiet: true });
   });
 

--- a/test/specs/actions/record.spec.js
+++ b/test/specs/actions/record.spec.js
@@ -98,7 +98,7 @@ chai.should();
 describe('record action creator', () => {
   const worker = setupWorker();
 
-  before(async function setup() {
+  before(async () => {
     await worker.start({ quiet: true });
   });
 

--- a/test/specs/actions/record.spec.js
+++ b/test/specs/actions/record.spec.js
@@ -99,8 +99,6 @@ describe('record action creator', () => {
   const worker = setupWorker();
 
   before(async function setup() {
-    this.timeout(3000);
-
     await worker.start({ quiet: true });
   });
 

--- a/test/specs/actions/relation.spec.js
+++ b/test/specs/actions/relation.spec.js
@@ -64,8 +64,6 @@ describe('relation action creator', () => {
   const worker = setupWorker();
 
   before(async function setup() {
-    this.timeout(3000);
-
     await worker.start({ quiet: true });
   });
 

--- a/test/specs/actions/relation.spec.js
+++ b/test/specs/actions/relation.spec.js
@@ -63,7 +63,7 @@ const config = {
 describe('relation action creator', () => {
   const worker = setupWorker();
 
-  before(async function setup() {
+  before(async () => {
     await worker.start({ quiet: true });
   });
 

--- a/test/specs/actions/report.spec.js
+++ b/test/specs/actions/report.spec.js
@@ -57,7 +57,7 @@ const mockStore = configureMockStore([thunk]);
 describe('report action creator', () => {
   const worker = setupWorker();
 
-  before(async function setup() {
+  before(async () => {
     await worker.start({ quiet: true });
   });
 

--- a/test/specs/actions/report.spec.js
+++ b/test/specs/actions/report.spec.js
@@ -58,8 +58,6 @@ describe('report action creator', () => {
   const worker = setupWorker();
 
   before(async function setup() {
-    this.timeout(3000);
-
     await worker.start({ quiet: true });
   });
 

--- a/test/specs/actions/search.spec.js
+++ b/test/specs/actions/search.spec.js
@@ -50,7 +50,7 @@ const mockStore = configureMockStore([thunk]);
 describe('search action creator', () => {
   const worker = setupWorker();
 
-  before(async function setup() {
+  before(async () => {
     await worker.start({ quiet: true });
   });
 

--- a/test/specs/actions/search.spec.js
+++ b/test/specs/actions/search.spec.js
@@ -51,8 +51,6 @@ describe('search action creator', () => {
   const worker = setupWorker();
 
   before(async function setup() {
-    this.timeout(3000);
-
     await worker.start({ quiet: true });
   });
 

--- a/test/specs/actions/structuredDate.spec.js
+++ b/test/specs/actions/structuredDate.spec.js
@@ -19,8 +19,6 @@ describe('structured date action creator', () => {
   const worker = setupWorker();
 
   before(async function setup() {
-    this.timeout(3000);
-
     await worker.start({ quiet: true });
   });
 

--- a/test/specs/actions/structuredDate.spec.js
+++ b/test/specs/actions/structuredDate.spec.js
@@ -18,7 +18,7 @@ chai.should();
 describe('structured date action creator', () => {
   const worker = setupWorker();
 
-  before(async function setup() {
+  before(async () => {
     await worker.start({ quiet: true });
   });
 

--- a/test/specs/actions/vocabulary.spec.js
+++ b/test/specs/actions/vocabulary.spec.js
@@ -26,7 +26,7 @@ chai.should();
 describe('vocabulary action creator', () => {
   const worker = setupWorker();
 
-  before(async function setup() {
+  before(async () => {
     await worker.start({ quiet: true });
   });
 

--- a/test/specs/actions/vocabulary.spec.js
+++ b/test/specs/actions/vocabulary.spec.js
@@ -27,8 +27,6 @@ describe('vocabulary action creator', () => {
   const worker = setupWorker();
 
   before(async function setup() {
-    this.timeout(3000);
-
     await worker.start({ quiet: true });
   });
 

--- a/test/specs/components/notification/Notification.spec.jsx
+++ b/test/specs/components/notification/Notification.spec.jsx
@@ -61,8 +61,6 @@ describe('Notification', () => {
   });
 
   it('should call close automatically after the autoCloseTime timeout when autoClose is true', function test() {
-    this.timeout(3000);
-
     let closedID = null;
 
     const close = (id) => {

--- a/test/specs/components/record/RecordBrowser.spec.jsx
+++ b/test/specs/components/record/RecordBrowser.spec.jsx
@@ -93,8 +93,6 @@ describe('RecordBrowser', () => {
   const worker = setupWorker();
 
   before(async function setup() {
-    this.timeout(3000);
-
     await Promise.all([
       worker.start({ quiet: true }),
       store.dispatch(configureCSpace()).then(() => store.clearActions()),

--- a/test/specs/components/record/RecordBrowser.spec.jsx
+++ b/test/specs/components/record/RecordBrowser.spec.jsx
@@ -92,7 +92,7 @@ const config = {
 describe('RecordBrowser', () => {
   const worker = setupWorker();
 
-  before(async function setup() {
+  before(async () => {
     await Promise.all([
       worker.start({ quiet: true }),
       store.dispatch(configureCSpace()).then(() => store.clearActions()),

--- a/test/specs/components/record/RelatedRecordBrowser.spec.jsx
+++ b/test/specs/components/record/RelatedRecordBrowser.spec.jsx
@@ -134,8 +134,6 @@ describe('RelatedRecordBrowser', () => {
   const worker = setupWorker();
 
   before(async function setup() {
-    this.timeout(3000);
-
     await Promise.all([
       worker.start({ quiet: true }),
       store.dispatch(configureCSpace()).then(() => store.clearActions()),

--- a/test/specs/components/record/RelatedRecordBrowser.spec.jsx
+++ b/test/specs/components/record/RelatedRecordBrowser.spec.jsx
@@ -133,7 +133,7 @@ const config = {
 describe('RelatedRecordBrowser', () => {
   const worker = setupWorker();
 
-  before(async function setup() {
+  before(async () => {
     await Promise.all([
       worker.start({ quiet: true }),
       store.dispatch(configureCSpace()).then(() => store.clearActions()),

--- a/test/specs/containers/invocable/InvocationModalContainer.spec.jsx
+++ b/test/specs/containers/invocable/InvocationModalContainer.spec.jsx
@@ -48,8 +48,6 @@ describe('InvocationModalContainer', () => {
   const worker = setupWorker();
 
   before(async function setup() {
-    this.timeout(3000);
-
     await Promise.all([
       worker.start({ quiet: true }),
       store.dispatch(configureCSpace()).then(() => store.clearActions()),

--- a/test/specs/containers/invocable/InvocationModalContainer.spec.jsx
+++ b/test/specs/containers/invocable/InvocationModalContainer.spec.jsx
@@ -47,7 +47,7 @@ const config = {
 describe('InvocationModalContainer', () => {
   const worker = setupWorker();
 
-  before(async function setup() {
+  before(async () => {
     await Promise.all([
       worker.start({ quiet: true }),
       store.dispatch(configureCSpace()).then(() => store.clearActions()),

--- a/test/specs/containers/pages/ContentViewerPageContainer.spec.jsx
+++ b/test/specs/containers/pages/ContentViewerPageContainer.spec.jsx
@@ -24,8 +24,6 @@ describe('ContentViewerPageContainer', () => {
   const worker = setupWorker();
 
   before(async function setup() {
-    this.timeout(3000);
-
     await Promise.all([
       worker.start({ quiet: true }),
       store.dispatch(configureCSpace()).then(() => store.clearActions()),

--- a/test/specs/containers/pages/ContentViewerPageContainer.spec.jsx
+++ b/test/specs/containers/pages/ContentViewerPageContainer.spec.jsx
@@ -23,7 +23,7 @@ const store = mockStore({
 describe('ContentViewerPageContainer', () => {
   const worker = setupWorker();
 
-  before(async function setup() {
+  before(async () => {
     await Promise.all([
       worker.start({ quiet: true }),
       store.dispatch(configureCSpace()).then(() => store.clearActions()),

--- a/test/specs/containers/pages/ExportViewerPageContainer.spec.jsx
+++ b/test/specs/containers/pages/ExportViewerPageContainer.spec.jsx
@@ -29,7 +29,7 @@ const store = mockStore({
 describe('ExportViewerPageContainer', () => {
   const worker = setupWorker();
 
-  before(async function setup() {
+  before(async () => {
     await Promise.all([
       worker.start({ quiet: true }),
       store.dispatch(configureCSpace()).then(() => store.clearActions()),

--- a/test/specs/containers/pages/ExportViewerPageContainer.spec.jsx
+++ b/test/specs/containers/pages/ExportViewerPageContainer.spec.jsx
@@ -30,8 +30,6 @@ describe('ExportViewerPageContainer', () => {
   const worker = setupWorker();
 
   before(async function setup() {
-    this.timeout(3000);
-
     await Promise.all([
       worker.start({ quiet: true }),
       store.dispatch(configureCSpace()).then(() => store.clearActions()),

--- a/test/specs/containers/pages/ReportViewerPageContainer.spec.jsx
+++ b/test/specs/containers/pages/ReportViewerPageContainer.spec.jsx
@@ -24,8 +24,6 @@ describe('ReportViewerPageContainer', () => {
   const worker = setupWorker();
 
   before(async function setup() {
-    this.timeout(3000);
-
     await Promise.all([
       worker.start({ quiet: true }),
       store.dispatch(configureCSpace()).then(() => store.clearActions()),

--- a/test/specs/containers/pages/ReportViewerPageContainer.spec.jsx
+++ b/test/specs/containers/pages/ReportViewerPageContainer.spec.jsx
@@ -23,7 +23,7 @@ const store = mockStore({
 describe('ReportViewerPageContainer', () => {
   const worker = setupWorker();
 
-  before(async function setup() {
+  before(async () => {
     await Promise.all([
       worker.start({ quiet: true }),
       store.dispatch(configureCSpace()).then(() => store.clearActions()),

--- a/test/specs/containers/record/RecordEditorContainer.spec.jsx
+++ b/test/specs/containers/record/RecordEditorContainer.spec.jsx
@@ -128,8 +128,6 @@ describe('RecordEditorContainer', () => {
   });
 
   before(async function setup() {
-    this.timeout(3000);
-
     await Promise.all([
       worker.start({ quiet: true }),
       store.dispatch(configureCSpace()).then(() => store.clearActions()),

--- a/test/specs/containers/record/RecordEditorContainer.spec.jsx
+++ b/test/specs/containers/record/RecordEditorContainer.spec.jsx
@@ -127,7 +127,7 @@ describe('RecordEditorContainer', () => {
     user: Immutable.Map(),
   });
 
-  before(async function setup() {
+  before(async () => {
     await Promise.all([
       worker.start({ quiet: true }),
       store.dispatch(configureCSpace()).then(() => store.clearActions()),


### PR DESCRIPTION
**What does this do?**

This removes calls to `this.setTimeout` in tests (mostly in `before` hooks), that were setting the timeout to 3 seconds. These aren't needed, because we globally set the timeout to 4 seconds in karma.conf.js: https://github.com/collectionspace/cspace-ui.js/blob/2fa50d52ec55293669c3d0de7091b204f28fb8fb/karma.conf.js#L56-L60

**Why are we doing this? (with JIRA link)**

This helps the tests to be less flaky in Firefox. Setting up the http server stub in the `before` hooks sometimes takes a long time on Firefox, and occasionally can exceed the 3 second timeout. This allows the 4 second global setting to take effect, which will hopefully be enough to prevent timeout failures.

JIRA: https://collectionspace.atlassian.net/browse/DRYD-1223

**How should this be tested? Do these changes have associated tests?**

The CI tests for this PR should succeed.

**Dependencies for merging? Releasing to production?**

None

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran tests locally in Chrome and Firefox, and verified that the tests also pass in CI.