### PR TITLE
DRYD-1417: Go to UI authorize page after password reset success.

### DIFF
--- a/src/components/pages/service/PasswordResetPage.jsx
+++ b/src/components/pages/service/PasswordResetPage.jsx
@@ -90,12 +90,15 @@ const propTypes = {
   csrf: PropTypes.object,
   intl: intlShape.isRequired,
   tenantId: PropTypes.string,
+  tenantLoginUrl: PropTypes.string,
   token: PropTypes.string.isRequired,
 };
 
 const defaultProps = {
   csrf: null,
   tenantId: null,
+  // If we don't receive a tenant-specific login URL, default to the services login page.
+  tenantLoginUrl: '/cspace-services/login',
 };
 
 function PasswordResetPage(props) {
@@ -103,6 +106,7 @@ function PasswordResetPage(props) {
     csrf,
     intl,
     tenantId,
+    tenantLoginUrl,
     token,
   } = props;
 
@@ -175,7 +179,7 @@ function PasswordResetPage(props) {
           setError(null);
 
           const loginLink = (
-            <a href="../login">
+            <a href={tenantLoginUrl}>
               <FormattedMessage {...messages.loginLink} />
             </a>
           );

--- a/src/service.jsx
+++ b/src/service.jsx
@@ -42,6 +42,7 @@ export default (uiConfig) => {
     messages,
     sso,
     tenantId,
+    tenantLoginUrl,
     token,
   } = config;
 
@@ -116,6 +117,7 @@ export default (uiConfig) => {
                   <PasswordResetPage
                     csrf={csrf}
                     tenantId={tenantId}
+                    tenantLoginUrl={tenantLoginUrl}
                     token={token}
                   />
                 )}


### PR DESCRIPTION
**What does this do?**

This changes the "Sign in" link displayed after a successful password reset to go to a tenant-specific URL supplied as a prop, instead of the service layer login page at `/cspace-services/login`. Typically, the prop should be set to the UI page that initiates an OAuth authorization attempt for the tenant, e.g. `/cspace/{tenant short name}/authorize`. 

If the prop is not provided, `/cspace-services/login` is used as a fallback.

**Why are we doing this? (with JIRA link)**

After a password reset, a new OAuth authorization attempt should be started by going to the appropriate page in the UI, which will redirect to `/cspace-services/login` after setting up the correct state. Going directly to `/cspace-services/login` may pick up the state from a previous failed authorization attempt that may have been started in another browser tab/window. The current tab/window won't know about the state from the other tab/window, which would cause an error.

JIRA: https://collectionspace.atlassian.net/browse/DRYD-1417

**How should this be tested? Do these changes have associated tests?**

See the reproduction steps in the above JIRA.

**Dependencies for merging? Releasing to production?**

This works in tandem with https://github.com/collectionspace/services/pull/408 to fix DRYD-1417, but doesn't break anything further if that PR has not been merged.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee tested locally.