### PR TITLE
Improve login error handling.

### DIFF
--- a/src/components/login/LoginForm.jsx
+++ b/src/components/login/LoginForm.jsx
@@ -43,6 +43,11 @@ const messages = defineMessages({
     description: 'Generic login error message. Displayed when a more specific error message is not available.',
     defaultMessage: 'Sign in failed.',
   },
+  ERR_BAD_REQUEST: {
+    id: 'loginForm.ERR_BAD_REQUEST',
+    description: 'Error message displayed when a bad request response was received during login.',
+    defaultMessage: 'Sign in failed. The CollectionSpace server received a bad request.',
+  },
   ERR_INVALID_CREDENTIALS: {
     id: 'loginForm.ERR_INVALID_CREDENTIALS',
     description: 'Error message displayed when incorrect credentials were entered during login.',
@@ -331,7 +336,7 @@ class LoginForm extends Component {
       <Notification
         id="loginForm.error"
         items={[{
-          message: messages[messageKey],
+          message: messages[messageKey] || messages.error,
         }]}
         showCloseButton={false}
         status="error"


### PR DESCRIPTION
**What does this do?**

This makes a few improvements to the handling of errors during login:

- When a specific error message is not found for an error code, fall back to a generic error message. This prevents react-intl from displaying a confusing/unhelpful message ("An id must be provided to format a message").
- Add an error message for the ERR_BAD_REQUEST error code.
- When retrieving vocabularies for authorities as part of login, ignore any 404 Not Found responses. This likely means the authority doesn't exist for the tenant, but is still configured and enabled in the UI config. This is generally fine, and shouldn't fail the login.

**Why are we doing this? (with JIRA link)**

I ran into the aforementioned unhelpful react-intl error during login when running master against an older services layer. This was caused by the new chronology authority not existing on that server. This addresses all the issues that caused that unhelpful error to occur, so that the latest UI code can be run with an older services layer. 

**How should this be tested? Do these changes have associated tests?**

Run the UI with a 7.1 or older services layer. Attempt to log in. The log in should succeed. On the Create New page, the Chronology authority should not appear.

**Dependencies for merging? Releasing to production?**

None.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran this against a 7.1 services layer.