### PR TITLE
DRYD-1305: Instructions for DateInput

### DIFF
--- a/docs/configuration/messages.js
+++ b/docs/configuration/messages.js
@@ -470,6 +470,9 @@ export default {
   // Title of the dashboard page.
   "dashboardPage.title": "My CollectionSpace",
 
+  // The tooltip for DateInput dropdowns.
+  "dateInput.tooltip": "Use the down arrow key or mouse to open the calendar",
+
   // The value of a datetime field.
   "dateTimeInputContainer.value": "{date} {time}",
 

--- a/docs/configuration/messages.js
+++ b/docs/configuration/messages.js
@@ -470,9 +470,6 @@ export default {
   // Title of the dashboard page.
   "dashboardPage.title": "My CollectionSpace",
 
-  // The tooltip for DateInput dropdowns.
-  "dateInput.tooltip": "Use the down arrow key or mouse to open the calendar",
-
   // The value of a datetime field.
   "dateTimeInputContainer.value": "{date} {time}",
 

--- a/src/containers/input/DateInputContainer.jsx
+++ b/src/containers/input/DateInputContainer.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { injectIntl, intlShape } from 'react-intl';
+import { defineMessages, injectIntl, intlShape } from 'react-intl';
 import { components as inputComponents } from 'cspace-input';
 
 const { DateInput } = inputComponents;
@@ -8,6 +8,14 @@ const propTypes = {
   intl: intlShape,
 };
 
+const messages = defineMessages({
+  tooltip: {
+    id: 'dateInput.tooltip',
+    description: 'Tip to display for interacting with the DateInput',
+    defaultMessage: 'Use the down arrow key or mouse to open the calendar',
+  },
+});
+
 export function IntlAwareDateInput(props) {
   const {
     intl,
@@ -15,12 +23,14 @@ export function IntlAwareDateInput(props) {
   } = props;
 
   const { locale } = intl;
+  const tooltip = intl.formatMessage(messages.tooltip);
 
   return (
     <DateInput
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...remainingProps}
       locale={locale}
+      tooltip={tooltip}
     />
   );
 }


### PR DESCRIPTION
**What does this do?**
* Adds a tooltip prop to DateInput
* Add title to LineInput to display provided tooltips

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1305

This is the second PR for adding instructions for the DateInput. It informs the user that the down arrow can be used as well as the mouse in order to open up the calendar. I mentioned in the other PR that this likely needs to be done for other components as well, such as the TermPicker, OptionPicker, and StructuredDate inputs.

**How should this be tested? Do these changes have associated tests?**
* Run `npm run lint` and `npm run test` to ensure nothing broke
* Rebuild and deploy alongside the cspace-input PR
* Run the devserver `npm run devserver`
* Mouseover a DateInput and see that a message is provided with instructions about usage

**Dependencies for merging? Releasing to production?**
Requires cspace-input PR in order to provide any functionality so that the tooltip is displayed.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally