### PR TITLE
DRYD-1238: Controlled event fields for collectionobject

### DIFF
--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -3265,17 +3265,17 @@ export default (configContext) => {
             messages: defineMessages({
               fullName: {
                 id: 'field.collectionobjects_common.assocEvent.fullName',
-                defaultMessage: 'Associated controlled event',
+                defaultMessage: 'Associated controlled event or period/era',
               },
               name: {
                 id: 'field.collectionobjects_common.assocEvent.name',
-                defaultMessage: 'Event',
+                defaultMessage: 'Event or period/era',
               },
             }),
             view: {
               type: AutocompleteInput,
               props: {
-                source: 'chronology/event',
+                source: 'chronology/event,chronology/era',
               },
             },
           },

--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -1747,6 +1747,34 @@ export default (configContext) => {
             },
           },
         },
+        contentEvents: {
+          [config]: {
+            view: {
+              type: CompoundInput,
+            },
+          },
+          contentEvent: {
+            [config]: {
+              messages: defineMessages({
+                fullName: {
+                  id: 'field.collectionobjects_common.contentEvent.fullName',
+                  defaultMessage: 'Content controlled event or period/era',
+                },
+                name: {
+                  id: 'field.collectionobjects_common.contentEvent.name',
+                  defaultMessage: 'Event or period/era',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: AutocompleteInput,
+                props: {
+                  source: 'chronology/event,chronology/era',
+                },
+              },
+            },
+          },
+        },
         contentOtherGroupList: {
           [config]: {
             view: {

--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -3260,22 +3260,30 @@ export default (configContext) => {
             },
           },
         },
-        assocEvent: {
+        assocEvents: {
           [config]: {
-            messages: defineMessages({
-              fullName: {
-                id: 'field.collectionobjects_common.assocEvent.fullName',
-                defaultMessage: 'Associated controlled event or period/era',
-              },
-              name: {
-                id: 'field.collectionobjects_common.assocEvent.name',
-                defaultMessage: 'Event or period/era',
-              },
-            }),
             view: {
-              type: AutocompleteInput,
-              props: {
-                source: 'chronology/event,chronology/era',
+              type: CompoundInput,
+            },
+          },
+          assocEvent: {
+            [config]: {
+              messages: defineMessages({
+                fullName: {
+                  id: 'field.collectionobjects_common.assocEvent.fullName',
+                  defaultMessage: 'Associated controlled event or period/era',
+                },
+                name: {
+                  id: 'field.collectionobjects_common.assocEvent.name',
+                  defaultMessage: 'Event or period/era',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: AutocompleteInput,
+                props: {
+                  source: 'chronology/event,chronology/era',
+                },
               },
             },
           },

--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -3280,23 +3280,6 @@ export default (configContext) => {
             },
           },
         },
-        assocEventType: {
-          [config]: {
-            messages: defineMessages({
-              fullName: {
-                id: 'field.collectionobjects_common.assocEventType.fullName',
-                defaultMessage: 'Associated controlled event type',
-              },
-              name: {
-                id: 'field.collectionobjects_common.assocEventType.name',
-                defaultMessage: 'Type',
-              },
-            }),
-            view: {
-              type: TextInput,
-            },
-          },
-        },
         assocEventOrganizations: {
           [config]: {
             view: {

--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -259,6 +259,10 @@ const template = (configContext) => {
                 </Field>
               </Field>
 
+              <Field name="contentEvents">
+                <Field name="contentEvent" />
+              </Field>
+
               <Field name="contentOtherGroupList">
                 <Field name="contentOtherGroup">
                   <Field name="contentOther" />

--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -458,10 +458,9 @@ const template = (configContext) => {
                 <Field name="assocEventNameType" />
               </InputTable>
 
-              <InputTable name="assocControlledEvent">
+              <Field name="assocEvents">
                 <Field name="assocEvent" />
-                <Field name="assocEventType" />
-              </InputTable>
+              </Field>
 
               <Field name="assocEventOrganizations">
                 <Field name="assocEventOrganization" />

--- a/src/plugins/recordTypes/collectionobject/messages.js
+++ b/src/plugins/recordTypes/collectionobject/messages.js
@@ -94,7 +94,7 @@ export default {
     },
     assocControlledEvent: {
       id: 'inputTable.collectionobject.assocControlledEvent',
-      defaultMessage: 'Associated controlled event',
+      defaultMessage: 'Associated controlled event or period/era',
     },
     ownershipExchange: {
       id: 'inputTable.collectionobject.ownershipExchange',

--- a/src/plugins/recordTypes/collectionobject/messages.js
+++ b/src/plugins/recordTypes/collectionobject/messages.js
@@ -92,10 +92,6 @@ export default {
       id: 'inputTable.collectionobject.assocEvent',
       defaultMessage: 'Associated event',
     },
-    assocControlledEvent: {
-      id: 'inputTable.collectionobject.assocControlledEvent',
-      defaultMessage: 'Associated controlled event or period/era',
-    },
     ownershipExchange: {
       id: 'inputTable.collectionobject.ownershipExchange',
       defaultMessage: 'Ownership exchange',


### PR DESCRIPTION
**What does this do?**
* Update assocEvent to be repeatable
* Remove assocEventType
* Add controlled contentEvent

**Why are we doing this? (with JIRA link)**
Changes requested for assocEvent, including adding contentEvent.

Jira: https://collectionspace.atlassian.net/browse/DRYD-1238

**How should this be tested? Do these changes have associated tests?**
* Build cspace with fcart enabled
* Run the devserver
* Test that assocEvent is repeatable and can use `chronology/event` and `chronology/era`
* Test that contentEvent is repeatable and can use `chronology/event` and `chronology/era`

**Dependencies for merging? Releasing to production?**
Application layer PR is required

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally