### PR TITLE
DRYD-1259: Fix repeated search panel requests when login has expired.

### DIFF
--- a/src/components/search/SearchPanel.jsx
+++ b/src/components/search/SearchPanel.jsx
@@ -46,6 +46,7 @@ const propTypes = {
   recordData: PropTypes.instanceOf(Immutable.Map),
   searchDescriptor: PropTypes.instanceOf(Immutable.Map),
   searchError: PropTypes.instanceOf(Immutable.Map),
+  searchIsPending: PropTypes.bool,
   searchResult: PropTypes.instanceOf(Immutable.Map),
   listType: PropTypes.string,
   title: PropTypes.node,
@@ -114,6 +115,7 @@ export default class SearchPanel extends Component {
     const {
       searchDescriptor,
       searchError,
+      searchIsPending,
       searchResult,
       onSearchDescriptorChange,
     } = this.props;
@@ -122,7 +124,12 @@ export default class SearchPanel extends Component {
       !Immutable.is(prevSearchDescriptor, searchDescriptor)
       // If the search result was cleared from the store (not due to the search failing), redo the
       // search.
-      || (typeof searchResult === 'undefined' && prevSearchResult && !searchError)
+      || (
+        typeof searchResult === 'undefined'
+        && prevSearchResult
+        && !searchError
+        && !searchIsPending
+      )
     ) {
       this.search();
 

--- a/src/containers/search/SearchPanelContainer.js
+++ b/src/containers/search/SearchPanelContainer.js
@@ -5,7 +5,9 @@ import { setSearchPanelPageSize } from '../../actions/prefs';
 
 import {
   getSearchPanelPageSize,
+  getSearchError,
   getSearchResult,
+  isSearchPending,
 } from '../../reducers';
 
 const mapStateToProps = (state, ownProps) => {
@@ -36,7 +38,9 @@ const mapStateToProps = (state, ownProps) => {
 
   return {
     searchDescriptor,
+    searchError: getSearchError(state, name, searchDescriptor),
     searchResult: getSearchResult(state, name, searchDescriptor),
+    searchIsPending: isSearchPending(state, name, searchDescriptor),
   };
 };
 


### PR DESCRIPTION
**What does this do?**

This correctly connects the `searchError` prop of the `SearchPanel` component to state from the Redux store. Previously, `searchError` was not being set, even though it was needed for proper functioning of the `SearchPanel`. It also tweaks the conditions under which `SearchPanel` executes a new search.

**Why are we doing this? (with JIRA link)**

This fixes a bug where the `SearchPanel` would issue a new search whenever a search resulted in an error. When the error was a 401 due to not being logged in, this would cause an endless loop of searches.

JIRA: https://collectionspace.atlassian.net/browse/DRYD-1259

**How should this be tested? Do these changes have associated tests?**

- Log in using the UI
- Do a keyword search on a record type
- Open the Network panel in the developer tools
- Restart tomcat, so that all active tokens are invalidated
- In the UI, select a different record type in the keyword search box, and click the search button

Expect: A single request is made to populate the Reports sidebar, and another single request is made to populate the Data Updates (batch) sidebar. The requests should return 401 errors. The requests should not be repeated after the 401 errors.

**Dependencies for merging? Releasing to production?**

None.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran this locally.
