### PR TITLE
DRYD-1226: Add proxy feature to devserver.

### DIFF
--- a/docs/developer/BuildScripts.md
+++ b/docs/developer/BuildScripts.md
@@ -53,10 +53,14 @@ The `coverage` script generates test coverage reports from the raw coverage data
 ### devserver
 
 ```
-npm run devserver
+npm run devserver [--back-end=<url> [--local-index=<path>]]
 ```
 
-The `devserver` script starts a local development web server, listening at port 8080. The cspace-ui application may be accessed in a browser by opening the URL http://localhost:8080. As source code files are edited, changes are automatically detected and deployed into the dev server. The browser automatically reloads the page, so the latest changes are always visible. The page served by the dev server is the top-level [index.html](../../index.html) file.
+The `devserver` script starts a local development web server, listening at port 8080. The cspace-ui application may be accessed in a browser by opening the URL http://localhost:8080. As source code files are edited, changes are automatically detected and deployed into the dev server. The browser automatically reloads the page, so the latest changes are always visible.
+
+If the `back-end` option is supplied, the dev server acts as a proxy to the specified URL. This allows the locally running UI to connect to a remote CollectionSpace server regardless of CORS settings on that server. When the index.html file is retrieved from the server, the proxy attempts to rewrite it to inject the local UI that is under development. If this fails, or other changes are needed to the index.html file retrieved from the server, a local index file can be substituted by supplying the `local-index` option, specifying a path to a local HTML file.
+
+If the `back-end` option is not supplied, the page served by the dev server is the top-level [index.html](../../index.html) file.
 
 To stop the dev server, type control-c in the shell in which it was started.
 

--- a/docs/developer/GettingStarted.md
+++ b/docs/developer/GettingStarted.md
@@ -41,9 +41,11 @@ If the tests succeed, the environment is ready.
 
 To run the cspace-ui application, use the command:
 ```
-npm run devserver
+npm run devserver [--back-end=<url>]
 ```
-This starts a local web server, listening on port 8080. In a web browser, open the URL `http://localhost:8080`. The CollectionSpace UI should appear. This UI is configured to connect to the REST API on a local collectionspace server running at http://localhost:8180. To change this, edit the index.html file, and set the `serverUrl` property to your desired server. Note that the server must be configured to allow CORS requests from `http://localhost:8080`.
+This starts a local web server, listening on port 8080. In a web browser, open the URL `http://localhost:8080`. The CollectionSpace UI should appear. This UI will connect to the REST API at the specified back-end URL, and will use the UI configuration (the index.html page) retrieved from that server.
+
+If the `back-end` option is not supplied, the local index.html file will be loaded, and the UI configuration can be changed by editing that file. By default, the UI will connect to the REST API at http://localhost:8180, but this can be changed by setting the `serverUrl` property to your desired server in index.html. Note that in this case, the server must be configured to allow CORS requests from `http://localhost:8080`. Using the `back-end` option avoids the need to change CORS settings on the server.
 
 As source code files are edited, changes are automatically detected and deployed into the dev server, and the browser is automatically notified to reload the page. The latest code should always be running in the browser without any intervention.
 

--- a/index.html
+++ b/index.html
@@ -11,9 +11,10 @@
   <meta charset="UTF-8">
   <!--
     webpack dev server generates a JS bundle into memory, and updates it as files are edited.
-    This bundle is served from the URL /cspaceUI.js, but it does not exist in the filesystem.
+    This bundle is served from the URL /webpack-dev-assets/cspaceUI.js, but it does not exist in
+    the filesystem.
   -->
-  <script src="/cspaceUI.js"></script>
+  <script src="/webpack-dev-assets/cspaceUI.js"></script>
 </head>
 <body>
   <div id="cspace"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "eslint-plugin-react-hooks": "^1.7.0",
         "file-loader": "^6.2.0",
         "glob": "^7.1.2",
+        "http-proxy-middleware": "^2.0.6",
         "istanbul": "^0.4.5",
         "jsonfile": "^4.0.0",
         "karma": "^6.4.1",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "eslint-plugin-react-hooks": "^1.7.0",
     "file-loader": "^6.2.0",
     "glob": "^7.1.2",
+    "http-proxy-middleware": "^2.0.6",
     "istanbul": "^0.4.5",
     "jsonfile": "^4.0.0",
     "karma": "^6.4.1",

--- a/webpackDevServerConfig.js
+++ b/webpackDevServerConfig.js
@@ -1,0 +1,324 @@
+/* eslint import/no-extraneous-dependencies: "off" */
+/* eslint-disable no-console */
+
+const fs = require('fs');
+
+const {
+  createProxyMiddleware,
+  responseInterceptor,
+} = require('http-proxy-middleware');
+
+/**
+ * Generates a regular expression that matches a script URL for a given library.
+ *
+ * @param library The name of the library.
+ * @returns A regular expression that detects if the library is used on an HTML page.
+ */
+const scriptUrlPattern = (library) =>
+  new RegExp(`src=".*?/${library}(@.*?)\\.js"`, 'g');
+
+/**
+ * Determines if an HTML page uses a given library.
+ *
+ * @param page The HTML content of the page.
+ * @param library The name of the library.
+ * @returns true if the page uses the library; false otherwise.
+ */
+const pageUsesLibrary = (page, library) =>
+  scriptUrlPattern(library).test(page);
+
+/**
+ * Determines if a given library is a CSpace UI plugin that can be injected into an HTML page.
+ *
+ * @param page The HTML content of the page.
+ * @param library The name of the library.
+ * @returns true if the library is a plugin that can be injected; false otherwise.
+ */
+const canInjectLibraryAsPlugin = (page, library) => (
+  library.startsWith('cspaceUIPlugin')
+  && page.includes('cspaceUI({')
+);
+
+/**
+ * Verifies that a given target URL can be used as a back-end for a given library under
+ * development. If not, print a message and exit.
+ *
+ * A URL can be used as a back end if:
+ * - It is a valid URL.
+ * - It is reachable.
+ * - It returns HTML content that we know how to inject the library into, i.e. it has a
+ *   conventional CSpace UI index.html page.
+ *
+ * @param proxyTarget The URL to verify.
+ * @param library The name of the library.
+ */
+const verifyTarget = async (proxyTarget, library) => {
+  try {
+    new URL(proxyTarget);
+  } catch (error) {
+    console.error(`The back-end URL ${proxyTarget} is not a valid URL.`);
+    process.exit(1);
+  }
+
+  let response;
+
+  try {
+    response = await fetch(proxyTarget);
+  } catch (error) {
+    response = null;
+  }
+
+  if (!(response && response.ok)) {
+    console.error(`The back-end URL ${proxyTarget} is not reachable.`);
+    process.exit(1);
+  }
+
+  const page = await response.text();
+
+  if (
+    !pageUsesLibrary(page, library) &&
+    !canInjectLibraryAsPlugin(page, library)
+  ) {
+    console.error(`The back-end URL ${proxyTarget} is not a CollectionSpace server, or is one that currently is not usable as a devserver back-end.`);
+    process.exit(1);
+  }
+};
+
+/**
+ * Inject an element containing a status message into a CSpace HTML page.
+ *
+ * @param page The HTML content of the page.
+ * @param status The status message.
+ * @returns The HTML content of the page with the status message injected.
+ */
+const injectStatusElement = (page, status) => {
+  return page.replace(
+    '</body>',
+    `
+    <script>
+      addEventListener('load', () => {
+        const statusElement = document.createElement('div');
+
+        statusElement.style.backgroundColor = 'gold';
+        statusElement.style.fontFamily = 'monospace';
+        statusElement.style.textAlign = 'center';
+        statusElement.style.margin = '-10px -10px 10px -10px';
+        statusElement.style.padding = '10px';
+        statusElement.style.borderBottom = '1px solid #333';
+
+        statusElement.innerHTML = ${JSON.stringify(status)};
+
+        document.body.prepend(statusElement);
+      })
+    </script>
+    </body>
+    `,
+  )
+};
+
+/**
+ * Generates a webpack dev server configuration object.
+ */
+module.exports = async ({
+  library,
+  localIndex,
+  proxyTarget,
+  publicPath,
+}) => {
+  if (process.env.npm_lifecycle_event !== 'devserver') {
+    return undefined;
+  }
+
+  if (!proxyTarget) {
+    console.info('Serving local files.');
+    console.info('Edit index.html to configure the CollectionSpace UI.');
+    console.info();
+
+    return {
+      static: {
+        directory: __dirname,
+      },
+      historyApiFallback: true,
+    };
+  }
+
+  await verifyTarget(proxyTarget, library);
+
+  console.info(`Proxying to a remote CollectionSpace server at ${proxyTarget}`);
+
+  if (localIndex) {
+    if (!fs.existsSync(localIndex)) {
+      console.error(`The local index file ${localIndex} does not exist.`);
+      process.exit(1);
+    }
+
+    console.info('The UI configuration on the remote server will be ignored.');
+    console.info(`Edit ${localIndex} to configure the CollectionSpace UI.`);
+  } else {
+    console.info('The UI configuration on the remote server will be used.');
+  }
+
+  console.info();
+
+  const proxyTargetUrl = new URL(proxyTarget);
+
+  /**
+   * Rewrite a location header (as received in a 3xx response). This changes back-end URLs to
+   * point to the local server instead.
+   *
+   * @param res The response.
+   * @param req The request.
+   */
+  const rewriteLocationHeader = (res, req) => {
+    const location = res.getHeader('location');
+
+    if (!location) {
+      return;
+    }
+
+    const locationUrl = new URL(location);
+
+    if (locationUrl.host !== proxyTargetUrl.host) {
+      return;
+    }
+
+    const requestHost = req.headers.host;
+
+    if (!requestHost) {
+      return;
+    }
+
+    locationUrl.protocol = 'http';
+    locationUrl.host = requestHost;
+
+    res.setHeader('location', locationUrl.href);
+  };
+
+  /**
+   * Injects the library under development into a CSpace HTML page.
+   *
+   * @param page The HTML content of the page.
+   * @returns The HTML content of the page with the library injected.
+   */
+  const injectDevScript = (page) => {
+    // If this package is being used in the page, replace it with the local dev build.
+
+    if (pageUsesLibrary(page, library)) {
+      return page.replace(
+        scriptUrlPattern(library),
+        `src="${publicPath}${library}.js"`,
+      );
+    }
+
+    // This package isn't being used in the page. If the page appears to use the CSpace UI and this
+    // package appears to be a CSpace UI plugin, inject a script tag for it, and add it to the
+    // UI plugin configuration.
+
+    if (canInjectLibraryAsPlugin(page, library)) {
+      const pageWithScript = page.replace(
+        '</head>',
+        `
+          <script src="${publicPath}${library}.js"></script>
+        </head>
+        `,
+      );
+
+      if (pageWithScript.includes('plugins: [')) {
+        return pageWithScript.replace(
+          'plugins: [',
+          `plugins: [
+            ${library}(),
+          `,
+        );
+      }
+
+      return pageWithScript.replace(
+        'cspaceUI({',
+        `cspaceUI({
+          plugins: [
+            ${library}(),
+          ],
+        `,
+      );
+    }
+
+    return page;
+  };
+
+  /**
+   * Rewrites an HTML response.
+   *
+   * @param responseBuffer A buffer containing the response body.
+   * @param req The request.
+   * @returns The rewritten response body.
+   */
+  const rewriteHTML = (responseBuffer, req, proxyTarget) => {
+    const requestHost = req.headers.host;
+
+    if (!requestHost) {
+      return responseBuffer;
+    }
+
+    const page = responseBuffer.toString('utf8');
+    const pageWithDevScript = injectDevScript(page);
+
+    return injectStatusElement(
+      pageWithDevScript,
+      `devserver: running local package <b>${library}</b> with back-end <b>${proxyTarget}</b>`
+    );
+  };
+
+  const replaceHTML = (localIndex, proxyTarget) => {
+    const page = fs.readFileSync(localIndex).toString('utf8');
+
+    return injectStatusElement(
+      page,
+      `devserver: running local index file <b>${localIndex}</b> with back-end <b>${proxyTarget}</b>`,
+    );
+  };
+
+  const proxyMiddleware = createProxyMiddleware({
+    changeOrigin: true,
+    headers: {
+      origin: proxyTarget,
+    },
+    onProxyRes: responseInterceptor(
+      async (responseBuffer, proxyRes, req, res) => {
+        rewriteLocationHeader(res, req);
+
+        const contentType = res.getHeader('content-type');
+
+        if (contentType && contentType.startsWith('text/html')) {
+          if (localIndex) {
+            return replaceHTML(localIndex, proxyTarget);
+          }
+
+          return rewriteHTML(responseBuffer, req, proxyTarget);
+        }
+
+        return responseBuffer;
+      },
+    ),
+    proxyTimeout: 10000,
+    secure: false,
+    selfHandleResponse: true,
+    target: proxyTarget,
+    timeout: 10000,
+  });
+
+  return {
+    static: {
+      directory: __dirname,
+      publicPath,
+    },
+    setupMiddlewares: (middlewares) => {
+      middlewares.push({
+        name: 'cspace-proxy',
+        path: '/',
+        middleware: proxyMiddleware,
+      });
+
+      return middlewares;
+    },
+  };
+};

--- a/webpackDevServerConfig.js
+++ b/webpackDevServerConfig.js
@@ -15,7 +15,7 @@ const {
  * @returns A regular expression that detects if the library is used on an HTML page.
  */
 const scriptUrlPattern = (library) =>
-  new RegExp(`src=".*?/${library}(@.*?)\\.js"`, 'g');
+  new RegExp(`src=".*?/${library}(@.*?)?(\\.min)?\\.js"`, 'g');
 
 /**
  * Determines if an HTML page uses a given library.


### PR DESCRIPTION
**What does this do?**

This adds a `back-end` option to the devserver script that establishes a proxy to a back-end CollectionSpace server. This allows the UI under development to connect to a remote server, regardless of the CORS settings on that server. It also allows the UI under development to easily use the configuration from a remote server, without needing to reproduce that configuration in the local index.html file.

**Why are we doing this? (with JIRA link)**

This makes it easier to test changes under development against configurations and data from remote CollectionSpace servers, without needing to manage CORS settings on those servers. It will be especially important for hosted clients who want to develop plugins, and see them run against their staging or production sites.

JIRA: https://collectionspace.atlassian.net/browse/DRYD-1226

**How should this be tested? Do these changes have associated tests?**

Run `npm run devserver --back-end=<url>` with various back end URLs, such as:
- https://core.dev.collectionspace.org
- https://anthro.dev.collectionspace.org
- https://outreach.collectionspace.org
- https://core.collectionspace.org
- https://anthro.collectionspace.org

For each server:
- Verify that log in succeeds
- Verify that data from the back end appears in searches
- Verify that changes to the local code cause the browser to reload, and the local changes become visible in the browser

Run `npm run devserver` (without the `back-end` option), and verify that it continues to work as before.

**Dependencies for merging? Releasing to production?**

None.

**Has the application documentation been updated for these changes?**

This PR includes updates to the developer documentation.

**Did someone actually run this code to verify it works?**

@ray-lee tested with various back-ends.