### PR TITLE
DRYD-1081: Add top-level disableAltTerms setting.

### DIFF
--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -142,6 +142,12 @@ defaultSearchPanelSize: number = 5
 ```
 The default page size for search results presented in a panel, for example, in a sidebar.
 
+### disableAltTerms
+```
+disableAltTerms: boolean = false
+```
+If true, alternate terms (aka non-preferred terms) are disabled (but remain visible) in autocompletion inputs when they match the partial term that the user has entered. The user may only select the preferred term. This setting can be overridden on a per-vocabulary basis in the [vocabulary configuration](./VocabularyConfiguration.md#disableAltTerms).
+
 ### idGeneratorTransform
 ```
 idGeneratorTransform: (string) => string = undefined

--- a/docs/configuration/VocabularyConfiguration.md
+++ b/docs/configuration/VocabularyConfiguration.md
@@ -77,7 +77,7 @@ If true, the vocabulary is not shown in the UI.
 ```
 disableAltTerms: boolean
 ```
-If true, alternate terms (aka non-preferred terms) are disabled (but remain visible when they match the partial term that the user has entered). The user may only select the preferred term.
+If true, alternate terms (aka non-preferred terms) are disabled (but remain visible) in autocompletion inputs when they match the partial term that the user has entered. The user may only select the preferred term. This setting applies only to this vocabulary, and overrides the [top-level `disableAltTerms`](./README.md#disableAltTerms) setting. If it is not defined, the top-level setting takes effect.
 
 ### messages
 ```

--- a/src/helpers/configHelpers.js
+++ b/src/helpers/configHelpers.js
@@ -144,6 +144,8 @@ export const initializeRecordTypes = (config) => {
  * argument configuration.
  *
  * - Delete any record type or vocabulary that is disabled
+ * - Set the disableAltTerms property of each vocabulary to the top-level disableAltTerms property
+ *   if it is undefined
  */
 export const finalizeRecordTypes = (config) => {
   const { recordTypes } = config;
@@ -163,6 +165,8 @@ export const finalizeRecordTypes = (config) => {
 
             if (vocabulary.disabled) {
               delete vocabularies[vocabularyName];
+            } else if (typeof vocabulary.disableAltTerms === 'undefined') {
+              vocabulary.disableAltTerms = config.disableAltTerms;
             }
           });
         }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -42,6 +42,7 @@ const defaultConfig = mergeConfig({
       },
     },
   },
+  disableAltTerms: false,
   index: '/search',
   locale: 'en-US',
   logo: logoUrl,

--- a/test/specs/helpers/configHelpers.spec.jsx
+++ b/test/specs/helpers/configHelpers.spec.jsx
@@ -599,7 +599,9 @@ describe('configHelpers', () => {
           },
           person: {
             vocabularies: {
-              local: {},
+              local: {
+                disableAltTerms: false,
+              },
               ulan: {
                 disabled: true,
               },
@@ -612,7 +614,54 @@ describe('configHelpers', () => {
         recordTypes: {
           person: {
             vocabularies: {
-              local: {},
+              local: {
+                disableAltTerms: false,
+              },
+            },
+          },
+        },
+      });
+    });
+
+    it('should inherit disableAltTerms in vocabularies from the top-level disableAltTerms setting when it is undefined', () => {
+      const config = {
+        disableAltTerms: true,
+        recordTypes: {
+          person: {
+            vocabularies: {
+              local: {
+                disableAltTerms: false,
+              },
+              ulan: {
+              },
+              shared: {
+                disableAltTerms: undefined,
+              },
+              another: {
+                disableAltTerms: true,
+              },
+            },
+          },
+        },
+      };
+
+      finalizeRecordTypes(config).should.deep.equal({
+        disableAltTerms: true,
+        recordTypes: {
+          person: {
+            vocabularies: {
+              local: {
+                disableAltTerms: false,
+              },
+              ulan: {
+                disableAltTerms: true,
+              },
+              shared: {
+                disableAltTerms: true,
+              },
+              another: {
+                disableAltTerms: true,
+              },
             },
           },
         },


### PR DESCRIPTION
**What does this do?**

This adds a top-level `disableAltTerms` setting to the UI config (default false). This setting has the same effect as the `disableAltTerms` setting in the config for a vocabulary, but it applies to all vocabularies. The `disableAltTerms` setting in a vocabulary remains. If it is set, it overrides the top-level setting, for that vocabulary.

**Why are we doing this? (with JIRA link)**

This makes it easy to make alternate terms unselectable globally, without having to add configuration to every vocabulary.

JIRA: https://collectionspace.atlassian.net/browse/DRYD-1081

**How should this be tested? Do these changes have associated tests?**

- In the index.html for a tenant, add the configuration setting `disableAltTerms: true`.
- Create a Person record with a Display Name and an alternate Display Name.
- Edit a record that contains a field tied to the Person authority. Start to enter the name of the person.
The person should be displayed in the autocomplete dropdown. The primary display name should be selectable. The alternate display name should appear, but should be disabled, and not selectable.

Unit tests are included.

**Dependencies for merging? Releasing to production?**

None

**Has the application documentation been updated for these changes?**

The developer docs are updated in this PR.

**Did someone actually run this code to verify it works?**

@ray-lee tested locally.