### PR TITLE
DRYD-1316: Add object count group fields

### DIFF
--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -6207,6 +6207,123 @@ export default (configContext) => {
             },
           },
         },
+        objectCountGroupList: {
+          [config]: {
+            view: {
+              type: CompoundInput,
+            },
+          },
+          objectCountGroup: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.collectionobjects_common.objectCountGroup.name',
+                  defaultMessage: 'Object count',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: CompoundInput,
+              },
+            },
+            objectCount: {
+              [config]: {
+                dataType: DATA_TYPE_INT,
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.collectionobjects_common.objectCount.fullName',
+                    defaultMessage: 'Object count value',
+                  },
+                  name: {
+                    id: 'field.collectionobjects_common.objectCount.name',
+                    defaultMessage: 'Value',
+                  },
+                }),
+                view: {
+                  type: TextInput,
+                },
+              },
+            },
+            objectCountType: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.collectionobjects_common.objectCountType.fullName',
+                    defaultMessage: 'Object count type',
+                  },
+                  name: {
+                    id: 'field.collectionobjects_common.objectCountType.name',
+                    defaultMessage: 'Type',
+                  },
+                }),
+                view: {
+                  type: TermPickerInput,
+                  props: {
+                    source: 'objectcounttypes',
+                  },
+                },
+              },
+            },
+            objectCountCountedBy: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.collectionobjects_common.objectCountCountedBy.fullName',
+                    defaultMessage: 'Object count counted by',
+                  },
+                  name: {
+                    id: 'field.collectionobjects_common.objectCountCountedBy.name',
+                    defaultMessage: 'Counted by',
+                  },
+                }),
+                view: {
+                  type: AutocompleteInput,
+                  props: {
+                    source: 'person/local,person/shared,person/ulan',
+                  },
+                },
+              },
+            },
+            objectCountDate: {
+              [config]: {
+                dataType: DATA_TYPE_DATE,
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.collectionobjects_common.objectCountDate.fullName',
+                    defaultMessage: 'Object count date',
+                  },
+                  name: {
+                    id: 'field.collectionobjects_common.objectCountDate.name',
+                    defaultMessage: 'Date',
+                  },
+                }),
+                view: {
+                  type: DateInput,
+                },
+              },
+            },
+            objectCountNote: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.collectionobjects_common.objectCountNote.fullName',
+                    defaultMessage: 'Object count note',
+                  },
+                  name: {
+                    id: 'field.collectionobjects_common.objectCountNote.name',
+                    defaultMessage: 'Note',
+                  },
+                }),
+                view: {
+                  type: TextInput,
+                  props: {
+                    multiline: true,
+                  },
+                },
+              },
+            },
+          },
+        },
       },
     },
   };

--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -126,6 +126,21 @@ const template = (configContext) => {
             <Field name="objectNameNote" />
           </Field>
         </Field>
+
+        <Field name="objectCountGroupList">
+          <Field name="objectCountGroup">
+            <Panel>
+              <Row>
+                <Field name="objectCount" />
+                <Field name="objectCountType" />
+                <Field name="objectCountCountedBy" />
+                <Field name="objectCountDate" />
+              </Row>
+              <Field name="objectCountNote" />
+            </Panel>
+          </Field>
+        </Field>
+
       </Panel>
 
       <Panel name="desc" collapsible collapsed>

--- a/src/plugins/recordTypes/collectionobject/forms/photo.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/photo.jsx
@@ -86,6 +86,20 @@ const template = (configContext) => {
             <Field name="objectNameNote" />
           </Field>
         </Field>
+
+        <Field name="objectCountGroupList">
+          <Field name="objectCountGroup">
+            <Panel>
+              <Row>
+                <Field name="objectCount" />
+                <Field name="objectCountType" />
+                <Field name="objectCountCountedBy" />
+                <Field name="objectCountDate" />
+              </Row>
+              <Field name="objectCountNote" />
+            </Panel>
+          </Field>
+        </Field>
       </Panel>
 
       <Panel name="desc" collapsible collapsed>

--- a/src/plugins/recordTypes/collectionobject/forms/public.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/public.jsx
@@ -74,6 +74,19 @@ const template = (configContext) => {
           </Field>
         </Field>
 
+        <Field name="objectCountGroupList">
+          <Field name="objectCountGroup">
+            <Panel>
+              <Row>
+                <Field name="objectCount" />
+                <Field name="objectCountType" />
+                <Field name="objectCountCountedBy" />
+                <Field name="objectCountDate" />
+              </Row>
+              <Field name="objectCountNote" />
+            </Panel>
+          </Field>
+        </Field>
       </Panel>
 
       <Panel name="desc" collapsible>

--- a/src/plugins/recordTypes/collectionobject/forms/timebased.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/timebased.jsx
@@ -109,6 +109,20 @@ const template = (configContext) => {
           </Field>
         </Field>
 
+        <Field name="objectCountGroupList">
+          <Field name="objectCountGroup">
+            <Panel>
+              <Row>
+                <Field name="objectCount" />
+                <Field name="objectCountType" />
+                <Field name="objectCountCountedBy" />
+                <Field name="objectCountDate" />
+              </Row>
+              <Field name="objectCountNote" />
+            </Panel>
+          </Field>
+        </Field>
+
         <Field name="objectSignificanceGroupList">
           <Field name="objectSignificanceGroup">
             <Field name="assignedSignificance" />


### PR DESCRIPTION
**What does this do?**
Adds fields and updates the default form for object count fields

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1316

This is intended to replace the `numberOfObjects` field with a more complete set of fields to support reporting needs for archaeology and NAGPRA profiles. 

**How should this be tested? Do these changes have associated tests?**
* Rebuild collectionspace
* See that the new term list exists under `objectcounttypes`
* Create a collectionobject using the new fields and term

**Dependencies for merging? Releasing to production?**
We'll need to double check that the layout is what was expected. I wasn't sure which one was being used for the wireframes, and wanted to get this up to make testing the application layer PR easier.

It's likely that other profiles will need to be updated as well but that will be noted in the ticket.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally 