### PR TITLE
Update DutyOfCare authority sources

### DIFF
--- a/src/plugins/recordTypes/dutyofcare/fields.js
+++ b/src/plugins/recordTypes/dutyofcare/fields.js
@@ -198,7 +198,7 @@ export default (configContext) => {
                 view: {
                   type: AutocompleteInput,
                   props: {
-                    source: 'person/local,organization/local',
+                    source: 'person/local,person/ulan,organization/local,organization/ulan',
                   },
                 },
               },
@@ -280,7 +280,7 @@ export default (configContext) => {
                 view: {
                   type: AutocompleteInput,
                   props: {
-                    source: 'person/local',
+                    source: 'person/local,person/ulan',
                   },
                 },
               },
@@ -300,7 +300,7 @@ export default (configContext) => {
                 view: {
                   type: AutocompleteInput,
                   props: {
-                    source: 'organization/local',
+                    source: 'organization/local,organization/ulan',
                   },
                 },
               },


### PR DESCRIPTION
**What does this do?**
*Adds ulan sources to various authorities

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1332

I had staged these changes but forgot to add them when making the PR. This allows the fields which use the person and organization authorities to use the ulan authorities.

**How should this be tested? Do these changes have associated tests?**
* Run the devserver
  * npm run devserver --back-end=https://core.dev.collectionspace.org
* When creating a duty of care, see that the party, on behalf of, and determined by fields pull from the local and ulan authority types

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against core.dev