### PR TITLE
7.2 QA Updates

### DIFF
--- a/docs/configuration/messages.js
+++ b/docs/configuration/messages.js
@@ -2633,27 +2633,27 @@ export default {
 
   "field.ext.associatedAuthority.placeType.name": "Relationship/Type",
 
-  "field.ext.associatedAuthority.relatedPeriod.fullName": "Related period associated",
+  "field.ext.associatedAuthority.chronology.fullName": "Related period associated",
 
-  "field.ext.associatedAuthority.relatedPeriod.name": "Associated",
+  "field.ext.associatedAuthority.chronology.name": "Associated",
 
-  "field.ext.associatedAuthority.relatedPeriodCitation.fullName": "Related period citation",
+  "field.ext.associatedAuthority.chronologyCitation.fullName": "Related period citation",
 
-  "field.ext.associatedAuthority.relatedPeriodCitation.name": "Citation",
+  "field.ext.associatedAuthority.chronologyCitation.name": "Citation",
 
-  "field.ext.associatedAuthority.relatedPeriodGroup.name": "Related period",
+  "field.ext.associatedAuthority.chronologyGroup.name": "Related chronology",
 
-  "field.ext.associatedAuthority.relatedPeriodNote.fullName": "Related period note",
+  "field.ext.associatedAuthority.chronologyNote.fullName": "Related chronology note",
 
-  "field.ext.associatedAuthority.relatedPeriodNote.name": "Note",
+  "field.ext.associatedAuthority.chronologyNote.name": "Note",
 
-  "field.ext.associatedAuthority.relatedPeriodStructuredDateGroup.fullName": "Related period date",
+  "field.ext.associatedAuthority.chronologyStructuredDateGroup.fullName": "Related chronology date",
 
-  "field.ext.associatedAuthority.relatedPeriodStructuredDateGroup.name": "Date",
+  "field.ext.associatedAuthority.chronologyStructuredDateGroup.name": "Date",
 
-  "field.ext.associatedAuthority.relatedPeriodType.fullName": "Related period relationship/type",
+  "field.ext.associatedAuthority.chronologyType.fullName": "Related chronology relationship/type",
 
-  "field.ext.associatedAuthority.relatedPeriodType.name": "Relationship/Type",
+  "field.ext.associatedAuthority.chronologyType.name": "Relationship/Type",
 
   "field.ext.authItem.csid.name": "System CSID",
 

--- a/docs/configuration/messages.js
+++ b/docs/configuration/messages.js
@@ -767,7 +767,7 @@ export default {
 
   "field.chronologies_common.altDateNote.name": "Note",
 
-  "field.chronologies_common.altDateSpatialCoverage.fullName": "Alternative date spacial coverage",
+  "field.chronologies_common.altDateSpatialCoverage.fullName": "Alternative date spatial coverage",
 
   "field.chronologies_common.altDateSpatialCoverage.name": "Spatial coverage",
 

--- a/docs/configuration/messages.js
+++ b/docs/configuration/messages.js
@@ -725,13 +725,13 @@ export default {
 
   "field.blobs_common.name.name": "Name",
 
-  "field.chronologies_common.chronologyDateStructuredDateGroup.name": "Primary date range",
+  "field.chronologies_common.primaryDateRangeStructuredDateGroup.name": "Primary date range",
 
   "field.chronologies_common.chronologyDescription.name": "Chronology description",
 
   "field.chronologies_common.chronologyNote.name": "Chronology note",
 
-  "field.chronologies_common.chronologyPlaces.name": "Spatial coverage",
+  "field.chronologies_common.spatialCoverage.name": "Spatial coverage",
 
   "field.chronologies_common.chronologyTermGroup.name": "Term",
 
@@ -757,23 +757,23 @@ export default {
 
   "field.chronologies_common.identifierValue.name": "Value",
 
-  "field.chronologies_common.otherDateCitation.fullName": "Alternative date citation",
+  "field.chronologies_common.altDateCitation.fullName": "Alternative date citation",
 
-  "field.chronologies_common.otherDateCitation.name": "Citation",
+  "field.chronologies_common.altDateCitation.name": "Citation",
 
-  "field.chronologies_common.otherDateGroup.name": "Alternative date",
+  "field.chronologies_common.altDateGroup.name": "Alternative date",
 
-  "field.chronologies_common.otherDateNote.fullName": "Alternative date note",
+  "field.chronologies_common.altDateNote.fullName": "Alternative date note",
 
-  "field.chronologies_common.otherDateNote.name": "Note",
+  "field.chronologies_common.altDateNote.name": "Note",
 
-  "field.chronologies_common.otherDatePlace.fullName": "Alternative date spacial coverage",
+  "field.chronologies_common.altDateSpatialCoverage.fullName": "Alternative date spacial coverage",
 
-  "field.chronologies_common.otherDatePlace.name": "Spatial coverage",
+  "field.chronologies_common.altDateSpatialCoverage.name": "Spatial coverage",
 
-  "field.chronologies_common.otherDateStructuredDateGroup.fullName": "Alternative date range",
+  "field.chronologies_common.altDateRangeStructuredDateGroup.fullName": "Alternative date range",
 
-  "field.chronologies_common.otherDateStructuredDateGroup.name": "Range",
+  "field.chronologies_common.altDateRangeStructuredDateGroup.name": "Range",
 
   "field.chronologies_common.termDisplayName.fullName": "Term display name",
 

--- a/src/plugins/extensions/associatedAuthority/fields.js
+++ b/src/plugins/extensions/associatedAuthority/fields.js
@@ -685,7 +685,7 @@ export default (configContext) => {
             view: {
               type: AutocompleteInput,
               props: {
-                source: 'chronology/era,chronology/event,chronology/fieldcollection',
+                source: 'chronology/era,chronology/event',
               },
             },
           },

--- a/src/plugins/extensions/associatedAuthority/fields.js
+++ b/src/plugins/extensions/associatedAuthority/fields.js
@@ -1,5 +1,9 @@
 import { defineMessages } from 'react-intl';
 
+/**
+ * The associated authorities extension is currently unused while
+ * it is being re-spec'd
+ */
 export default (configContext) => {
   const {
     AutocompleteInput,

--- a/src/plugins/extensions/associatedAuthority/fields.js
+++ b/src/plugins/extensions/associatedAuthority/fields.js
@@ -22,17 +22,17 @@ export default (configContext) => {
   } = configContext.config;
 
   return {
-    personGroupList: {
+    assocPersonAuthGroupList: {
       [config]: {
         view: {
           type: CompoundInput,
         },
       },
-      personGroup: {
+      assocPersonAuthGroup: {
         [config]: {
           messages: defineMessages({
             name: {
-              id: 'field.ext.associatedAuthority.personGroup.name',
+              id: 'field.ext.associatedAuthority.assocPersonAuthGroup.name',
               defaultMessage: 'Person',
             },
           }),
@@ -147,17 +147,17 @@ export default (configContext) => {
         },
       },
     },
-    peopleGroupList: {
+    assocPeopleAuthGroupList: {
       [config]: {
         view: {
           type: CompoundInput,
         },
       },
-      peopleGroup: {
+      assocPeopleAuthGroup: {
         [config]: {
           messages: defineMessages({
             name: {
-              id: 'field.ext.associatedAuthority.peopleGroup.name',
+              id: 'field.ext.associatedAuthority.assocPeopleAuthGroup.name',
               defaultMessage: 'People',
             },
           }),
@@ -272,17 +272,17 @@ export default (configContext) => {
         },
       },
     },
-    organizationGroupList: {
+    assocOrganizationAuthGroupList: {
       [config]: {
         view: {
           type: CompoundInput,
         },
       },
-      organizationGroup: {
+      assocOrganizationAuthGroup: {
         [config]: {
           messages: defineMessages({
             name: {
-              id: 'field.ext.associatedAuthority.organizationGroup.name',
+              id: 'field.ext.associatedAuthority.assocOrganizationAuthGroup.name',
               defaultMessage: 'Organization',
             },
           }),
@@ -397,17 +397,17 @@ export default (configContext) => {
         },
       },
     },
-    conceptGroupList: {
+    assocConceptAuthGroupList: {
       [config]: {
         view: {
           type: CompoundInput,
         },
       },
-      conceptGroup: {
+      assocConceptAuthGroup: {
         [config]: {
           messages: defineMessages({
             name: {
-              id: 'field.ext.associatedAuthority.conceptGroup.name',
+              id: 'field.ext.associatedAuthority.assocConceptAuthGroup.name',
               defaultMessage: 'Concept',
             },
           }),
@@ -522,17 +522,17 @@ export default (configContext) => {
         },
       },
     },
-    placeGroupList: {
+    assocPlaceAuthGroupList: {
       [config]: {
         view: {
           type: CompoundInput,
         },
       },
-      placeGroup: {
+      assocPlaceAuthGroup: {
         [config]: {
           messages: defineMessages({
             name: {
-              id: 'field.ext.associatedAuthority.placeGroup.name',
+              id: 'field.ext.associatedAuthority.assocPlaceAuthGroup.name',
               defaultMessage: 'Place',
             },
           }),
@@ -647,18 +647,18 @@ export default (configContext) => {
         },
       },
     },
-    relatedPeriodGroupList: {
+    assocChronologyAuthGroupList: {
       [config]: {
         view: {
           type: CompoundInput,
         },
       },
-      relatedPeriodGroup: {
+      assocChronologyAuthGroup: {
         [config]: {
           messages: defineMessages({
             name: {
-              id: 'field.ext.associatedAuthority.relatedPeriodGroup.name',
-              defaultMessage: 'Related period',
+              id: 'field.ext.associatedAuthority.assocChronologyAuthGroup.name',
+              defaultMessage: 'Related chronology',
             },
           }),
           repeating: true,
@@ -666,15 +666,15 @@ export default (configContext) => {
             type: CompoundInput,
           },
         },
-        relatedPeriod: {
+        chronology: {
           [config]: {
             messages: defineMessages({
               fullName: {
-                id: 'field.ext.associatedAuthority.relatedPeriod.fullName',
-                defaultMessage: 'Related period associated',
+                id: 'field.ext.associatedAuthority.chronology.fullName',
+                defaultMessage: 'Related chronology associated',
               },
               name: {
-                id: 'field.ext.associatedAuthority.relatedPeriod.name',
+                id: 'field.ext.associatedAuthority.chronology.name',
                 defaultMessage: 'Associated',
               },
             }),
@@ -686,15 +686,15 @@ export default (configContext) => {
             },
           },
         },
-        relatedPeriodType: {
+        chronologyType: {
           [config]: {
             messages: defineMessages({
               fullName: {
-                id: 'field.ext.associatedAuthority.relatedPeriodType.fullName',
-                defaultMessage: 'Related period relationship/type',
+                id: 'field.ext.associatedAuthority.chronologyType.fullName',
+                defaultMessage: 'Related chronology relationship/type',
               },
               name: {
-                id: 'field.ext.associatedAuthority.relatedPeriodType.name',
+                id: 'field.ext.associatedAuthority.chronologyType.name',
                 defaultMessage: 'Relationship/Type',
               },
             }),
@@ -706,16 +706,16 @@ export default (configContext) => {
             },
           },
         },
-        relatedPeriodStructuredDateGroup: {
+        chronologyStructuredDateGroup: {
           [config]: {
             dataType: DATA_TYPE_STRUCTURED_DATE,
             messages: defineMessages({
               fullName: {
-                id: 'field.ext.associatedAuthority.relatedPeriodStructuredDateGroup.fullName',
-                defaultMessage: 'Related period date',
+                id: 'field.ext.associatedAuthority.chronologyStructuredDateGroup.fullName',
+                defaultMessage: 'Related chronology date',
               },
               name: {
-                id: 'field.ext.associatedAuthority.relatedPeriodStructuredDateGroup.name',
+                id: 'field.ext.associatedAuthority.chronologyStructuredDateGroup.name',
                 defaultMessage: 'Date',
               },
             }),
@@ -725,21 +725,21 @@ export default (configContext) => {
           },
           ...extensions.structuredDate.fields,
         },
-        relatedPeriodCitations: {
+        chronologyCitations: {
           [config]: {
             view: {
               type: CompoundInput,
             },
           },
-          relatedPeriodCitation: {
+          chronologyCitation: {
             [config]: {
               messages: defineMessages({
                 fullName: {
-                  id: 'field.ext.associatedAuthority.relatedPeriodCitation.fullName',
-                  defaultMessage: 'Related period citation',
+                  id: 'field.ext.associatedAuthority.chronologyCitation.fullName',
+                  defaultMessage: 'Related chronology citation',
                 },
                 name: {
-                  id: 'field.ext.associatedAuthority.relatedPeriodCitation.name',
+                  id: 'field.ext.associatedAuthority.chronologyCitation.name',
                   defaultMessage: 'Citation',
                 },
               }),
@@ -753,15 +753,15 @@ export default (configContext) => {
             },
           },
         },
-        relatedPeriodNote: {
+        chronologyNote: {
           [config]: {
             messages: defineMessages({
               fullName: {
-                id: 'field.ext.associatedAuthority.relatedPeriodNote.fullName',
-                defaultMessage: 'Related period note',
+                id: 'field.ext.associatedAuthority.chronologyNote.fullName',
+                defaultMessage: 'Related chronology note',
               },
               name: {
-                id: 'field.ext.associatedAuthority.relatedPeriodNote.name',
+                id: 'field.ext.associatedAuthority.chronologyNote.name',
                 defaultMessage: 'Note',
               },
             }),

--- a/src/plugins/extensions/associatedAuthority/form.jsx
+++ b/src/plugins/extensions/associatedAuthority/form.jsx
@@ -20,8 +20,8 @@ export default (configContext) => {
 
   return (
     <>
-      <Field name="personGroupList">
-        <Field name="personGroup">
+      <Field name="assocPersonAuthGroupList">
+        <Field name="assocPersonAuthGroup">
           <Panel>
             <Row>
               <Field name="person" />
@@ -36,8 +36,8 @@ export default (configContext) => {
         </Field>
       </Field>
 
-      <Field name="peopleGroupList">
-        <Field name="peopleGroup">
+      <Field name="assocPeopleAuthGroupList">
+        <Field name="assocPeopleAuthGroup">
           <Panel>
             <Row>
               <Field name="people" />
@@ -52,8 +52,8 @@ export default (configContext) => {
         </Field>
       </Field>
 
-      <Field name="organizationGroupList">
-        <Field name="organizationGroup">
+      <Field name="assocOrganizationAuthGroupList">
+        <Field name="assocOrganizationAuthGroup">
           <Panel>
             <Row>
               <Field name="organization" />
@@ -68,8 +68,8 @@ export default (configContext) => {
         </Field>
       </Field>
 
-      <Field name="conceptGroupList">
-        <Field name="conceptGroup">
+      <Field name="assocConceptAuthGroupList">
+        <Field name="assocConceptAuthGroup">
           <Panel>
             <Row>
               <Field name="concept" />
@@ -84,8 +84,8 @@ export default (configContext) => {
         </Field>
       </Field>
 
-      <Field name="placeGroupList">
-        <Field name="placeGroup">
+      <Field name="assocPlaceAuthGroupList">
+        <Field name="assocPlaceAuthGroup">
           <Panel>
             <Row>
               <Field name="place" />
@@ -100,17 +100,17 @@ export default (configContext) => {
         </Field>
       </Field>
 
-      <Field name="relatedPeriodGroupList">
-        <Field name="relatedPeriodGroup">
+      <Field name="assocChronologyAuthGroupList">
+        <Field name="assocChronologyAuthGroup">
           <Panel>
             <Row>
-              <Field name="relatedPeriod" />
-              <Field name="relatedPeriodType" />
-              <Field name="relatedPeriodStructuredDateGroup" />
-              <Field name="relatedPeriodCitations">
-                <Field name="relatedPeriodCitation" />
+              <Field name="chronology" />
+              <Field name="chronologyType" />
+              <Field name="chronologyStructuredDateGroup" />
+              <Field name="chronologyCitations">
+                <Field name="chronologyCitation" />
               </Field>
-              <Field name="relatedPeriodNote" />
+              <Field name="chronologyNote" />
             </Row>
           </Panel>
         </Field>

--- a/src/plugins/recordTypes/chronology/fields.js
+++ b/src/plugins/recordTypes/chronology/fields.js
@@ -574,7 +574,7 @@ export default (configContext) => {
                   messages: defineMessages({
                     fullName: {
                       id: 'field.chronologies_common.altDateSpatialCoverage.fullName',
-                      defaultMessage: 'Alternative date spacial coverage',
+                      defaultMessage: 'Alternative date spatial coverage',
                     },
                     name: {
                       id: 'field.chronologies_common.altDateSpatialCoverage.name',

--- a/src/plugins/recordTypes/chronology/fields.js
+++ b/src/plugins/recordTypes/chronology/fields.js
@@ -360,12 +360,12 @@ export default (configContext) => {
             },
           },
         },
-        chronologyDateStructuredDateGroup: {
+        primaryDateRangeStructuredDateGroup: {
           [config]: {
             dataType: DATA_TYPE_STRUCTURED_DATE,
             messages: defineMessages({
               name: {
-                id: 'field.chronologies_common.chronologyDateStructuredDateGroup.name',
+                id: 'field.chronologies_common.primaryDateRangeStructuredDateGroup.name',
                 defaultMessage: 'Primary date range',
               },
             }),
@@ -375,17 +375,17 @@ export default (configContext) => {
           },
           ...extensions.structuredDate.fields,
         },
-        chronologyPlaces: {
+        spatialCoverages: {
           [config]: {
             view: {
               type: CompoundInput,
             },
           },
-          chronologyPlace: {
+          spatialCoverage: {
             [config]: {
               messages: defineMessages({
                 name: {
-                  id: 'field.chronologies_common.chronologyPlaces.name',
+                  id: 'field.chronologies_common.spatialCoverage.name',
                   defaultMessage: 'Spatial coverage',
                 },
               }),
@@ -526,17 +526,17 @@ export default (configContext) => {
             },
           },
         },
-        otherDateGroupList: {
+        altDateGroupList: {
           [config]: {
             view: {
               type: CompoundInput,
             },
           },
-          otherDateGroup: {
+          altDateGroup: {
             [config]: {
               messages: defineMessages({
                 name: {
-                  id: 'field.chronologies_common.otherDateGroup.name',
+                  id: 'field.chronologies_common.altDateGroup.name',
                   defaultMessage: 'Alternative date',
                 },
               }),
@@ -545,16 +545,16 @@ export default (configContext) => {
                 type: CompoundInput,
               },
             },
-            otherDateStructuredDateGroup: {
+            altDateRangeStructuredDateGroup: {
               [config]: {
                 dataType: DATA_TYPE_STRUCTURED_DATE,
                 messages: defineMessages({
                   fullName: {
-                    id: 'field.chronologies_common.otherDateStructuredDateGroup.fullName',
+                    id: 'field.chronologies_common.altDateRangeStructuredDateGroup.fullName',
                     defaultMessage: 'Alternative date range',
                   },
                   name: {
-                    id: 'field.chronologies_common.otherDateStructuredDateGroup.name',
+                    id: 'field.chronologies_common.altDateRangeStructuredDateGroup.name',
                     defaultMessage: 'Range',
                   },
                 }),
@@ -564,21 +564,21 @@ export default (configContext) => {
               },
               ...extensions.structuredDate.fields,
             },
-            otherDatePlaces: {
+            altDateSpatialCoverages: {
               [config]: {
                 view: {
                   type: CompoundInput,
                 },
               },
-              otherDatePlace: {
+              altDateSpatialCoverage: {
                 [config]: {
                   messages: defineMessages({
                     fullName: {
-                      id: 'field.chronologies_common.otherDatePlace.fullName',
+                      id: 'field.chronologies_common.altDateSpatialCoverage.fullName',
                       defaultMessage: 'Alternative date spacial coverage',
                     },
                     name: {
-                      id: 'field.chronologies_common.otherDatePlace.name',
+                      id: 'field.chronologies_common.altDateSpatialCoverage.name',
                       defaultMessage: 'Spatial coverage',
                     },
                   }),
@@ -592,21 +592,21 @@ export default (configContext) => {
                 },
               },
             },
-            otherDateCitations: {
+            altDateCitations: {
               [config]: {
                 view: {
                   type: CompoundInput,
                 },
               },
-              otherDateCitation: {
+              altDateCitation: {
                 [config]: {
                   messages: defineMessages({
                     fullName: {
-                      id: 'field.chronologies_common.otherDateCitation.fullName',
+                      id: 'field.chronologies_common.altDateCitation.fullName',
                       defaultMessage: 'Alternative date citation',
                     },
                     name: {
-                      id: 'field.chronologies_common.otherDateCitation.name',
+                      id: 'field.chronologies_common.altDateCitation.name',
                       defaultMessage: 'Citation',
                     },
                   }),
@@ -620,15 +620,15 @@ export default (configContext) => {
                 },
               },
             },
-            otherDateNote: {
+            altDateNote: {
               [config]: {
                 messages: defineMessages({
                   fullName: {
-                    id: 'field.chronologies_common.otherDateNote.fullName',
+                    id: 'field.chronologies_common.altDateNote.fullName',
                     defaultMessage: 'Alternative date note',
                   },
                   name: {
-                    id: 'field.chronologies_common.otherDateNote.name',
+                    id: 'field.chronologies_common.altDateNote.name',
                     defaultMessage: 'Note',
                   },
                 }),

--- a/src/plugins/recordTypes/chronology/fields.js
+++ b/src/plugins/recordTypes/chronology/fields.js
@@ -74,7 +74,6 @@ export default (configContext) => {
           },
         },
         ...extensions.authItem.fields,
-        ...extensions.associatedAuthority.fields,
         chronologyTermGroupList: {
           [config]: {
             messages: defineMessages({

--- a/src/plugins/recordTypes/chronology/forms/default.jsx
+++ b/src/plugins/recordTypes/chronology/forms/default.jsx
@@ -54,10 +54,10 @@ const template = (configContext) => {
 
         <Cols>
           <Col>
-            <Field name="chronologyDateStructuredDateGroup" />
+            <Field name="primaryDateRangeStructuredDateGroup" />
             <Field name="chronologyType" />
-            <Field name="chronologyPlaces">
-              <Field name="chronologyPlace" />
+            <Field name="spatialCoverages">
+              <Field name="spatialCoverage" />
             </Field>
           </Col>
           <Col>
@@ -80,22 +80,22 @@ const template = (configContext) => {
       </Panel>
 
       <Panel name="altdate" collapsible collapsed>
-        <Field name="otherDateGroupList">
-          <Field name="otherDateGroup">
+        <Field name="altDateGroupList">
+          <Field name="altDateGroup">
             <Panel>
               <Cols>
                 <Col>
-                  <Field name="otherDateStructuredDateGroup" />
-                  <Field name="otherDatePlaces">
-                    <Field name="otherDatePlace" />
+                  <Field name="altDateRangeStructuredDateGroup" />
+                  <Field name="altDateSpatialCoverages">
+                    <Field name="altDateSpatialCoverage" />
                   </Field>
                 </Col>
 
                 <Col>
-                  <Field name="otherDateCitations">
-                    <Field name="otherDateCitation" />
+                  <Field name="altDateCitations">
+                    <Field name="altDateCitation" />
                   </Field>
-                  <Field name="otherDateNote" />
+                  <Field name="altDateNote" />
                 </Col>
               </Cols>
             </Panel>

--- a/src/plugins/recordTypes/chronology/forms/default.jsx
+++ b/src/plugins/recordTypes/chronology/forms/default.jsx
@@ -17,10 +17,6 @@ const template = (configContext) => {
     InputTable,
   } = configContext.recordComponents;
 
-  const {
-    extensions,
-  } = configContext.config;
-
   return (
     <Field name="document">
       <Panel name="info" collapsible>
@@ -73,10 +69,6 @@ const template = (configContext) => {
             <Field name="identifierDate" />
           </Field>
         </Field>
-      </Panel>
-
-      <Panel name="associated" collapsible collapsed>
-        {extensions.associatedAuthority.form}
       </Panel>
 
       <Panel name="altdate" collapsible collapsed>

--- a/src/plugins/recordTypes/chronology/messages.js
+++ b/src/plugins/recordTypes/chronology/messages.js
@@ -18,10 +18,6 @@ export default {
       id: 'panel.chronology.info',
       defaultMessage: 'Chronology Information',
     },
-    associated: {
-      id: 'panel.chronology.associated',
-      defaultMessage: 'Associated Authorities',
-    },
     altdate: {
       id: 'panel.chronology.altdate',
       defaultMessage: 'Alternative Date Information',

--- a/src/plugins/recordTypes/chronology/vocabularies.js
+++ b/src/plugins/recordTypes/chronology/vocabularies.js
@@ -69,26 +69,4 @@ export default {
       servicePath: 'urn:cspace:name(event)',
     },
   },
-  fieldcollection: {
-    messages: defineMessages({
-      name: {
-        id: 'vocab.chronology.fieldcollection.name',
-        description: 'The name of the vocabulary.',
-        defaultMessage: 'Field Collection',
-      },
-      collectionName: {
-        id: 'vocab.chronology.fieldcollection.collectionName',
-        description: 'The name of a collection of records from the vocabulary.',
-        defaultMessage: 'Field Collection Chronologies',
-      },
-      itemName: {
-        id: 'vocab.chronology.fieldcollection.itemName',
-        description: 'The name of a record from the vocabulary.',
-        defaultMessage: 'Field Collection Chronology',
-      },
-    }),
-    serviceConfig: {
-      servicePath: 'urn:cspace:name(field_collection)',
-    },
-  },
 };


### PR DESCRIPTION
**What does this do?**
* Fixes some typos in chronology messages
* Updates to chronology field names so that they're consistent with the ui names
* Move the chronology fieldcollection authority to anthro
* Remove the associated authority block so that it can be re-spec'd

**Why are we doing this? (with JIRA link)**
* https://collectionspace.atlassian.net/browse/DRYD-1261
* https://collectionspace.atlassian.net/browse/DRYD-1262
* https://collectionspace.atlassian.net/browse/DRYD-1264
* https://collectionspace.atlassian.net/browse/DRYD-1267

This brings in a few changes from QA which were identified in order to bring more consistency between the chronology field names and their default messages. In addition, the associated authorities block was seen as still needing more work before it's ready for production and as such has been removed from the chronology authority as well as having its vocabularies removed. 

**How should this be tested? Do these changes have associated tests?**
* Run the devserver with the application PR
* Verify that the chronology fieldcollection authority is not available in core
* Verify that the associated authorities do not display on chronology records
* Verify that the chronology field names are updated
  * `primaryDateRangeStructuredDateGroup`
  * `spatialCoverages` + subfields
  * `altDateGroupList` + subfields

**Dependencies for merging? Releasing to production?**
I opted to leave the associatedAuthorities extension in as opposed to the application layer which removed it. I added a comment to note that it is currently unused, and can remove the extension if desired.

Actually the associatedAuthorities block is still referencing vocabularies which have now been removed, so I should probably remove those before merging.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against a local instance