### PR TITLE
DRYD-1217: Archaeological site

### DIFF
--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -3881,7 +3881,7 @@ export default (configContext) => {
             [config]: {
               messages: defineMessages({
                 name: {
-                  id: 'field.procedure.fieldCollectionSite.name',
+                  id: 'field.collectionobjects_common.fieldCollectionSite.name',
                   defaultMessage: 'Field collection site',
                 },
               }),

--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -3871,6 +3871,30 @@ export default (configContext) => {
             },
           },
         },
+        fieldCollectionSites: {
+          [config]: {
+            view: {
+              type: CompoundInput,
+            },
+          },
+          fieldCollectionSite: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.procedure.fieldCollectionSite.name',
+                  defaultMessage: 'Field collection site',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: AutocompleteInput,
+                props: {
+                  source: 'place/archaeological',
+                },
+              },
+            },
+          },
+        },
         fieldCollectionDateGroup: {
           [config]: {
             dataType: DATA_TYPE_STRUCTURED_DATE,

--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -551,6 +551,10 @@ const template = (configContext) => {
       <Panel name="collect" collapsible collapsed>
         <Row>
           <Col>
+            <Field name="fieldCollectionSites">
+              <Field name="fieldCollectionSite" />
+            </Field>
+
             <Field name="fieldCollectionDateGroup" />
 
             <Field name="fieldCollectionMethods">

--- a/src/plugins/recordTypes/place/vocabularies.js
+++ b/src/plugins/recordTypes/place/vocabularies.js
@@ -78,7 +78,7 @@ export default {
       },
       collectionName: {
         id: 'vocab.place.archaeological.collectionName',
-        description: 'The name of a collection of records the vocabulary',
+        description: 'The name of a collection of records from the vocabulary',
         defaultMessage: 'Archaeological Sites',
       },
       itemName: {

--- a/src/plugins/recordTypes/place/vocabularies.js
+++ b/src/plugins/recordTypes/place/vocabularies.js
@@ -69,4 +69,26 @@ export default {
       servicePath: 'urn:cspace:name(tgn_place)',
     },
   },
+  archaeological: {
+    messages: defineMessages({
+      name: {
+        id: 'vocab.place.archaeological.name',
+        description: 'The name of the vocabulary',
+        defaultMessage: 'Archaeological',
+      },
+      collectionName: {
+        id: 'vocab.place.archaeological.collectionName',
+        description: 'The name of a collection of records the vocabulary',
+        defaultMessage: 'Archaeological Sites',
+      },
+      itemName: {
+        id: 'vocab.place.archaeological.itemName',
+        description: 'The name of a record from the vocabulary',
+        defaultMessage: 'Archaeological Site',
+      },
+    }),
+    serviceConfig: {
+      servicePath: 'urn:cspace:name(archaeological)',
+    },
+  },
 };


### PR DESCRIPTION
**What does this do?**
* Add archaeological site to place authority
* Add fieldCollectionSites to collectionobjects

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1217

**How should this be tested? Do these changes have associated tests?**
* Create a place authority of type archaeological site
* Create a new collectionobject with a fieldCollectionEvent
* Reload the collectionobject and ensure that the fieldCollectionEvent persisted

**Dependencies for merging? Releasing to production?**
This doesn't contain the associated authorities, which will be added at a later date

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested that the new authority and collectionobject field can be created