### PR TITLE
DRYD-1213,DRYD-1214: Add description level and apparel size fields

### DIFF
--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -6148,6 +6148,30 @@ export default (configContext) => {
             },
           },
         },
+        apparelSizes: {
+          [config]: {
+            view: {
+              type: CompoundInput,
+            },
+          },
+          apparelSize: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.collectionobjects_common.apparelSize.name',
+                  defaultMessage: 'Apparel size',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: TermPickerInput,
+                props: {
+                  source: 'apparelsizes',
+                },
+              },
+            },
+          },
+        },
       },
     },
   };

--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -6172,6 +6172,22 @@ export default (configContext) => {
             },
           },
         },
+        descriptionLevel: {
+          [config]: {
+            messages: defineMessages({
+              name: {
+                id: 'field.collectionobjects_common.descriptionLevel.name',
+                defaultMessage: 'Description level',
+              },
+            }),
+            view: {
+              type: TermPickerInput,
+              props: {
+                source: 'descriptionlevel',
+              },
+            },
+          },
+        },
       },
     },
   };

--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -156,6 +156,10 @@ const template = (configContext) => {
             <Field name="colors">
               <Field name="color" />
             </Field>
+
+            <Field name="apparelSizes">
+              <Field name="apparelSize" />
+            </Field>
           </Col>
         </Row>
 

--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -50,6 +50,7 @@ const template = (configContext) => {
               </Col>
             </Row>
 
+            <Field name="descriptionLevel" />
             <Field name="recordStatus" />
 
             <Field name="publishToList">


### PR DESCRIPTION
**What does this do?**
* Adds apparel size and descriptionLevel fields to collectionobject
* Adds apparel size and descriptionLevel to default collectionobject form

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1214

This is a field which existed in the OHC profile was was requested to be brought into core

**How should this be tested? Do these changes have associated tests?**
* Rebuild and run collectionspace
* Run the devserver
* Create a collectionobject with an apparel size(s)
* Reload the collectionobject to ensure the save completed successfully

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter built and tested the new field saves