### PR TITLE
DRYD-1133: Add controlled chronology fields to collectionobject

### DIFF
--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -2257,6 +2257,30 @@ export default (configContext) => {
             ...extensions.structuredDate.fields,
           },
         },
+        objectProductionEras: {
+          [config]: {
+            view: {
+              type: CompoundInput,
+            },
+          },
+          objectProductionEra: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.collectionobjects_common.objectProductionEra.name',
+                  defaultMessage: 'Production era',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: AutocompleteInput,
+                props: {
+                  source: 'chronology/era',
+                },
+              },
+            },
+          },
+        },
         techniqueGroupList: {
           [config]: {
             view: {
@@ -3228,6 +3252,43 @@ export default (configContext) => {
               },
               name: {
                 id: 'field.collectionobjects_common.assocEventNameType.name',
+                defaultMessage: 'Type',
+              },
+            }),
+            view: {
+              type: TextInput,
+            },
+          },
+        },
+        assocControlledEventName: {
+          [config]: {
+            messages: defineMessages({
+              fullName: {
+                id: 'field.collectionobjects_common.assocControlledEventName.fullName',
+                defaultMessage: 'Associated controlled event',
+              },
+              name: {
+                id: 'field.collectionobjects_common.assocControlledEventName.name',
+                defaultMessage: 'Event',
+              },
+            }),
+            view: {
+              type: AutocompleteInput,
+              props: {
+                source: 'chronology/event',
+              },
+            },
+          },
+        },
+        assocControlledEventNameType: {
+          [config]: {
+            messages: defineMessages({
+              fullName: {
+                id: 'field.collectionobjects_common.assocControlledEventNameType.fullName',
+                defaultMessage: 'Associated controlled event type',
+              },
+              name: {
+                id: 'field.collectionobjects_common.assocControlledEventNameType.name',
                 defaultMessage: 'Type',
               },
             }),

--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -3260,15 +3260,15 @@ export default (configContext) => {
             },
           },
         },
-        assocControlledEventName: {
+        assocEvent: {
           [config]: {
             messages: defineMessages({
               fullName: {
-                id: 'field.collectionobjects_common.assocControlledEventName.fullName',
+                id: 'field.collectionobjects_common.assocEvent.fullName',
                 defaultMessage: 'Associated controlled event',
               },
               name: {
-                id: 'field.collectionobjects_common.assocControlledEventName.name',
+                id: 'field.collectionobjects_common.assocEvent.name',
                 defaultMessage: 'Event',
               },
             }),
@@ -3280,15 +3280,15 @@ export default (configContext) => {
             },
           },
         },
-        assocControlledEventNameType: {
+        assocEventType: {
           [config]: {
             messages: defineMessages({
               fullName: {
-                id: 'field.collectionobjects_common.assocControlledEventNameType.fullName',
+                id: 'field.collectionobjects_common.assocEventType.fullName',
                 defaultMessage: 'Associated controlled event type',
               },
               name: {
-                id: 'field.collectionobjects_common.assocControlledEventNameType.name',
+                id: 'field.collectionobjects_common.assocEventType.name',
                 defaultMessage: 'Type',
               },
             }),

--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -328,6 +328,10 @@ const template = (configContext) => {
               <Field name="objectProductionDateGroup" />
             </Field>
 
+            <Field name="objectProductionEras">
+              <Field name="objectProductionEra" />
+            </Field>
+
             <Field name="techniqueGroupList">
               <Field name="techniqueGroup">
                 <Field name="technique" />
@@ -447,6 +451,11 @@ const template = (configContext) => {
               <InputTable name="assocEvent">
                 <Field name="assocEventName" />
                 <Field name="assocEventNameType" />
+              </InputTable>
+
+              <InputTable name="assocControlledEvent">
+                <Field name="assocControlledEventName" />
+                <Field name="assocControlledEventNameType" />
               </InputTable>
 
               <Field name="assocEventOrganizations">

--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -454,8 +454,8 @@ const template = (configContext) => {
               </InputTable>
 
               <InputTable name="assocControlledEvent">
-                <Field name="assocControlledEventName" />
-                <Field name="assocControlledEventNameType" />
+                <Field name="assocEvent" />
+                <Field name="assocEventType" />
               </InputTable>
 
               <Field name="assocEventOrganizations">

--- a/src/plugins/recordTypes/collectionobject/messages.js
+++ b/src/plugins/recordTypes/collectionobject/messages.js
@@ -92,6 +92,10 @@ export default {
       id: 'inputTable.collectionobject.assocEvent',
       defaultMessage: 'Associated event',
     },
+    assocControlledEvent: {
+      id: 'inputTable.collectionobject.assocControlledEvent',
+      defaultMessage: 'Associated controlled event',
+    },
     ownershipExchange: {
       id: 'inputTable.collectionobject.ownershipExchange',
       defaultMessage: 'Ownership exchange',


### PR DESCRIPTION
**What does this do?**
Adds chronology fields to collectionobject

**Why are we doing this? (with JIRA link)**
The fields are defined in the spec for [DRYD-1133](https://collectionspace.atlassian.net/jira/software/c/projects/DRYD/issues/DRYD-1133).

**How should this be tested? Do these changes have associated tests?**
* Build collectionspace
* Using the adjacent PR from cspace-ui, try to create and save a collectionobject with new fields:
  * objectProductionEra
  * assocControlledEventName
  * assocControlledEventType

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested that the 3 fields listed save and load