### PR TITLE
DRYD-1206: Add nameNote field

### DIFF
--- a/src/plugins/recordTypes/organization/fields.js
+++ b/src/plugins/recordTypes/organization/fields.js
@@ -639,6 +639,22 @@ export default (configContext) => {
             },
           },
         },
+        nameNote: {
+          [config]: {
+            messages: defineMessages({
+              name: {
+                id: 'field.organizations_common.nameNote.name',
+                defaultMessage: 'Name note',
+              },
+            }),
+            view: {
+              type: TextInput,
+              props: {
+                multiline: true,
+              },
+            },
+          },
+        },
       },
       // TODO: Use the embedded contacts_common (available as of 5.1) to render contact info,
       // instead of the configured subrecord. For now just make it not cloneable, so that a

--- a/src/plugins/recordTypes/organization/forms/default.jsx
+++ b/src/plugins/recordTypes/organization/forms/default.jsx
@@ -65,6 +65,8 @@ const template = (configContext) => {
           </Col>
 
           <Col>
+            <Field name="nameNote" />
+
             <Field name="groups">
               <Field name="group" />
             </Field>


### PR DESCRIPTION
**What does this do?**
Adds nameNote to organization authority

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1206

This adds a field to the organization authority to store information about the authority.

**How should this be tested? Do these changes have associated tests?**
* Rebuild collectionspace
* Create an organization authority with the nameNote filled out
* Verify the field saves

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally