### PR TITLE
DRYD-1307: Focus indicator for CollectionSpace logo

### DIFF
--- a/styles/cspace-ui/BannerMain.css
+++ b/styles/cspace-ui/BannerMain.css
@@ -6,7 +6,6 @@
 
 .common > :global(.cspace-ui-Logo--common) {
   flex: 0 1 auto;
-  overflow: hidden;
 
   margin-right: 22px;
   /*

--- a/styles/cspace-ui/Logo.css
+++ b/styles/cspace-ui/Logo.css
@@ -1,3 +1,14 @@
+@value textDark from '../colors.css';
+@value activeEdgeWidth from '../dimensions.css';
+
+.common > a:focus {
+  outline: solid textDark;
+  outline-width: activeEdgeWidth;
+  outline-offset: activeEdgeWidth;
+  border-radius: 1px;
+  position: relative;
+}
+
 .common > a {
   display: inline-block;
 }

--- a/styles/cspace-ui/Logo.css
+++ b/styles/cspace-ui/Logo.css
@@ -1,14 +1,6 @@
 @value textDark from '../colors.css';
 @value activeEdgeWidth from '../dimensions.css';
 
-.common > a:focus {
-  outline: solid textDark;
-  outline-width: activeEdgeWidth;
-  outline-offset: activeEdgeWidth;
-  border-radius: 1px;
-  position: relative;
-}
-
 .common > a {
   display: inline-block;
 }


### PR DESCRIPTION
**What does this do?**
* Adds a border to the CollectionSpace logo when focused

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1307

The CollectionSpace logo was one of the few elements without any focus indicators. This updates the css so that it will get a similar border to that of other input elements with a rounded border. The overflow rule in the banner is removed so that the outline displays properly as the logo is at the boundaries of the banner.

**How should this be tested? Do these changes have associated tests?**
* Run the devserver `npm run devserver`
* Log in to CollectionSpace and tab or shift tab until the focus is on the CollectionSpace logo
* See that the border shows, indicating that the logo is the focused element

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against a local instance