### PR TITLE
Add Object Name Controlled and Material Controlled to Missing Forms

### DIFF
--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -115,8 +115,8 @@ const template = (configContext) => {
 
         <Field name="objectNameList">
           <Field name="objectNameGroup">
-            <Field name="objectName" />
             <Field name="objectNameControlled" />
+            <Field name="objectName" />
             <Field name="objectNameCurrency" />
             <Field name="objectNameLevel" />
             <Field name="objectNameSystem" />
@@ -180,8 +180,8 @@ const template = (configContext) => {
 
         <Field name="materialGroupList">
           <Field name="materialGroup">
-            <Field name="material" />
             <Field name="materialControlled" />
+            <Field name="material" />
             <Field name="materialComponent" />
             <Field name="materialComponentNote" />
             <Field name="materialName" />

--- a/src/plugins/recordTypes/collectionobject/forms/inventory.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/inventory.jsx
@@ -72,6 +72,7 @@ const template = (configContext) => {
         <Field name="objectNameList">
           <Field name="objectNameGroup">
             <Field name="objectName" />
+            <Field name="objectNameControlled" />
             <Field name="objectNameCurrency" />
             <Field name="objectNameLevel" />
             <Field name="objectNameSystem" />

--- a/src/plugins/recordTypes/collectionobject/forms/inventory.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/inventory.jsx
@@ -71,8 +71,8 @@ const template = (configContext) => {
 
         <Field name="objectNameList">
           <Field name="objectNameGroup">
-            <Field name="objectName" />
             <Field name="objectNameControlled" />
+            <Field name="objectName" />
             <Field name="objectNameCurrency" />
             <Field name="objectNameLevel" />
             <Field name="objectNameSystem" />

--- a/src/plugins/recordTypes/collectionobject/forms/photo.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/photo.jsx
@@ -76,8 +76,8 @@ const template = (configContext) => {
 
         <Field name="objectNameList">
           <Field name="objectNameGroup">
-            <Field name="objectName" />
             <Field name="objectNameControlled" />
+            <Field name="objectName" />
             <Field name="objectNameCurrency" />
             <Field name="objectNameLevel" />
             <Field name="objectNameSystem" />
@@ -115,8 +115,8 @@ const template = (configContext) => {
 
         <Field name="materialGroupList">
           <Field name="materialGroup">
-            <Field name="material" />
             <Field name="materialControlled" />
+            <Field name="material" />
             <Field name="materialComponent" />
             <Field name="materialComponentNote" />
             <Field name="materialName" />

--- a/src/plugins/recordTypes/collectionobject/forms/photo.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/photo.jsx
@@ -77,6 +77,7 @@ const template = (configContext) => {
         <Field name="objectNameList">
           <Field name="objectNameGroup">
             <Field name="objectName" />
+            <Field name="objectNameControlled" />
             <Field name="objectNameCurrency" />
             <Field name="objectNameLevel" />
             <Field name="objectNameSystem" />
@@ -115,6 +116,7 @@ const template = (configContext) => {
         <Field name="materialGroupList">
           <Field name="materialGroup">
             <Field name="material" />
+            <Field name="materialControlled" />
             <Field name="materialComponent" />
             <Field name="materialComponentNote" />
             <Field name="materialName" />

--- a/src/plugins/recordTypes/collectionobject/forms/public.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/public.jsx
@@ -64,8 +64,8 @@ const template = (configContext) => {
 
         <Field name="objectNameList">
           <Field name="objectNameGroup">
-            <Field name="objectName" />
             <Field name="objectNameControlled" />
+            <Field name="objectName" />
             <Field name="objectNameCurrency" />
             <Field name="objectNameLevel" />
             <Field name="objectNameSystem" />
@@ -93,8 +93,8 @@ const template = (configContext) => {
 
         <Field name="materialGroupList">
           <Field name="materialGroup">
-            <Field name="material" />
             <Field name="materialControlled" />
+            <Field name="material" />
             <Field name="materialComponent" />
             <Field name="materialComponentNote" />
             <Field name="materialName" />

--- a/src/plugins/recordTypes/collectionobject/forms/public.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/public.jsx
@@ -65,6 +65,7 @@ const template = (configContext) => {
         <Field name="objectNameList">
           <Field name="objectNameGroup">
             <Field name="objectName" />
+            <Field name="objectNameControlled" />
             <Field name="objectNameCurrency" />
             <Field name="objectNameLevel" />
             <Field name="objectNameSystem" />
@@ -93,6 +94,7 @@ const template = (configContext) => {
         <Field name="materialGroupList">
           <Field name="materialGroup">
             <Field name="material" />
+            <Field name="materialControlled" />
             <Field name="materialComponent" />
             <Field name="materialComponentNote" />
             <Field name="materialName" />

--- a/src/plugins/recordTypes/collectionobject/forms/timebased.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/timebased.jsx
@@ -98,8 +98,8 @@ const template = (configContext) => {
 
         <Field name="objectNameList">
           <Field name="objectNameGroup">
-            <Field name="objectName" />
             <Field name="objectNameControlled" />
+            <Field name="objectName" />
             <Field name="objectNameCurrency" />
             <Field name="objectNameLevel" />
             <Field name="objectNameSystem" />
@@ -191,8 +191,8 @@ const template = (configContext) => {
 
         <Field name="materialGroupList">
           <Field name="materialGroup">
-            <Field name="material" />
             <Field name="materialControlled" />
+            <Field name="material" />
             <Field name="materialComponent" />
             <Field name="materialComponentNote" />
             <Field name="materialName" />

--- a/src/plugins/recordTypes/collectionobject/forms/timebased.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/timebased.jsx
@@ -99,6 +99,7 @@ const template = (configContext) => {
         <Field name="objectNameList">
           <Field name="objectNameGroup">
             <Field name="objectName" />
+            <Field name="objectNameControlled" />
             <Field name="objectNameCurrency" />
             <Field name="objectNameLevel" />
             <Field name="objectNameSystem" />
@@ -191,6 +192,7 @@ const template = (configContext) => {
         <Field name="materialGroupList">
           <Field name="materialGroup">
             <Field name="material" />
+            <Field name="materialControlled" />
             <Field name="materialComponent" />
             <Field name="materialComponentNote" />
             <Field name="materialName" />


### PR DESCRIPTION
**What does this do?**
This updates the forms which were missing the controlled fields from 7.2. It also updates ordering of the fields so that the controlled field is display first in the row.

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1397

This is something I discovered while adding public browser data through the template and realized I never updated the other forms to include these fields.

**How should this be tested? Do these changes have associated tests?**
* Run the devserver
* Create a collectionobject using...
  * inventory template
  * photo template
  * public browser template
  * time based media template
* See that the controlled object name and controlled material fields exist and display first

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested