### PR TITLE
Change relation type to associated authority relation

### DIFF
--- a/src/plugins/extensions/associatedAuthority/fields.js
+++ b/src/plugins/extensions/associatedAuthority/fields.js
@@ -76,7 +76,7 @@ export default (configContext) => {
             view: {
               type: TermPickerInput,
               props: {
-                source: 'relationtypetype',
+                source: 'assocauthorityrelationtype',
               },
             },
           },
@@ -208,7 +208,7 @@ export default (configContext) => {
             view: {
               type: TermPickerInput,
               props: {
-                source: 'relationtypetype',
+                source: 'assocauthorityrelationtype',
               },
             },
           },
@@ -340,7 +340,7 @@ export default (configContext) => {
             view: {
               type: TermPickerInput,
               props: {
-                source: 'relationtypetype',
+                source: 'assocauthorityrelationtype',
               },
             },
           },
@@ -472,7 +472,7 @@ export default (configContext) => {
             view: {
               type: TermPickerInput,
               props: {
-                source: 'relationtypetype',
+                source: 'assocauthorityrelationtype',
               },
             },
           },
@@ -608,7 +608,7 @@ export default (configContext) => {
             view: {
               type: TermPickerInput,
               props: {
-                source: 'relationtypetype',
+                source: 'assocauthorityrelationtype',
               },
             },
           },
@@ -740,7 +740,7 @@ export default (configContext) => {
             view: {
               type: TermPickerInput,
               props: {
-                source: 'relationtypetype',
+                source: 'assocauthorityrelationtype',
               },
             },
           },


### PR DESCRIPTION
**What does this do?**
Updates the source for related authorities to use assocauthorityrelationtype

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1286

This changes the term source related authorities to use the new assocauthorityrelationtype.

**How should this be tested? Do these changes have associated tests?**
* Run the devserver
* Create one of chronology, person, or place
* Under Associated Authorities, fill out the form entries and see that the new term list is being populated by assocauthorityrelationtype

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally against core