### PR TITLE
DRYD-1080: Display uri in export list

### DIFF
--- a/src/plugins/extensions/core/fields.js
+++ b/src/plugins/extensions/core/fields.js
@@ -91,6 +91,23 @@ export default (configContext) => {
           },
         },
       },
+      uri: {
+        [config]: {
+          messages: defineMessages({
+            name: {
+              id: 'field.ext.core.uri.name',
+              defaultMessage: 'Uri',
+            },
+          }),
+          searchDisabled: false,
+          view: {
+            type: TextInput,
+            props: {
+              readOnly: true,
+            },
+          },
+        },
+      },
     },
   };
 };

--- a/src/plugins/extensions/core/fields.js
+++ b/src/plugins/extensions/core/fields.js
@@ -96,7 +96,7 @@ export default (configContext) => {
           messages: defineMessages({
             name: {
               id: 'field.ext.core.uri.name',
-              defaultMessage: 'Uri',
+              defaultMessage: 'URI',
             },
           }),
           searchDisabled: false,


### PR DESCRIPTION
**What does this do?**
Adds field definition for collectionspace_core uri so that it can be selected in drop downs when exporting data.

**Why are we doing this? (with JIRA link)**
As part of [DRYD-1080](https://collectionspace.atlassian.net/jira/software/c/projects/DRYD/issues/DRYD-1080), we want to be able to export the uri in order to make operations for other components easy. The work was completed in the services layer but no support was added in order to do this from the ui as well. Adding the field definition allows the uri to be picked up when choosing what fields to export.

**How should this be tested? Do these changes have associated tests?**
* Start the devserver: `npm run devserver`
* If no objects/procedures/authorities exist, create one
* Search for newly created record
* Use the export modal to select the `Uri` field
* Check the downloaded csv for the correct response data

**Dependencies for merging? Releasing to production?**
This also allows the uri to be selected in the advanced search. This is a little awkward, though shouldn't break anything.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally
