### PR TITLE
Decrease multiline height for various fields

### DIFF
--- a/src/plugins/recordTypes/acquisition/fields.js
+++ b/src/plugins/recordTypes/acquisition/fields.js
@@ -338,6 +338,7 @@ export default (configContext) => {
                 view: {
                   type: TextInput,
                   props: {
+                    height: 23,
                     multiline: true,
                   },
                 },

--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -152,6 +152,7 @@ export default (configContext) => {
                 view: {
                   type: TextInput,
                   props: {
+                    height: 23,
                     multiline: true,
                   },
                 },

--- a/src/plugins/recordTypes/intake/fields.js
+++ b/src/plugins/recordTypes/intake/fields.js
@@ -339,6 +339,7 @@ export default (configContext) => {
                 view: {
                   type: TextInput,
                   props: {
+                    height: 23,
                     multiline: true,
                   },
                 },

--- a/src/plugins/recordTypes/loanin/fields.js
+++ b/src/plugins/recordTypes/loanin/fields.js
@@ -202,6 +202,7 @@ export default (configContext) => {
                 view: {
                   type: TextInput,
                   props: {
+                    height: 23,
                     multiline: true,
                   },
                 },

--- a/src/plugins/recordTypes/loanout/fields.js
+++ b/src/plugins/recordTypes/loanout/fields.js
@@ -370,6 +370,7 @@ export default (configContext) => {
                 view: {
                   type: TextInput,
                   props: {
+                    height: 23,
                     multiline: true,
                   },
                 },

--- a/src/plugins/recordTypes/objectexit/fields.js
+++ b/src/plugins/recordTypes/objectexit/fields.js
@@ -366,6 +366,7 @@ export default (configContext) => {
                 view: {
                   type: TextInput,
                   props: {
+                    height: 23,
                     multiline: true,
                   },
                 },

--- a/src/plugins/recordTypes/uoc/fields.js
+++ b/src/plugins/recordTypes/uoc/fields.js
@@ -215,6 +215,7 @@ export default (configContext) => {
                 view: {
                   type: TextInput,
                   props: {
+                    height: 23,
                     multiline: true,
                   },
                 },


### PR DESCRIPTION
**What does this do?**
* Set height to 23px for note fields in annotation and status groups

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1284
Jira: https://collectionspace.atlassian.net/browse/DRYD-1285

This is just a small styling tweak requested from feedback. I saw 23px defined in the dimensions for cspace-input and went with that for the size.

**How should this be tested? Do these changes have associated tests?**
* Run the devserver
* View the note field in the following procedures
  * acquisition - approval group
  * collectionobject - annotation group
  * intake - approval group
  * loan in - loan status group
  * loan out - loan status group
  * object exist - deaccession approval group
  * uoc - authorization group

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally