### PR TITLE
DRYD-1069: Show all supportsGroup invocables in group record sidebar.

### DIFF
--- a/src/components/invocable/InvocationEditor.jsx
+++ b/src/components/invocable/InvocationEditor.jsx
@@ -30,7 +30,7 @@ const renderLoading = () => (
 );
 
 const propTypes = {
-  allowedModes: PropTypes.arrayOf(PropTypes.string),
+  allowedModes: PropTypes.func,
   config: PropTypes.shape({
     recordTypes: PropTypes.object,
   }),
@@ -89,7 +89,10 @@ export default class InvocationEditor extends Component {
     }
 
     if (allowedModes) {
-      modes = modes.filter((mode) => allowedModes.includes(mode));
+      const supportedRecordTypes = this.getSupportedRecordTypes();
+      const reportAllowedModes = allowedModes(supportedRecordTypes);
+
+      modes = modes.filter((mode) => reportAllowedModes.includes(mode));
     }
 
     return modes;

--- a/src/components/invocable/InvocationModal.jsx
+++ b/src/components/invocable/InvocationModal.jsx
@@ -39,7 +39,7 @@ const messages = defineMessages({
 });
 
 const propTypes = {
-  allowedModes: PropTypes.arrayOf(PropTypes.string),
+  allowedModes: PropTypes.func,
   config: PropTypes.shape({
     recordTypes: PropTypes.object,
   }).isRequired,

--- a/test/specs/components/invocable/InvocationEditor.spec.jsx
+++ b/test/specs/components/invocable/InvocationEditor.spec.jsx
@@ -133,6 +133,8 @@ describe('InvocationEditor', () => {
   });
 
   it('should filter out supported modes that are not allowed, if allowedModes is supplied', () => {
+    const getAllowedModes = () => ['group', 'single'];
+
     const shallowRenderer = createRenderer();
 
     shallowRenderer.render(
@@ -141,7 +143,7 @@ describe('InvocationEditor', () => {
         invocationDescriptor={invocationDescriptor}
         metadata={reportMetadata}
         recordType="report"
-        allowedModes={['group', 'single']}
+        allowedModes={getAllowedModes}
       />,
     );
 

--- a/test/specs/components/record/RecordBatchPanel.spec.jsx
+++ b/test/specs/components/record/RecordBatchPanel.spec.jsx
@@ -107,8 +107,31 @@ describe('RecordBatchPanel', () => {
     searchPanel.props.searchDescriptor.should.equal(Immutable.fromJS({
       recordType: 'batch',
       searchQuery: {
-        doctype: 'Group',
-        mode: ['single', 'group'],
+        as: {
+          op: 'or',
+          value: [
+            {
+              op: 'eq',
+              path: 'ns2:batch_common/supportsGroup',
+              value: true,
+            },
+            {
+              op: 'and',
+              value: [
+                {
+                  op: 'eq',
+                  path: 'ns2:batch_common/forDocTypes/forDocType',
+                  value: 'Group',
+                },
+                {
+                  op: 'eq',
+                  path: 'ns2:batch_common/supportsSingleDoc',
+                  value: true,
+                },
+              ],
+            },
+          ],
+        },
         p: 0,
         size: 5,
       },
@@ -193,8 +216,31 @@ describe('RecordBatchPanel', () => {
     searchPanel.props.searchDescriptor.should.equal(Immutable.fromJS({
       recordType: 'batch',
       searchQuery: {
-        doctype: 'Group',
-        mode: ['single', 'group'],
+        as: {
+          op: 'or',
+          value: [
+            {
+              op: 'eq',
+              path: 'ns2:batch_common/supportsGroup',
+              value: true,
+            },
+            {
+              op: 'and',
+              value: [
+                {
+                  op: 'eq',
+                  path: 'ns2:batch_common/forDocTypes/forDocType',
+                  value: 'Group',
+                },
+                {
+                  op: 'eq',
+                  path: 'ns2:batch_common/supportsSingleDoc',
+                  value: true,
+                },
+              ],
+            },
+          ],
+        },
         p: 0,
         size: 5,
       },
@@ -568,8 +614,31 @@ describe('RecordBatchPanel', () => {
     searchDescriptor.should.equal(Immutable.fromJS({
       recordType: 'batch',
       searchQuery: {
-        doctype: 'Group',
-        mode: ['single', 'group'],
+        as: {
+          op: 'or',
+          value: [
+            {
+              op: 'eq',
+              path: 'ns2:batch_common/supportsGroup',
+              value: true,
+            },
+            {
+              op: 'and',
+              value: [
+                {
+                  op: 'eq',
+                  path: 'ns2:batch_common/forDocTypes/forDocType',
+                  value: 'Group',
+                },
+                {
+                  op: 'eq',
+                  path: 'ns2:batch_common/supportsSingleDoc',
+                  value: true,
+                },
+              ],
+            },
+          ],
+        },
         p: 0,
         size: 5,
       },
@@ -583,5 +652,53 @@ describe('RecordBatchPanel', () => {
     searchPanel = findWithType(result, SearchPanelContainer);
 
     searchPanel.props.searchDescriptor.should.equal(newSearchDescriptor);
+  });
+
+  it('should allow group mode invocation when the record type is group', () => {
+    const csid = '1234';
+    const recordType = 'group';
+
+    const shallowRenderer = createRenderer();
+
+    shallowRenderer.render(
+      <RecordBatchPanel
+        config={config}
+        csid={csid}
+        recordData={recordData}
+        recordType={recordType}
+        perms={perms}
+      />,
+    );
+
+    const result = shallowRenderer.getRenderOutput();
+    const invocationModal = findWithType(result, InvocationModalContainer);
+    const getAllowedModes = invocationModal.props.allowedModes;
+    const modes = getAllowedModes();
+
+    modes.should.deep.equal(['group']);
+  });
+
+  it('should allow group and single mode invocation when the record type is group and the batch job is registered for doctype group', () => {
+    const csid = '1234';
+    const recordType = 'group';
+
+    const shallowRenderer = createRenderer();
+
+    shallowRenderer.render(
+      <RecordBatchPanel
+        config={config}
+        csid={csid}
+        recordData={recordData}
+        recordType={recordType}
+        perms={perms}
+      />,
+    );
+
+    const result = shallowRenderer.getRenderOutput();
+    const invocationModal = findWithType(result, InvocationModalContainer);
+    const getAllowedModes = invocationModal.props.allowedModes;
+    const modes = getAllowedModes(['group']);
+
+    modes.should.deep.equal(['group', 'single']);
   });
 });

--- a/test/specs/components/record/RecordReportPanel.spec.jsx
+++ b/test/specs/components/record/RecordReportPanel.spec.jsx
@@ -106,8 +106,31 @@ describe('RecordReportPanel', () => {
     searchPanel.props.searchDescriptor.should.equal(Immutable.fromJS({
       recordType: 'report',
       searchQuery: {
-        doctype: 'Group',
-        mode: ['single', 'group'],
+        as: {
+          op: 'or',
+          value: [
+            {
+              op: 'eq',
+              path: 'ns2:reports_common/supportsGroup',
+              value: true,
+            },
+            {
+              op: 'and',
+              value: [
+                {
+                  op: 'eq',
+                  path: 'ns2:reports_common/forDocTypes/forDocType',
+                  value: 'Group',
+                },
+                {
+                  op: 'eq',
+                  path: 'ns2:reports_common/supportsSingleDoc',
+                  value: true,
+                },
+              ],
+            },
+          ],
+        },
         p: 0,
         size: 5,
       },
@@ -192,8 +215,31 @@ describe('RecordReportPanel', () => {
     searchPanel.props.searchDescriptor.should.equal(Immutable.fromJS({
       recordType: 'report',
       searchQuery: {
-        doctype: 'Group',
-        mode: ['single', 'group'],
+        as: {
+          op: 'or',
+          value: [
+            {
+              op: 'eq',
+              path: 'ns2:reports_common/supportsGroup',
+              value: true,
+            },
+            {
+              op: 'and',
+              value: [
+                {
+                  op: 'eq',
+                  path: 'ns2:reports_common/forDocTypes/forDocType',
+                  value: 'Group',
+                },
+                {
+                  op: 'eq',
+                  path: 'ns2:reports_common/supportsSingleDoc',
+                  value: true,
+                },
+              ],
+            },
+          ],
+        },
         p: 0,
         size: 5,
       },
@@ -400,8 +446,31 @@ describe('RecordReportPanel', () => {
     searchDescriptor.should.equal(Immutable.fromJS({
       recordType: 'report',
       searchQuery: {
-        doctype: 'Group',
-        mode: ['single', 'group'],
+        as: {
+          op: 'or',
+          value: [
+            {
+              op: 'eq',
+              path: 'ns2:reports_common/supportsGroup',
+              value: true,
+            },
+            {
+              op: 'and',
+              value: [
+                {
+                  op: 'eq',
+                  path: 'ns2:reports_common/forDocTypes/forDocType',
+                  value: 'Group',
+                },
+                {
+                  op: 'eq',
+                  path: 'ns2:reports_common/supportsSingleDoc',
+                  value: true,
+                },
+              ],
+            },
+          ],
+        },
         p: 0,
         size: 5,
       },
@@ -415,5 +484,53 @@ describe('RecordReportPanel', () => {
     searchPanel = findWithType(result, SearchPanelContainer);
 
     searchPanel.props.searchDescriptor.should.equal(newSearchDescriptor);
+  });
+
+  it('should allow group mode invocation when the record type is group', () => {
+    const csid = '1234';
+    const recordType = 'group';
+
+    const shallowRenderer = createRenderer();
+
+    shallowRenderer.render(
+      <RecordReportPanel
+        config={config}
+        csid={csid}
+        recordData={recordData}
+        recordType={recordType}
+        perms={perms}
+      />,
+    );
+
+    const result = shallowRenderer.getRenderOutput();
+    const invocationModal = findWithType(result, InvocationModalContainer);
+    const getAllowedModes = invocationModal.props.allowedModes;
+    const modes = getAllowedModes();
+
+    modes.should.deep.equal(['group']);
+  });
+
+  it('should allow group and single mode invocation when the record type is group and the report is registered for doctype group', () => {
+    const csid = '1234';
+    const recordType = 'group';
+
+    const shallowRenderer = createRenderer();
+
+    shallowRenderer.render(
+      <RecordReportPanel
+        config={config}
+        csid={csid}
+        recordData={recordData}
+        recordType={recordType}
+        perms={perms}
+      />,
+    );
+
+    const result = shallowRenderer.getRenderOutput();
+    const invocationModal = findWithType(result, InvocationModalContainer);
+    const getAllowedModes = invocationModal.props.allowedModes;
+    const modes = getAllowedModes(['group']);
+
+    modes.should.deep.equal(['group', 'single']);
   });
 });


### PR DESCRIPTION
**What does this do?**

This changes the report and batch job sidebars on group records to show items that have either `supportsSingleDoc`=`true` and `forDocType`=`Group`, or `supportsGroup`=`true` (regardless of `forDocType`). Previously, only items with `supportsSingleDoc`=`true` and `forDocType`=`Group` were shown.

**Why are we doing this? (with JIRA link)**

This allows reports and batch jobs that are runnable in group mode to appear in the sidebar of group records, without needing to also set `forDocType` to `group`. Setting `supportsGroup` to true should be sufficient for getting a report/batch job to appear in the sidebar for Group records.

JIRA: https://collectionspace.atlassian.net/browse/DRYD-1069

**How should this be tested? Do these changes have associated tests?**

- Open a group record (or create and save a new one).
In the Reports sidebar, there should be two reports, "Group Basic List", and "Group Object Ethnographic Object List".
- Click on "Group Basic List".
In the modal that opens, Run on group should be selected (and there should be no other options).
- Close the modal.
- Click on "Group Object Ethnographic Object List".
In the modal that opens, Run on single record should be selected (and there should be no other options).

**Dependencies for merging? Releasing to production?**

https://github.com/collectionspace/services/pull/355 should be merged at the same time. Otherwise, running reports/batch jobs that have `supportsGroup`=`true` but not `forDocType`=`group` will fail (for example, "Group Basic List").

**Has the application documentation been updated for these changes?**

I will update the relevant report authoring documentation.

**Did someone actually run this code to verify it works?**

@ray-lee tested this locally.