### PR TITLE
DRYD-1236: Fix miniview popup not appearing after autocomplete value changes.

### DIFF
--- a/src/components/record/MiniViewPopupAutocompleteInput.jsx
+++ b/src/components/record/MiniViewPopupAutocompleteInput.jsx
@@ -78,9 +78,9 @@ export class BaseMiniViewPopupAutocompleteInput extends Component {
   handleDropdownClose() {
     this.close();
 
-    this.state = {
+    this.setState({
       isFiltering: false,
-    };
+    });
   }
 
   handleDropdownOpen() {


### PR DESCRIPTION
**What does this do?**

This fixes a bug in the `MiniViewPopupAutocompleteInput` component that was updating the component state by assigning to `this.state` directly, instead of calling `setState`. This was always an incorrect usage of the React API, but it didn't cause any visible problems until we upgraded to React 16.

**Why are we doing this? (with JIRA link)**

The incorrect state caused the popup not to open after the value in the autocomplete input was changed.

JIRA: https://collectionspace.atlassian.net/browse/DRYD-1236

**How should this be tested? Do these changes have associated tests?**

- Create a new Group.
- Enter a value in the Group Owner field (either select an existing term, or create a new one).
- Hover the mouse pointer over the field.

A pop-up should appear, showing information about the term.

**Dependencies for merging? Releasing to production?**

None.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran this locally.
