### PR TITLE
DRYD-1395: Make fieldCollectionPlace repeatable

### DIFF
--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -4049,18 +4049,26 @@ export default (configContext) => {
             },
           },
         },
-        fieldCollectionPlace: {
+        fieldCollectionPlaces: {
           [config]: {
-            messages: defineMessages({
-              name: {
-                id: 'field.collectionobjects_common.fieldCollectionPlace.name',
-                defaultMessage: 'Field collection place',
-              },
-            }),
             view: {
-              type: AutocompleteInput,
-              props: {
-                source: 'place/local,place/shared,place/tgn',
+              type: CompoundInput,
+            },
+          },
+          fieldCollectionPlace: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.collectionobjects_common.fieldCollectionPlace.name',
+                  defaultMessage: 'Field collection place',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: AutocompleteInput,
+                props: {
+                  source: 'place/local,place/shared,place/tgn',
+                },
               },
             },
           },

--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -592,7 +592,9 @@ const template = (configContext) => {
               <Field name="fieldCollectionMethod" />
             </Field>
 
-            <Field name="fieldCollectionPlace" />
+            <Field name="fieldCollectionPlaces">
+              <Field name="fieldCollectionPlace" />
+            </Field>
 
             <Field name="fieldCollectionSources">
               <Field name="fieldCollectionSource" />


### PR DESCRIPTION
**What does this do?**
Adds repeating group for fieldCollectionPlace to collectionobject fields and form.

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1395

This updates filedCollectionPlace so that it can be repeatable, which was requested in the associated JIRA.

**How should this be tested? Do these changes have associated tests?**
* Rebuild and start collectionspace
* Run the devserver
* Check that the field collection place shows as repeatable input
* Check that the field collection place can save and load input

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against a local instance