### PR TITLE
Update ObjectCountGroup layout

### DIFF
--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -234,20 +234,6 @@ export default (configContext) => {
             },
           },
         },
-        numberOfObjects: {
-          [config]: {
-            dataType: DATA_TYPE_INT,
-            messages: defineMessages({
-              name: {
-                id: 'field.collectionobjects_common.numberOfObjects.name',
-                defaultMessage: 'Number of objects',
-              },
-            }),
-            view: {
-              type: TextInput,
-            },
-          },
-        },
         otherNumberList: {
           [config]: {
             view: {

--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -6224,6 +6224,9 @@ export default (configContext) => {
               repeating: true,
               view: {
                 type: CompoundInput,
+                props: {
+                  tabular: true,
+                },
               },
             },
             objectCount: {
@@ -6316,9 +6319,6 @@ export default (configContext) => {
                 }),
                 view: {
                   type: TextInput,
-                  props: {
-                    multiline: true,
-                  },
                 },
               },
             },

--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -27,7 +27,6 @@ const template = (configContext) => {
         <Row>
           <Col>
             <Field name="objectNumber" />
-            <Field name="numberOfObjects" />
 
             <Field name="otherNumberList">
               <Field name="otherNumber">

--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -129,15 +129,11 @@ const template = (configContext) => {
 
         <Field name="objectCountGroupList">
           <Field name="objectCountGroup">
-            <Panel>
-              <Row>
-                <Field name="objectCount" />
-                <Field name="objectCountType" />
-                <Field name="objectCountCountedBy" />
-                <Field name="objectCountDate" />
-              </Row>
-              <Field name="objectCountNote" />
-            </Panel>
+            <Field name="objectCount" />
+            <Field name="objectCountType" />
+            <Field name="objectCountCountedBy" />
+            <Field name="objectCountDate" />
+            <Field name="objectCountNote" />
           </Field>
         </Field>
 

--- a/src/plugins/recordTypes/collectionobject/forms/photo.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/photo.jsx
@@ -89,15 +89,11 @@ const template = (configContext) => {
 
         <Field name="objectCountGroupList">
           <Field name="objectCountGroup">
-            <Panel>
-              <Row>
-                <Field name="objectCount" />
-                <Field name="objectCountType" />
-                <Field name="objectCountCountedBy" />
-                <Field name="objectCountDate" />
-              </Row>
-              <Field name="objectCountNote" />
-            </Panel>
+            <Field name="objectCount" />
+            <Field name="objectCountType" />
+            <Field name="objectCountCountedBy" />
+            <Field name="objectCountDate" />
+            <Field name="objectCountNote" />
           </Field>
         </Field>
       </Panel>

--- a/src/plugins/recordTypes/collectionobject/forms/photo.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/photo.jsx
@@ -25,7 +25,6 @@ const template = (configContext) => {
         <Row>
           <Col>
             <Field name="objectNumber" />
-            <Field name="numberOfObjects" />
 
             <Field name="responsibleDepartments">
               <Field name="responsibleDepartment" />

--- a/src/plugins/recordTypes/collectionobject/forms/public.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/public.jsx
@@ -76,15 +76,11 @@ const template = (configContext) => {
 
         <Field name="objectCountGroupList">
           <Field name="objectCountGroup">
-            <Panel>
-              <Row>
-                <Field name="objectCount" />
-                <Field name="objectCountType" />
-                <Field name="objectCountCountedBy" />
-                <Field name="objectCountDate" />
-              </Row>
-              <Field name="objectCountNote" />
-            </Panel>
+            <Field name="objectCount" />
+            <Field name="objectCountType" />
+            <Field name="objectCountCountedBy" />
+            <Field name="objectCountDate" />
+            <Field name="objectCountNote" />
           </Field>
         </Field>
       </Panel>

--- a/src/plugins/recordTypes/collectionobject/forms/timebased.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/timebased.jsx
@@ -27,7 +27,6 @@ const template = (configContext) => {
         <Row>
           <Col>
             <Field name="objectNumber" />
-            <Field name="numberOfObjects" />
 
             <Field name="otherNumberList">
               <Field name="otherNumber">

--- a/src/plugins/recordTypes/collectionobject/forms/timebased.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/timebased.jsx
@@ -111,15 +111,11 @@ const template = (configContext) => {
 
         <Field name="objectCountGroupList">
           <Field name="objectCountGroup">
-            <Panel>
-              <Row>
-                <Field name="objectCount" />
-                <Field name="objectCountType" />
-                <Field name="objectCountCountedBy" />
-                <Field name="objectCountDate" />
-              </Row>
-              <Field name="objectCountNote" />
-            </Panel>
+            <Field name="objectCount" />
+            <Field name="objectCountType" />
+            <Field name="objectCountCountedBy" />
+            <Field name="objectCountDate" />
+            <Field name="objectCountNote" />
           </Field>
         </Field>
 

--- a/test/specs/helpers/searchHelpers.spec.js
+++ b/test/specs/helpers/searchHelpers.spec.js
@@ -401,13 +401,13 @@ describe('searchHelpers', () => {
     it('should normalize the value of the condition', () => {
       const condition = Immutable.fromJS({
         op: OP_RANGE,
-        path: 'ns2:part/numberOfObjects',
+        path: 'ns2:part/objectCountGroupList/objectCountGroup/objectCount',
         value: [' 2', ' 4 '],
       });
 
       normalizeRangeFieldCondition(fields, condition).should.equal(Immutable.fromJS({
         op: OP_RANGE,
-        path: 'ns2:part/numberOfObjects',
+        path: 'ns2:part/objectCountGroupList/objectCountGroup/objectCount',
         value: ['2', '4'],
       }));
     });
@@ -415,7 +415,7 @@ describe('searchHelpers', () => {
     it('should return null if the value normalizes to null', () => {
       const condition = Immutable.fromJS({
         op: OP_RANGE,
-        path: 'ns2:part/numberOfObjects',
+        path: 'ns2:part/objectCountGroupList/objectCountGroup/objectCount',
         value: [' ', null],
       });
 
@@ -425,7 +425,7 @@ describe('searchHelpers', () => {
     it('should return null if the condition has no value', () => {
       const condition = Immutable.fromJS({
         op: OP_RANGE,
-        path: 'ns2:part/numberOfObjects',
+        path: 'ns2:part/objectCountGroupList/objectCountGroup/objectCount',
       });
 
       expect(normalizeRangeFieldCondition(fields, condition)).to.equal(null);
@@ -434,13 +434,13 @@ describe('searchHelpers', () => {
     it('should return a >= condition if the value is not a list and the field is not a structured date', () => {
       const condition = Immutable.fromJS({
         op: OP_RANGE,
-        path: 'ns2:part/numberOfObjects',
+        path: 'ns2:part/objectCountGroupList/objectCountGroup/objectCount',
         value: '2',
       });
 
       normalizeRangeFieldCondition(fields, condition).should.equal(Immutable.fromJS({
         op: OP_GTE,
-        path: 'ns2:part/numberOfObjects',
+        path: 'ns2:part/objectCountGroupList/objectCountGroup/objectCount',
         value: '2',
       }));
     });
@@ -448,13 +448,13 @@ describe('searchHelpers', () => {
     it('should return a >= condition if the end of range is omitted and the field is not a structured date', () => {
       const condition = Immutable.fromJS({
         op: OP_RANGE,
-        path: 'ns2:part/numberOfObjects',
+        path: 'ns2:part/objectCountGroupList/objectCountGroup/objectCount',
         value: ['2'],
       });
 
       normalizeRangeFieldCondition(fields, condition).should.equal(Immutable.fromJS({
         op: OP_GTE,
-        path: 'ns2:part/numberOfObjects',
+        path: 'ns2:part/objectCountGroupList/objectCountGroup/objectCount',
         value: '2',
       }));
     });
@@ -476,13 +476,13 @@ describe('searchHelpers', () => {
     it('should return a <= condition if the start of range is omitted and the field is not a structured date', () => {
       const condition = Immutable.fromJS({
         op: OP_RANGE,
-        path: 'ns2:part/numberOfObjects',
+        path: 'ns2:part/objectCountGroupList/objectCountGroup/objectCount',
         value: [undefined, '4'],
       });
 
       normalizeRangeFieldCondition(fields, condition).should.equal(Immutable.fromJS({
         op: OP_LTE,
-        path: 'ns2:part/numberOfObjects',
+        path: 'ns2:part/objectCountGroupList/objectCountGroup/objectCount',
         value: '4',
       }));
     });
@@ -564,13 +564,13 @@ describe('searchHelpers', () => {
     it('should normalize OP_RANGE conditions', () => {
       const condition = Immutable.fromJS({
         op: OP_RANGE,
-        path: 'collectionobjects_common/numberOfObjects',
+        path: 'collectionobjects_common/objectCountGroupList/objectCountGroup/objectCount',
         value: [' 2', ' 4 '],
       });
 
       normalizeCondition(fields, condition).should.equal(Immutable.fromJS({
         op: OP_RANGE,
-        path: 'collectionobjects_common/numberOfObjects',
+        path: 'collectionobjects_common/objectCountGroupList/objectCountGroup/objectCount',
         value: ['2', '4'],
       }));
     });


### PR DESCRIPTION
**What does this do?**
* Updates object count group layout to be tabular
* Removes numberOfObjects

**Why are we doing this? (with JIRA link)**
This is a combination of 2 jiras:
* https://collectionspace.atlassian.net/browse/DRYD-1374
* https://collectionspace.atlassian.net/browse/DRYD-1379

The first is making updates to the layout for the new object count group so that it is tabular and has its note inline. This comes from feedback that the larger note field is not necessary for this set of fields.

The second is removing numberOfObjects, which is being done because the field is being replaced by objectCount.

**How should this be tested? Do these changes have associated tests?**
* Run npm test + npm lint
* Run the devserver
* View the new object count group layout
* Observer that numberOfObjects no longer displays

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locallt