### PR TITLE
DRYD-1242: Fix unnecessary re-authorization.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cspace-ui",
-  "version": "9.0.0-dev.2",
+  "version": "9.0.0-dev.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cspace-ui",
-      "version": "9.0.0-dev.2",
+      "version": "9.0.0-dev.3",
       "license": "ECL-2.0",
       "dependencies": {
         "classnames": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cspace-ui",
-  "version": "9.0.0-dev.2",
+  "version": "9.0.0-dev.3",
   "description": "CollectionSpace user interface for browsers",
   "author": "Ray Lee <ray.lee@lyrasis.org>",
   "license": "ECL-2.0",

--- a/src/actions/cspace.js
+++ b/src/actions/cspace.js
@@ -33,6 +33,9 @@ export const setSession = (newSession) => {
   return {
     type: CSPACE_CONFIGURED,
     payload: getSession().config(),
+    meta: {
+      username: getSession().username(),
+    },
   };
 };
 

--- a/src/actions/login.js
+++ b/src/actions/login.js
@@ -213,14 +213,15 @@ export const login = (config, authCode, authCodeRequestData = {}) => (dispatch, 
 };
 
 /**
- * Log in using a fulfilled authorization code request.
+ * Receive an authorization code from the OAuth server. This will have been sent in a redirect from
+ * the server, in response to an authorization code request.
  *
  * @param {*} config
  * @param {*} authCodeRequestId
  * @param {*} authCode
  * @returns
  */
-export const loginWithAuthCodeRequest = (
+export const receiveAuthCode = (
   config,
   authCodeRequestId,
   authCode,

--- a/src/components/pages/AuthorizedPage.jsx
+++ b/src/components/pages/AuthorizedPage.jsx
@@ -19,7 +19,7 @@ const propTypes = {
   location: PropTypes.shape({
     search: PropTypes.string,
   }).isRequired,
-  loginWithAuthCodeRequest: PropTypes.func.isRequired,
+  receiveAuthCode: PropTypes.func.isRequired,
   username: PropTypes.string,
 };
 
@@ -167,7 +167,7 @@ export default function AuthorizedPage(props, context = {}) {
     isPending,
     isSuccess,
     location,
-    loginWithAuthCodeRequest,
+    receiveAuthCode,
     username,
   } = props;
 
@@ -180,7 +180,7 @@ export default function AuthorizedPage(props, context = {}) {
     const authCodeRequestId = params.get('state');
     const authCode = params.get('code');
 
-    loginWithAuthCodeRequest(config, authCodeRequestId, authCode);
+    receiveAuthCode(config, authCodeRequestId, authCode);
   }, []);
 
   useEffect(() => {

--- a/src/containers/pages/AuthorizedPageContainer.js
+++ b/src/containers/pages/AuthorizedPageContainer.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import AuthorizedPage from '../../components/pages/AuthorizedPage';
-import { loginWithAuthCodeRequest } from '../../actions/login';
+import { receiveAuthCode } from '../../actions/login';
 
 import {
   getLoginUsername,
@@ -19,7 +19,7 @@ const mapStateToProps = (state) => ({
 });
 
 const mapDispatchToProps = {
-  loginWithAuthCodeRequest,
+  receiveAuthCode,
 };
 
 export default connect(

--- a/src/reducers/user.js
+++ b/src/reducers/user.js
@@ -63,7 +63,7 @@ export default (state = Immutable.Map(), action) => {
     case AUTH_RENEW_FULFILLED:
       return handleAccountPermsReadFulfilled(state, action);
     case CSPACE_CONFIGURED:
-      return state.set('username', action.payload.username);
+      return state.set('username', action.meta.username);
     case LOGIN_FULFILLED:
       return state.set('username', action.meta.username);
     case LOGOUT_FULFILLED:

--- a/test/specs/reducers/user.spec.js
+++ b/test/specs/reducers/user.spec.js
@@ -35,7 +35,8 @@ describe('user reducer', () => {
 
     const state = reducer(undefined, {
       type: CSPACE_CONFIGURED,
-      payload: {
+      payload: {},
+      meta: {
         username,
       },
     });


### PR DESCRIPTION
**What does this do?**

This fixes a bug (introduced with the Spring Security upgrade/switch to OAuth authorization code grant) where the logged in user is not updated properly in the redux store. This resulted in unnecessary re-authorization when a valid stored token was present.

**Why are we doing this? (with JIRA link)**

This is part of the Spring Security upgrade: https://collectionspace.atlassian.net/browse/DRYD-1242

**How should this be tested? Do these changes have associated tests?**

Log in, browse to a record, and reload the browser. Upon reload, re-authorization should not occur (there is no request to the /cspace-services/oauth2/authorize endpoint, and no resulting redirect to the /authorized page in the UI).

**Dependencies for merging? Releasing to production?**

None.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran this locally.