### PR TITLE
Update focus order for search result page

### DIFF
--- a/src/components/pages/SearchResultPage.jsx
+++ b/src/components/pages/SearchResultPage.jsx
@@ -104,7 +104,6 @@ export default class SearchResultPage extends Component {
     this.renderCheckbox = this.renderCheckbox.bind(this);
     this.renderFooter = this.renderFooter.bind(this);
     this.renderHeader = this.renderHeader.bind(this);
-    this.renderSidebarToggle = this.renderSidebarToggle.bind(this);
     this.search = this.search.bind(this);
 
     this.state = {
@@ -767,16 +766,6 @@ export default class SearchResultPage extends Component {
     return null;
   }
 
-  renderSidebarToggle() {
-    const searchDescriptor = this.getSearchDescriptor();
-    const advancedSearchCondition = searchDescriptor.getIn(['searchQuery', 'as']);
-    return (
-      <div className={sidebarToggleBarStyles.advanced}>
-        <SearchResultSidebarToggleButtonContainer />
-      </div>
-    );
-  }
-
   render() {
     const {
       location,
@@ -880,7 +869,6 @@ export default class SearchResultPage extends Component {
             isOpen={isSidebarOpen}
             recordType={recordType}
             selectedItems={selectedItems}
-            renderSidebarToggle={this.renderSidebarToggle}
           />
         </div>
 

--- a/src/components/pages/SearchResultPage.jsx
+++ b/src/components/pages/SearchResultPage.jsx
@@ -104,6 +104,7 @@ export default class SearchResultPage extends Component {
     this.renderCheckbox = this.renderCheckbox.bind(this);
     this.renderFooter = this.renderFooter.bind(this);
     this.renderHeader = this.renderHeader.bind(this);
+    this.renderSidebarToggle = this.renderSidebarToggle.bind(this);
     this.search = this.search.bind(this);
 
     this.state = {
@@ -766,6 +767,22 @@ export default class SearchResultPage extends Component {
     return null;
   }
 
+  renderSidebarToggle() {
+    const searchDescriptor = this.getSearchDescriptor();
+    const advancedSearchCondition = searchDescriptor.getIn(['searchQuery', 'as']);
+    return (
+      <div
+        className={
+          advancedSearchCondition
+            ? sidebarToggleBarStyles.advanced
+            : sidebarToggleBarStyles.normal
+        }
+      >
+        <SearchResultSidebarToggleButtonContainer />
+      </div>
+    );
+  }
+
   render() {
     const {
       location,
@@ -785,7 +802,6 @@ export default class SearchResultPage extends Component {
     } = this.state;
 
     const searchDescriptor = this.getSearchDescriptor();
-    const advancedSearchCondition = searchDescriptor.getIn(['searchQuery', 'as']);
 
     const listType = this.getListType(searchDescriptor);
 
@@ -847,17 +863,6 @@ export default class SearchResultPage extends Component {
           searchName={SEARCH_RESULT_PAGE_SEARCH_NAME}
           updateDocumentTitle
         />
-
-        <div
-          className={
-            advancedSearchCondition
-              ? sidebarToggleBarStyles.advanced
-              : sidebarToggleBarStyles.normal
-          }
-        >
-          <SearchResultSidebarToggleButtonContainer />
-        </div>
-
         <div className={isSidebarOpen ? pageBodyStyles.common : pageBodyStyles.full}>
           <WatchedSearchResultTableContainer
             config={config}
@@ -881,6 +886,7 @@ export default class SearchResultPage extends Component {
             isOpen={isSidebarOpen}
             recordType={recordType}
             selectedItems={selectedItems}
+            renderSidebarToggle={this.renderSidebarToggle}
           />
         </div>
 

--- a/src/components/pages/SearchResultPage.jsx
+++ b/src/components/pages/SearchResultPage.jsx
@@ -771,13 +771,7 @@ export default class SearchResultPage extends Component {
     const searchDescriptor = this.getSearchDescriptor();
     const advancedSearchCondition = searchDescriptor.getIn(['searchQuery', 'as']);
     return (
-      <div
-        className={
-          advancedSearchCondition
-            ? sidebarToggleBarStyles.advanced
-            : sidebarToggleBarStyles.normal
-        }
-      >
+      <div className={sidebarToggleBarStyles.advanced}>
         <SearchResultSidebarToggleButtonContainer />
       </div>
     );

--- a/src/components/pages/SearchResultPage.jsx
+++ b/src/components/pages/SearchResultPage.jsx
@@ -17,7 +17,6 @@ import SearchResultTitleBar from '../search/SearchResultTitleBar';
 import SelectBar from '../search/SelectBar';
 import ExportModalContainer from '../../containers/search/ExportModalContainer';
 import WatchedSearchResultTableContainer from '../../containers/search/WatchedSearchResultTableContainer';
-import SearchResultSidebarToggleButtonContainer from '../../containers/search/SearchResultSidebarToggleButtonContainer';
 import SearchToRelateModalContainer from '../../containers/search/SearchToRelateModalContainer';
 import { canRelate } from '../../helpers/permissionHelpers';
 import { getListType } from '../../helpers/searchHelpers';
@@ -32,7 +31,6 @@ import {
 
 import styles from '../../../styles/cspace-ui/SearchResultPage.css';
 import pageBodyStyles from '../../../styles/cspace-ui/PageBody.css';
-import sidebarToggleBarStyles from '../../../styles/cspace-ui/SidebarToggleBar.css';
 
 // const stopPropagation = (event) => {
 //   event.stopPropagation();

--- a/src/components/search/SearchResultSidebar.jsx
+++ b/src/components/search/SearchResultSidebar.jsx
@@ -17,6 +17,7 @@ const propTypes = {
   recordType: PropTypes.string,
   isOpen: PropTypes.bool,
   selectedItems: PropTypes.instanceOf(Immutable.Map),
+  renderSidebarToggle: PropTypes.func,
 };
 
 const defaultProps = {
@@ -30,14 +31,23 @@ export default function SearchResultSidebar(props) {
     recordType,
     isOpen,
     selectedItems,
+    renderSidebarToggle,
   } = props;
 
+  const toggle = renderSidebarToggle();
+
   if (!isOpen) {
-    return null;
+    return (
+      <div className={styles.common}>
+        {toggle}
+      </div>
+    );
   }
 
   return (
     <div className={styles.common}>
+      {toggle}
+
       <SearchResultReportPanelContainer
         color={panelColor}
         config={config}

--- a/src/components/search/SearchResultSidebar.jsx
+++ b/src/components/search/SearchResultSidebar.jsx
@@ -3,7 +3,9 @@ import PropTypes from 'prop-types';
 import Immutable from 'immutable';
 import SearchResultBatchPanelContainer from '../../containers/search/SearchResultBatchPanelContainer';
 import SearchResultReportPanelContainer from '../../containers/search/SearchResultReportPanelContainer';
+import SearchResultSidebarToggleButtonContainer from '../../containers/search/SearchResultSidebarToggleButtonContainer';
 import styles from '../../../styles/cspace-ui/SearchResultSidebar.css';
+import sidebarToggleBarStyles from '../../../styles/cspace-ui/SidebarToggleBar.css';
 
 const panelColor = 'black';
 
@@ -17,12 +19,19 @@ const propTypes = {
   recordType: PropTypes.string,
   isOpen: PropTypes.bool,
   selectedItems: PropTypes.instanceOf(Immutable.Map),
-  renderSidebarToggle: PropTypes.func,
 };
 
 const defaultProps = {
   isOpen: true,
 };
+
+function renderSidebarToggle() {
+  return (
+    <div className={sidebarToggleBarStyles.common}>
+      <SearchResultSidebarToggleButtonContainer />
+    </div>
+  );
+}
 
 export default function SearchResultSidebar(props) {
   const {
@@ -31,7 +40,6 @@ export default function SearchResultSidebar(props) {
     recordType,
     isOpen,
     selectedItems,
-    renderSidebarToggle,
   } = props;
 
   const toggle = renderSidebarToggle();

--- a/src/components/search/SearchResultSidebar.jsx
+++ b/src/components/search/SearchResultSidebar.jsx
@@ -38,7 +38,7 @@ export default function SearchResultSidebar(props) {
 
   if (!isOpen) {
     return (
-      <div className={styles.common}>
+      <div className={styles.closed}>
         {toggle}
       </div>
     );

--- a/src/components/search/SearchResultTitleBar.jsx
+++ b/src/components/search/SearchResultTitleBar.jsx
@@ -95,6 +95,7 @@ export default function SearchResultTitleBar(props) {
   }
 
   let advancedTitle;
+  let serviceType = 'searchresult';
 
   if (advancedSearchCondition) {
     advancedTitle = (
@@ -106,6 +107,7 @@ export default function SearchResultTitleBar(props) {
         recordType={recordType}
       />
     );
+    serviceType = 'advancedsearchresult';
   }
 
   const title = (
@@ -125,6 +127,7 @@ export default function SearchResultTitleBar(props) {
       title={title}
       aside={aside}
       subtitle={advancedTitle}
+      serviceType={serviceType}
       {...remainingProps}
     />
   );

--- a/styles/cspace-ui/SearchResultSidebar.css
+++ b/styles/cspace-ui/SearchResultSidebar.css
@@ -1,3 +1,7 @@
 .common {
   width: 30%;
 }
+
+.closed {
+  flex: none;
+}

--- a/styles/cspace-ui/SidebarToggleBar.css
+++ b/styles/cspace-ui/SidebarToggleBar.css
@@ -1,15 +1,11 @@
 @value tabHeight from '../dimensions.css';
 
-.normal {
-  height: tabHeight;
-}
-
-.advanced {
+.common {
   height: 0;
   position: relative;
 }
 
-.advanced > :global(.cspace-ui-SidebarToggleButton--common) {
+.common > :global(.cspace-ui-SidebarToggleButton--common) {
   top: -31px;
   right: 0;
   width: max-content;

--- a/styles/cspace-ui/SidebarToggleBar.css
+++ b/styles/cspace-ui/SidebarToggleBar.css
@@ -12,4 +12,5 @@
 .advanced > :global(.cspace-ui-SidebarToggleButton--common) {
   top: -31px;
   right: 0;
+  width: max-content;
 }

--- a/styles/cspace-ui/TitleBar.css
+++ b/styles/cspace-ui/TitleBar.css
@@ -40,6 +40,10 @@
   text-align: right;
 }
 
+.searchresult {
+  margin-bottom: 31px;
+}
+
 .audit > div > div > aside > h2,
 .object > div > div > aside > h2,
 .procedure > div > div > aside > h2,

--- a/test/specs/components/search/SearchResultSidebar.spec.jsx
+++ b/test/specs/components/search/SearchResultSidebar.spec.jsx
@@ -1,5 +1,10 @@
 import React from 'react';
 import { createRenderer } from 'react-test-renderer/shallow';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { Provider as StoreProvider } from 'react-redux';
+import Immutable from 'immutable';
+import { IntlProvider } from 'react-intl';
 import createTestContainer from '../../../helpers/createTestContainer';
 import { render } from '../../../helpers/renderHelpers';
 import SearchResultSidebar from '../../../../src/components/search/SearchResultSidebar';
@@ -35,15 +40,27 @@ describe('SearchResultSidebar', () => {
     result.type.should.equal('div');
   });
 
-  it('should render nothing if isOpen is false', function test() {
+  it('should only render the sidebar toggle if isOpen is false', function test() {
+    const mockStore = configureMockStore([thunk]);
+    const store = mockStore({
+      prefs: Immutable.Map({
+        searchResultSidebarOpen: false,
+      }),
+    });
+
     render(
-      <SearchResultSidebar
-        config={config}
-        recordType="group"
-        isOpen={false}
-      />, this.container,
+      <IntlProvider locale="en">
+        <StoreProvider store={store}>
+          <SearchResultSidebar
+            config={config}
+            recordType="group"
+            isOpen={false}
+          />
+        </StoreProvider>
+      </IntlProvider>, this.container,
     );
 
-    expect(this.container.firstElementChild).to.equal(null);
+    expect(this.container.querySelector('.cspace-ui-SearchResultSidebar--common')).to.equal(null);
+    this.container.querySelector('.cspace-ui-SearchResultSidebar--closed').textContent.should.equal('Show sidebar');
   });
 });


### PR DESCRIPTION
**What does this do?**
* Render the sidebar toggle button as part of the sidebar
* Update css to keep sidebar styling consistent with previous behavior

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1309

This issue came about from the wcag audit with respect to the logical ordering of elements when tabbing through the page. According to the audit the expected behavior is for the tab input to go through the search result table first, then navigate to the sidebar. The toggle bar for the sidebar was created before the sidebar which caused it to be tabbed to before the search result table, which is out of order according to the audit. 

**How should this be tested? Do these changes have associated tests?**
* Run the devserver
* Test the behavior for a simple search
  * Navigate to the search page and execute a search
  * Tab through the page and see that the order goes from the navbar, to the search results, to the sidebar toggle + sidebar
  * Toggle and untoggle the sidebar and see that the behavior is consistent with dev
* Test the behavior for and advanced search
  * Navigate to the search page and execute an advanced search
  * Tab through the page and see that the order goes from the navbar, to the search results, to the sidebar toggle + sidebar
  * Toggle and untoggle the sidebar and see that the behavior is consistent with dev

**Dependencies for merging? Releasing to production?**
These changes also need to be made for the record page before we can close the Jira, as the issue exists on both pages. I'll add a comment on the ticket as well so that it's notated there.

In addition I believe these changes will be applicable to [DRYD-1295](https://collectionspace.atlassian.net/browse/DRYD-1295) as well because it updates the DOM to be ordered correctly. I still need to download NVDA and test screen reading.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally