### PR TITLE
DRYD-1333: Summary Documentation

### DIFF
--- a/src/plugins/recordTypes/index.js
+++ b/src/plugins/recordTypes/index.js
@@ -40,6 +40,7 @@ import relation from './relation';
 import report from './report';
 import reportinvocation from './reportinvocation';
 import structdateparser from './structdateparser';
+import summarydocumentation from './summarydocumentation';
 import transport from './transport';
 import uoc from './uoc';
 import valuation from './valuation';
@@ -91,6 +92,7 @@ export default [
   report,
   reportinvocation,
   structdateparser,
+  summarydocumentation,
   valuation,
   vocabulary,
   work,

--- a/src/plugins/recordTypes/summarydocumentation/advancedSearch.js
+++ b/src/plugins/recordTypes/summarydocumentation/advancedSearch.js
@@ -1,0 +1,21 @@
+export default (configContext) => {
+  const {
+    OP_CONTAIN,
+  } = configContext.searchOperators;
+
+  const {
+    defaultAdvancedSearchBooleanOp,
+    extensions,
+  } = configContext.config;
+
+  return {
+    op: defaultAdvancedSearchBooleanOp,
+    value: [
+      {
+        op: OP_CONTAIN,
+        path: 'ns2:summarydocumentations_common/documentationCommon',
+      },
+      ...extensions.core.advancedSearch,
+    ],
+  };
+};

--- a/src/plugins/recordTypes/summarydocumentation/advancedSearch.js
+++ b/src/plugins/recordTypes/summarydocumentation/advancedSearch.js
@@ -13,7 +13,7 @@ export default (configContext) => {
     value: [
       {
         op: OP_CONTAIN,
-        path: 'ns2:summarydocumentations_common/documentationCommon',
+        path: 'ns2:summarydocumentations_common/documentationNumber',
       },
       ...extensions.core.advancedSearch,
     ],

--- a/src/plugins/recordTypes/summarydocumentation/columns.js
+++ b/src/plugins/recordTypes/summarydocumentation/columns.js
@@ -1,0 +1,46 @@
+import { defineMessages } from 'react-intl';
+
+export default (configContext) => {
+  const {
+    formatTimestamp,
+  } = configContext.formatHelpers;
+
+  return {
+    default: {
+      referenceNumber: {
+        messages: defineMessages({
+          label: {
+            id: 'column.summarydocumentation.default.documentationNumber',
+            defaultMessage: 'Summary number',
+          },
+        }),
+        order: 10,
+        sortBy: 'summarydocumentations_common:documentationNumber',
+        width: 200,
+      },
+      title: {
+        messages: defineMessages({
+          label: {
+            id: 'column.summarydocumentation.default.title',
+            defaultMessage: 'Title',
+          },
+        }),
+        order: 20,
+        sortBy: 'summarydocumentations_common:titles/title/0',
+        width: 200,
+      },
+      updatedAt: {
+        formatValue: formatTimestamp,
+        messages: defineMessages({
+          label: {
+            id: 'column.summarydocumentation.default.updatedAt',
+            defaultMessage: 'Updated',
+          },
+        }),
+        order: 30,
+        sortBy: 'collectionspace_core:updatedAt',
+        width: 150,
+      },
+    },
+  };
+};

--- a/src/plugins/recordTypes/summarydocumentation/fields.js
+++ b/src/plugins/recordTypes/summarydocumentation/fields.js
@@ -1,0 +1,777 @@
+import { defineMessages } from 'react-intl';
+
+export default (configContext) => {
+  const {
+    AutocompleteInput,
+    CompoundInput,
+    DateInput,
+    IDGeneratorInput,
+    TextInput,
+    TermPickerInput,
+  } = configContext.inputComponents;
+
+  const {
+    configKey: config,
+  } = configContext.configHelpers;
+
+  const {
+    DATA_TYPE_DATE,
+  } = configContext.dataTypes;
+
+  const {
+    extensions,
+  } = configContext.config;
+
+  const {
+    validateNotInUse,
+  } = configContext.validationHelpers;
+
+  return {
+    document: {
+      [config]: {
+        view: {
+          type: CompoundInput,
+          props: {
+            defaultChildSubpath: 'ns2:summarydocumentations_common',
+          },
+        },
+      },
+      ...extensions.core.fields,
+      'ns2:summarydocumentations_common': {
+        [config]: {
+          service: {
+            ns: 'http://collectionspace.org/services/summarydocumentation',
+          },
+        },
+        documentationNumber: {
+          [config]: {
+            cloneable: false,
+            messages: defineMessages({
+              inUse: {
+                id: 'field.summarydocumentations_common.documentationNumber.inUse',
+                defaultMessage: 'The identification number {value} is in use by another record.',
+              },
+              name: {
+                id: 'field.summarydocumentations_common.documentationNumber.name',
+                defaultMessage: 'Summary/documentation number',
+              },
+            }),
+            required: true,
+            searchView: {
+              type: TextInput,
+            },
+            validate: (validationContext) => validateNotInUse({
+              configContext,
+              validationContext,
+              fieldName: 'summarydocumentations_common:documentationNumber',
+            }),
+            view: {
+              type: IDGeneratorInput,
+              props: {
+                source: 'summarydocumentation',
+              },
+            },
+          },
+        },
+        originationDate: {
+          [config]: {
+            dataType: DATA_TYPE_DATE,
+            messages: defineMessages({
+              name: {
+                id: 'field.summarydocumentations_common.originationDate.name',
+                defaultMessage: 'Origination date',
+              },
+            }),
+            view: {
+              type: DateInput,
+            },
+          },
+        },
+        titles: {
+          [config]: {
+            view: {
+              type: CompoundInput,
+            },
+          },
+          title: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.summarydocumentations_common.title.name',
+                  defaultMessage: 'Title',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: TextInput,
+              },
+            },
+          },
+        },
+        types: {
+          [config]: {
+            view: {
+              type: CompoundInput,
+            },
+          },
+          type: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.summarydocumentations_common.type.name',
+                  defaultMessage: 'Type',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: TermPickerInput,
+                props: {
+                  source: 'summarydocumentationtype',
+                },
+              },
+            },
+          },
+        },
+        consultationNotes: {
+          [config]: {
+            view: {
+              type: CompoundInput,
+            },
+          },
+          consultationNote: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.summarydocumentations_common.consultationNote.name',
+                  defaultMessage: 'Consultation note',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: TextInput,
+                props: {
+                  multiline: true,
+                },
+              },
+            },
+          },
+        },
+        treatmentNotes: {
+          [config]: {
+            view: {
+              type: CompoundInput,
+            },
+          },
+          treatmentNote: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.summarydocumentations_common.treatmentNote.name',
+                  defaultMessage: 'Treatment note',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: TextInput,
+                props: {
+                  multiline: true,
+                },
+              },
+            },
+          },
+        },
+        partiesInvolvedGroupList: {
+          [config]: {
+            view: {
+              type: CompoundInput,
+            },
+          },
+          partiesInvolvedGroup: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.summarydocumentations_common.partiesInvolvedGroup.name',
+                  defaultMessage: 'Party involved',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: CompoundInput,
+                props: {
+                  tabular: true,
+                },
+              },
+            },
+            involvedParty: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.summarydocumentations_common.involvedParty.fullName',
+                    defaultMessage: 'Party involved name',
+                  },
+                  name: {
+                    id: 'field.summarydocumentations_common.involvedParty.name',
+                    defaultMessage: 'Name',
+                  },
+                }),
+                view: {
+                  type: AutocompleteInput,
+                  props: {
+                    source: 'person/local,person/ulan',
+                  },
+                },
+              },
+            },
+            involvedOnBehalfOf: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.summarydocumentations_common.involvedOnBehalfOf.fullName',
+                    defaultMessage: 'Party involved on behalf of',
+                  },
+                  name: {
+                    id: 'field.summarydocumentations_common.involvedOnBehalfOf.name',
+                    defaultMessage: 'On behalf of',
+                  },
+                }),
+                view: {
+                  type: AutocompleteInput,
+                  props: {
+                    source: 'organization/local,organization/ulan',
+                  },
+                },
+              },
+            },
+            involvedRole: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.summarydocumentations_common.involvedRole.fullName',
+                    defaultMessage: 'Party involved role',
+                  },
+                  name: {
+                    id: 'field.summarydocumentations_common.involvedRole.name',
+                    defaultMessage: 'Role',
+                  },
+                }),
+                view: {
+                  type: TermPickerInput,
+                  props: {
+                    source: 'nagprainvolvedrole',
+                  },
+                },
+              },
+            },
+          },
+        },
+        culturalAffiliationGroupList: {
+          [config]: {
+            view: {
+              type: CompoundInput,
+            },
+          },
+          culturalAffiliationGroup: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.summarydocumentations_common.culturalAffiliationGroup.name',
+                  defaultMessage: 'Summary affiliation',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: CompoundInput,
+              },
+            },
+            tribeOrNation: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.summarydocumentations_common.tribeOrNation.fullName',
+                    defaultMessage: 'Summary affiliation tribe',
+                  },
+                  name: {
+                    id: 'field.summarydocumentations_common.tribeOrNation.name',
+                    defaultMessage: 'Tribe',
+                  },
+                }),
+                view: {
+                  type: AutocompleteInput,
+                  props: {
+                    source: 'organization/local,organization/ulan',
+                  },
+                },
+              },
+            },
+            includeInNotice: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.summarydocumentations_common.includeInNotice.fullName',
+                    defaultMessage: 'Summary affiliation include in notice',
+                  },
+                  name: {
+                    id: 'field.summarydocumentations_common.includeInNotice.name',
+                    defaultMessage: 'Include in notice',
+                  },
+                }),
+                view: {
+                  type: TermPickerInput,
+                  props: {
+                    source: 'nagpranotice',
+                  },
+                },
+              },
+            },
+            determinedByList: {
+              [config]: {
+                view: {
+                  type: CompoundInput,
+                },
+              },
+              determinedBy: {
+                [config]: {
+                  messages: defineMessages({
+                    fullName: {
+                      id: 'field.summarydocumentations_common.determinedBy.fullName',
+                      defaultMessage: 'Summary affiliation determined by',
+                    },
+                    name: {
+                      id: 'field.summarydocumentations_common.determinedBy.name',
+                      defaultMessage: 'Determined by',
+                    },
+                  }),
+                  repeating: true,
+                  view: {
+                    type: AutocompleteInput,
+                    props: {
+                      source: 'person/local,person/ulan,organization/local,organization/ulan',
+                    },
+                  },
+                },
+              },
+            },
+            determinationDate: {
+              [config]: {
+                dataType: DATA_TYPE_DATE,
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.summarydocumentations_common.determinationDate.fullName',
+                    defaultMessage: 'Summary affiliation determination date',
+                  },
+                  name: {
+                    id: 'field.summarydocumentations_common.determinationDate.name',
+                    defaultMessage: 'Determination date',
+                  },
+                }),
+                view: {
+                  type: DateInput,
+                },
+              },
+            },
+            basisOfDetermination: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.summarydocumentations_common.basisOfDetermination.fullName',
+                    defaultMessage: 'Summary affiliation basis of determination',
+                  },
+                  name: {
+                    id: 'field.summarydocumentations_common.basisOfDetermination.name',
+                    defaultMessage: 'Basis of determination',
+                  },
+                }),
+                view: {
+                  type: TextInput,
+                  props: {
+                    multiline: true,
+                  },
+                },
+              },
+            },
+            determinationNote: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.summarydocumentations_common.determinationNote.fullName',
+                    defaultMessage: 'Summary affiliation determination note',
+                  },
+                  name: {
+                    id: 'field.summarydocumentations_common.determinationNote.name',
+                    defaultMessage: 'Determination note',
+                  },
+                }),
+                view: {
+                  type: TextInput,
+                  props: {
+                    multiline: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+        statusGroupList: {
+          [config]: {
+            view: {
+              type: CompoundInput,
+            },
+          },
+          statusGroup: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.summarydocumentations_common.statusGroup.name',
+                  defaultMessage: 'Summary status',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: CompoundInput,
+              },
+            },
+            statusGroupType: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.summarydocumentations_common.statusGroupType.fullName',
+                    defaultMessage: 'Summary status group',
+                  },
+                  name: {
+                    id: 'field.summarydocumentations_common.statusGroupType.name',
+                    defaultMessage: 'Group',
+                  },
+                }),
+                view: {
+                  type: TextInput,
+                },
+              },
+            },
+            statusIndividual: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.summarydocumentations_common.statusIndividual.fullName',
+                    defaultMessage: 'Summary status individual',
+                  },
+                  name: {
+                    id: 'field.summarydocumentations_common.statusIndividual.name',
+                    defaultMessage: 'Individual',
+                  },
+                }),
+                view: {
+                  type: AutocompleteInput,
+                  props: {
+                    source: 'person/local,person/ulan',
+                  },
+                },
+              },
+            },
+            status: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.summarydocumentations_common.status.fullName',
+                    defaultMessage: 'Summary status',
+                  },
+                  name: {
+                    id: 'field.summarydocumentations_common.status.name',
+                    defaultMessage: 'Status',
+                  },
+                }),
+                view: {
+                  type: TermPickerInput,
+                  props: {
+                    source: 'nagprastatus',
+                  },
+                },
+              },
+            },
+            statusDate: {
+              [config]: {
+                dataType: DATA_TYPE_DATE,
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.summarydocumentations_common.statusDate.fullName',
+                    defaultMessage: 'Summary status date',
+                  },
+                  name: {
+                    id: 'field.summarydocumentations_common.statusDate.name',
+                    defaultMessage: 'Date',
+                  },
+                }),
+                view: {
+                  type: DateInput,
+                },
+              },
+            },
+            statusNote: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.summarydocumentations_common.statusNote.fullName',
+                    defaultMessage: 'Summary status note',
+                  },
+                  name: {
+                    id: 'field.summarydocumentations_common.statusNote.name',
+                    defaultMessage: 'Note',
+                  },
+                }),
+                view: {
+                  type: TextInput,
+                  props: {
+                    multiline: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+        geographicPlaceGroupList: {
+          [config]: {
+            view: {
+              type: CompoundInput,
+            },
+          },
+          geographicPlaceGroup: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.summarydocumentations_common.geographicPlaceGroup.name',
+                  defaultMessage: 'Place represented',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: CompoundInput,
+                props: {
+                  tabular: true,
+                },
+              },
+            },
+            geographicPlace: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.summarydocumentations_common.geographicPlace.fullName',
+                    defaultMessage: 'Place represented name',
+                  },
+                  name: {
+                    id: 'field.summarydocumentations_common.geographicPlace.name',
+                    defaultMessage: 'Name',
+                  },
+                }),
+                view: {
+                  type: AutocompleteInput,
+                  props: {
+                    source: 'place/local,place/tgn',
+                  },
+                },
+              },
+            },
+            geographicPlaceNote: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.summarydocumentations_common.geographicPlaceNote.fullName',
+                    defaultMessage: 'Place represented note',
+                  },
+                  name: {
+                    id: 'field.summarydocumentations_common.geographicPlaceNote.name',
+                    defaultMessage: 'Note',
+                  },
+                }),
+                view: {
+                  type: TextInput,
+                },
+              },
+            },
+          },
+        },
+        timePeriodGroupList: {
+          [config]: {
+            view: {
+              type: CompoundInput,
+            },
+          },
+          timePeriodGroup: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.summarydocumentations_common.timePeriodGroup.name',
+                  defaultMessage: 'Time period',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: CompoundInput,
+                props: {
+                  tabular: true,
+                },
+              },
+            },
+            timePeriod: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.summarydocumentations_common.timePeriod.fullName',
+                    defaultMessage: 'Time period era',
+                  },
+                  name: {
+                    id: 'field.summarydocumentations_common.timePeriod.name',
+                    defaultMessage: 'Era',
+                  },
+                }),
+                view: {
+                  type: AutocompleteInput,
+                  props: {
+                    source: 'chronology/era',
+                  },
+                },
+              },
+            },
+            timePeriodNote: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.summarydocumentations_common.timePeriodNote.fullName',
+                    defaultMessage: 'Time period note',
+                  },
+                  name: {
+                    id: 'field.summarydocumentations_common.timePeriodNote.name',
+                    defaultMessage: 'Note',
+                  },
+                }),
+                view: {
+                  type: TextInput,
+                },
+              },
+            },
+          },
+        },
+        culturalGroupList: {
+          [config]: {
+            view: {
+              type: CompoundInput,
+            },
+          },
+          culturalGroup: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.summarydocumentations_common.culturalGroup.name',
+                  defaultMessage: 'Cultural group',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: CompoundInput,
+                props: {
+                  tabular: true,
+                },
+              },
+            },
+            culture: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.summarydocumentations_common.culture.fullName',
+                    defaultMessage: 'Cultural group name',
+                  },
+                  name: {
+                    id: 'field.summarydocumentations_common.culture.name',
+                    defaultMessage: 'Name',
+                  },
+                }),
+                view: {
+                  type: AutocompleteInput,
+                  props: {
+                    source: 'concept/ethculture',
+                  },
+                },
+              },
+            },
+            cultureNote: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.summarydocumentations_common.cultureNote.fullName',
+                    defaultMessage: 'Cultural group note',
+                  },
+                  name: {
+                    id: 'field.summarydocumentations_common.cultureNote.name',
+                    defaultMessage: 'Note',
+                  },
+                }),
+                view: {
+                  type: TextInput,
+                },
+              },
+            },
+          },
+        },
+        archaeologicalSiteGroupList: {
+          [config]: {
+            view: {
+              type: CompoundInput,
+            },
+          },
+          archaeologicalSiteGroup: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.summarydocumentations_common.archaeologicalSiteGroup.name',
+                  defaultMessage: 'Archaeological site',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: CompoundInput,
+                props: {
+                  tabular: true,
+                },
+              },
+            },
+            archaeologicalSite: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.summarydocumentations_common.archaeologicalSite.fullName',
+                    defaultMessage: 'Archaeological site name',
+                  },
+                  name: {
+                    id: 'field.summarydocumentations_common.archaeologicalSite.name',
+                    defaultMessage: 'Name',
+                  },
+                }),
+                view: {
+                  type: AutocompleteInput,
+                  props: {
+                    source: 'place/archaeological',
+                  },
+                },
+              },
+            },
+            archaeologicalSiteNote: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.summarydocumentations_common.archaeologicalSiteNote.fullName',
+                    defaultMessage: 'Archaeological site note',
+                  },
+                  name: {
+                    id: 'field.summarydocumentations_common.archaeologicalSiteNote.name',
+                    defaultMessage: 'Note',
+                  },
+                }),
+                view: {
+                  type: TextInput,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+};

--- a/src/plugins/recordTypes/summarydocumentation/forms/default.jsx
+++ b/src/plugins/recordTypes/summarydocumentation/forms/default.jsx
@@ -1,0 +1,128 @@
+import { defineMessages } from 'react-intl';
+
+const template = (configContext) => {
+  const {
+    React,
+  } = configContext.lib;
+
+  const {
+    Col,
+    Cols,
+    Panel,
+    Row,
+  } = configContext.layoutComponents;
+
+  const {
+    Field,
+  } = configContext.recordComponents;
+
+  return (
+    <Field name="document">
+      <Panel name="info" collapsible>
+        <Cols>
+          <Col>
+            <Field name="documentationNumber" />
+            <Field name="titles">
+              <Field name="title" />
+            </Field>
+            <Field name="types">
+              <Field name="type" />
+            </Field>
+          </Col>
+          <Col>
+            <Field name="originationDate" />
+            <Field name="consultationNotes">
+              <Field name="consultationNote" />
+            </Field>
+            <Field name="treatmentNotes">
+              <Field name="treatmentNote" />
+            </Field>
+          </Col>
+        </Cols>
+
+        <Field name="partiesInvolvedGroupList">
+          <Field name="partiesInvolvedGroup">
+            <Field name="involvedParty" />
+            <Field name="involvedOnBehalfOf" />
+            <Field name="involvedRole" />
+          </Field>
+        </Field>
+
+        <Field name="culturalAffiliationGroupList">
+          <Field name="culturalAffiliationGroup">
+            <Panel>
+              <Row>
+                <Field name="tribeOrNation" />
+                <Field name="includeInNotice" />
+                <Field name="determinedByList">
+                  <Field name="determinedBy" />
+                </Field>
+                <Field name="determinationDate" />
+              </Row>
+              <Field name="basisOfDetermination" />
+              <Field name="determinationNote" />
+            </Panel>
+          </Field>
+        </Field>
+
+        <Field name="statusGroupList">
+          <Field name="statusGroup">
+            <Panel>
+              <Row>
+                <Field name="statusGroupType" />
+                <Field name="statusIndividual" />
+                <Field name="status" />
+                <Field name="statusDate" />
+              </Row>
+              <Field name="statusNote" />
+            </Panel>
+          </Field>
+        </Field>
+
+      </Panel>
+
+      <Panel name="context" collapsible collapsed>
+        <Cols>
+          <Col>
+            <Field name="geographicPlaceGroupList">
+              <Field name="geographicPlaceGroup">
+                <Field name="geographicPlace" />
+                <Field name="geographicPlaceNote" />
+              </Field>
+            </Field>
+            <Field name="culturalGroupList">
+              <Field name="culturalGroup">
+                <Field name="culture" />
+                <Field name="cultureNote" />
+              </Field>
+            </Field>
+          </Col>
+          <Col>
+            <Field name="timePeriodGroupList">
+              <Field name="timePeriodGroup">
+                <Field name="timePeriod" />
+                <Field name="timePeriodNote" />
+              </Field>
+            </Field>
+            <Field name="archaeologicalSiteGroupList">
+              <Field name="archaeologicalSiteGroup">
+                <Field name="archaeologicalSite" />
+                <Field name="archaeologicalSiteNote" />
+              </Field>
+            </Field>
+          </Col>
+        </Cols>
+      </Panel>
+    </Field>
+  );
+};
+
+export default (configContext) => ({
+  messages: defineMessages({
+    name: {
+      id: 'form.summarydocumentation.default.name',
+      defaultMessage: 'Standard Template',
+    },
+  }),
+  template: template(configContext),
+});

--- a/src/plugins/recordTypes/summarydocumentation/forms/index.js
+++ b/src/plugins/recordTypes/summarydocumentation/forms/index.js
@@ -1,0 +1,5 @@
+import defaultForm from './default';
+
+export default (configContext) => ({
+  default: defaultForm(configContext),
+});

--- a/src/plugins/recordTypes/summarydocumentation/idGenerators.js
+++ b/src/plugins/recordTypes/summarydocumentation/idGenerators.js
@@ -1,0 +1,13 @@
+import { defineMessages } from 'react-intl';
+
+export default {
+  summarydocumentation: {
+    csid: '54ab6096-11e0-44a3-9a41-06a87c1c1bdb',
+    messages: defineMessages({
+      type: {
+        id: 'idGenerator.summarydocumentation.type',
+        defaultMessage: 'Summary documentation',
+      },
+    }),
+  },
+};

--- a/src/plugins/recordTypes/summarydocumentation/index.js
+++ b/src/plugins/recordTypes/summarydocumentation/index.js
@@ -1,0 +1,23 @@
+import advancedSearch from './advancedSearch';
+import columns from './columns';
+import fields from './fields';
+import forms from './forms';
+import idGenerators from './idGenerators';
+import messages from './messages';
+import serviceConfig from './serviceConfig';
+import title from './title';
+
+export default () => (configContext) => ({
+  idGenerators,
+  recordTypes: {
+    summarydocumentation: {
+      messages,
+      serviceConfig,
+      advancedSearch: advancedSearch(configContext),
+      columns: columns(configContext),
+      fields: fields(configContext),
+      forms: forms(configContext),
+      title: title(configContext),
+    },
+  },
+});

--- a/src/plugins/recordTypes/summarydocumentation/messages.js
+++ b/src/plugins/recordTypes/summarydocumentation/messages.js
@@ -1,0 +1,26 @@
+import { defineMessages } from 'react-intl';
+
+export default {
+  record: defineMessages({
+    name: {
+      id: 'record.summarydocumentation.name',
+      description: 'The name of the record type',
+      defaultMessage: 'Summary Documentation',
+    },
+    collectionName: {
+      id: 'record.summarydocumentation.collectionName',
+      description: 'The name of a collection of records of the type.',
+      defaultMessage: 'Summary Documentations',
+    },
+  }),
+  panel: defineMessages({
+    info: {
+      id: 'panel.summarydocumentation.info',
+      defaultMessage: 'Summary Documentation Information',
+    },
+    context: {
+      id: 'panel.summarydocumentation.context',
+      defaultMessage: 'Context',
+    },
+  }),
+};

--- a/src/plugins/recordTypes/summarydocumentation/serviceConfig.js
+++ b/src/plugins/recordTypes/summarydocumentation/serviceConfig.js
@@ -1,0 +1,8 @@
+export default {
+  serviceName: 'SummaryDocumentation',
+  servicePath: 'summarydocumentations',
+  serviceType: 'procedure',
+
+  objectName: 'SummaryDocumentation',
+  documentName: 'summarydocumentations',
+};

--- a/src/plugins/recordTypes/summarydocumentation/title.js
+++ b/src/plugins/recordTypes/summarydocumentation/title.js
@@ -1,0 +1,21 @@
+export default (configContext) => (data) => {
+  const {
+    deepGet,
+    getPart,
+  } = configContext.recordDataHelpers;
+
+  if (!data) {
+    return '';
+  }
+
+  const common = getPart(data, 'summarydocumentations_common');
+
+  if (!common) {
+    return '';
+  }
+
+  const referenceNumber = common.get('documentationNumber');
+  const title = deepGet(common, ['titles', 'title', '0']);
+
+  return [referenceNumber, title].filter((part) => !!part).join(' – ');
+};

--- a/test/specs/plugins/recordTypes/summarydocumentation/advancedSearch.spec.js
+++ b/test/specs/plugins/recordTypes/summarydocumentation/advancedSearch.spec.js
@@ -1,0 +1,16 @@
+import createConfigContext from '../../../../../src/helpers/createConfigContext';
+import advancedSearch from '../../../../../src/plugins/recordTypes/summarydocumentation/advancedSearch';
+
+chai.should();
+
+describe('summarydocumentation record advanced search', () => {
+  const configContext = createConfigContext();
+
+  it('should contain a top level property `op`', () => {
+    advancedSearch(configContext).should.have.property('op');
+  });
+
+  it('should contain a top level property `value` that is an array', () => {
+    advancedSearch(configContext).should.have.property('value').that.is.an('array');
+  });
+});

--- a/test/specs/plugins/recordTypes/summarydocumentation/columns.spec.js
+++ b/test/specs/plugins/recordTypes/summarydocumentation/columns.spec.js
@@ -1,0 +1,15 @@
+import summaryDocumentationRecordTypePluginFactory from '../../../../../src/plugins/recordTypes/summarydocumentation';
+import createColumns from '../../../../../src/plugins/recordTypes/summarydocumentation/columns';
+import createConfigContext from '../../../../../src/helpers/createConfigContext';
+
+chai.should();
+
+describe('summarydocumentation record columns', () => {
+  const summaryDocumentationRecordTypePlugin = summaryDocumentationRecordTypePluginFactory({});
+  const configContext = createConfigContext(summaryDocumentationRecordTypePlugin);
+  const columns = createColumns(configContext);
+
+  it('should have the correct shape', () => {
+    columns.should.have.property('default').that.is.an('object');
+  });
+});

--- a/test/specs/plugins/recordTypes/summarydocumentation/forms/default.spec.js
+++ b/test/specs/plugins/recordTypes/summarydocumentation/forms/default.spec.js
@@ -1,0 +1,14 @@
+import Field from '../../../../../../src/components/record/Field';
+import form from '../../../../../../src/plugins/recordTypes/summarydocumentation/forms/default';
+import createConfigContext from '../../../../../../src/helpers/createConfigContext';
+
+chai.should();
+
+describe('summarydocumentation record default form', () => {
+  it('should be a Field', () => {
+    const configContext = createConfigContext();
+    const { template } = form(configContext);
+
+    template.type.should.equal(Field);
+  });
+});

--- a/test/specs/plugins/recordTypes/summarydocumentation/index.spec.js
+++ b/test/specs/plugins/recordTypes/summarydocumentation/index.spec.js
@@ -1,0 +1,28 @@
+import summaryDocumentationRecordTypePluginFactory from '../../../../../src/plugins/recordTypes/summarydocumentation';
+import createConfigContext from '../../../../../src/helpers/createConfigContext';
+
+chai.should();
+
+describe('summarydocumentation record plugin', () => {
+  const config = {};
+  const summaryDocumentationRecordTypePlugin = summaryDocumentationRecordTypePluginFactory(config);
+  const configContext = createConfigContext(summaryDocumentationRecordTypePlugin);
+
+  it('should have the correct shape', () => {
+    const pluginConfiguration = summaryDocumentationRecordTypePlugin(configContext);
+
+    const {
+      recordTypes,
+    } = pluginConfiguration;
+
+    recordTypes.should.have.property('summarydocumentation');
+
+    const summaryDocumentationRecordType = recordTypes.summarydocumentation;
+
+    summaryDocumentationRecordType.should.have.property('title').that.is.a('function');
+    summaryDocumentationRecordType.should.have.property('forms').that.is.an('object');
+    summaryDocumentationRecordType.should.have.property('messages').that.is.an('object');
+    summaryDocumentationRecordType.should.have.property('serviceConfig').that.is.an('object');
+    summaryDocumentationRecordType.title().should.be.a('string');
+  });
+});

--- a/test/specs/plugins/recordTypes/summarydocumentation/messages.spec.js
+++ b/test/specs/plugins/recordTypes/summarydocumentation/messages.spec.js
@@ -1,0 +1,17 @@
+import messages from '../../../../../src/plugins/recordTypes/summarydocumentation/messages';
+
+chai.should();
+
+describe('summarydocumentation record messages', () => {
+  it('should contain properties with an id and defaultMessage properties', () => {
+    messages.should.be.an('object');
+
+    Object.keys(messages).forEach((summarydocumentationName) => {
+      const summarydocumentationMessages = messages[summarydocumentationName];
+
+      Object.keys(summarydocumentationMessages).forEach((name) => {
+        summarydocumentationMessages[name].should.contain.all.keys(['id', 'defaultMessage']);
+      });
+    });
+  });
+});

--- a/test/specs/plugins/recordTypes/summarydocumentation/serviceConfig.spec.js
+++ b/test/specs/plugins/recordTypes/summarydocumentation/serviceConfig.spec.js
@@ -1,0 +1,13 @@
+import serviceConfig from '../../../../../src/plugins/recordTypes/summarydocumentation/serviceConfig';
+
+chai.should();
+
+describe('summarydocumentation record serviceConfig', () => {
+  it('should have a servicePath property', () => {
+    serviceConfig.should.have.property('servicePath').that.is.a('string');
+    serviceConfig.should.have.property('serviceName').that.is.a('string');
+    serviceConfig.should.have.property('serviceType').that.is.a('string');
+    serviceConfig.should.have.property('objectName').that.is.a('string');
+    serviceConfig.should.have.property('documentName').that.is.a('string');
+  });
+});

--- a/test/specs/plugins/recordTypes/summarydocumentation/title.spec.js
+++ b/test/specs/plugins/recordTypes/summarydocumentation/title.spec.js
@@ -1,0 +1,68 @@
+import Immutable from 'immutable';
+import createTitleGetter from '../../../../../src/plugins/recordTypes/summarydocumentation/title';
+import createConfigContext from '../../../../../src/helpers/createConfigContext';
+
+chai.should();
+
+describe('summarydocumentation record title', () => {
+  const configContext = createConfigContext();
+  const title = createTitleGetter(configContext);
+
+  it('should return the summarydocumentation number and title when both are present', () => {
+    const data = Immutable.fromJS({
+      document: {
+        'ns2:summarydocumentations_common': {
+          documentationNumber: 'SD',
+          titles: {
+            title: ['Title', 'AltTitle'],
+          },
+        },
+      },
+    });
+
+    title(data).should.equal('SD – Title');
+  });
+
+  it('should return the summarydocumentation number only when the title is missing', () => {
+    const data = Immutable.fromJS({
+      document: {
+        'ns2:summarydocumentations_common': {
+          documentationNumber: 'SD',
+        },
+      },
+    });
+
+    title(data).should.equal('SD');
+  });
+
+  it('should return the title only when the summarydocumentation number is missing', () => {
+    const data = Immutable.fromJS({
+      document: {
+        'ns2:summarydocumentations_common': {
+          titles: {
+            title: ['Title'],
+          },
+        },
+      },
+    });
+
+    title(data).should.equal('Title');
+  });
+
+  it('should return an empty string if no document is passed', () => {
+    title(null).should.equal('');
+    title(undefined).should.equal('');
+  });
+
+  it('should return an empty string if the common part is not present', () => {
+    const data = Immutable.fromJS({
+      document: {
+        'ns2:summarydocumentations_extension': {
+          summarydocumentationAltTitle: 'Alt doc title',
+        },
+      },
+    });
+
+    title(data).should.equal('');
+  });
+});


### PR DESCRIPTION
**What does this do?**
* Add summary documentation procedure

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1333

This adds the summary documentation procedure which is a necessary part of nagpra workflows.

**How should this be tested? Do these changes have associated tests?**
* Ensure the linting and test pass
  * `npm run lint`
  * `npm run tests`
* Start the devserver
* Create a summary documentation and ensure it saves
* Check that the search results for summary documentation display correctly
* Check the advanced search fields for any messages which look incorrect

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against a local install