### PR TITLE
DRYD-1358: Update Held-in-Trust

### DIFF
--- a/src/plugins/recordTypes/heldintrust/columns.js
+++ b/src/plugins/recordTypes/heldintrust/columns.js
@@ -19,16 +19,16 @@ export default (configContext) => {
         sortBy: 'heldintrusts_common:heldInTrustNumber',
         width: 200,
       },
-      depositor: {
+      owner: {
         formatValue: formatRefName,
         messages: defineMessages({
           label: {
-            id: 'column.heldintrust.default.depositor',
-            defaultMessage: 'Depositor',
+            id: 'column.heldintrust.default.owner',
+            defaultMessage: 'Owner',
           },
         }),
         order: 20,
-        sortBy: 'heldintrusts_common:heldInTrustDepositorGroupList/0/depositor',
+        sortBy: 'heldintrusts_common:owners/owner/0',
         width: 450,
       },
       updatedAt: {

--- a/src/plugins/recordTypes/heldintrust/fields.js
+++ b/src/plugins/recordTypes/heldintrust/fields.js
@@ -82,7 +82,7 @@ export default (configContext) => {
               },
             }),
             view: {
-              type: AutocompleteInput,
+              type: TermPickerInput,
               props: {
                 source: 'heldintrusttype',
               },

--- a/src/plugins/recordTypes/heldintrust/fields.js
+++ b/src/plugins/recordTypes/heldintrust/fields.js
@@ -22,6 +22,10 @@ export default (configContext) => {
     extensions,
   } = configContext.config;
 
+  const {
+    validateNotInUse,
+  } = configContext.validationHelpers;
+
   return {
     document: {
       [config]: {
@@ -43,6 +47,10 @@ export default (configContext) => {
           [config]: {
             cloneable: false,
             messages: defineMessages({
+              inUse: {
+                id: 'field.heldintrusts_common.heldInTrustNumber.inUse',
+                defaultMessage: 'The Held-in-Trust number {value} is in use by another record.',
+              },
               name: {
                 id: 'field.heldintrusts_common.heldInTrustNumber.name',
                 defaultMessage: 'Held-in-Trust number',
@@ -52,6 +60,11 @@ export default (configContext) => {
             searchView: {
               type: TextInput,
             },
+            validate: (validationContext) => validateNotInUse({
+              configContext,
+              validationContext,
+              fieldName: 'heldintrusts_common:heldInTrustNumber',
+            }),
             view: {
               type: IDGeneratorInput,
               props: {

--- a/src/plugins/recordTypes/heldintrust/fields.js
+++ b/src/plugins/recordTypes/heldintrust/fields.js
@@ -60,32 +60,58 @@ export default (configContext) => {
             },
           },
         },
-        entryDate: {
+        typeOfAgreement: {
           [config]: {
-            dataType: DATA_TYPE_DATE,
             messages: defineMessages({
               name: {
-                id: 'field.heldintrusts_common.entryDate.name',
-                defaultMessage: 'Object entry date',
+                id: 'field.heldintrusts_common.typeOfAgreement.name',
+                defaultMessage: 'Type of agreement',
               },
             }),
             view: {
-              type: DateInput,
+              type: AutocompleteInput,
+              props: {
+                source: 'heldintrusttype',
+              },
             },
           },
         },
-        heldInTrustDepositorGroupList: {
+        owners: {
           [config]: {
             view: {
               type: CompoundInput,
             },
           },
-          heldInTrustDepositorGroup: {
+          owner: {
             [config]: {
               messages: defineMessages({
                 name: {
-                  id: 'field.heldintrusts_common.heldInTrustDepositorGroup.name',
-                  defaultMessage: 'Depositor',
+                  id: 'field.heldintrusts_common.owner.name',
+                  defaultMessage: 'Owner',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: AutocompleteInput,
+                props: {
+                  source: 'person/local,person/ulan',
+                },
+              },
+            },
+          },
+        },
+        plannedReturnGroupList: {
+          [config]: {
+            view: {
+              type: CompoundInput,
+            },
+          },
+          plannedReturnGroup: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.heldintrusts_common.plannedReturnGroup.name',
+                  defaultMessage: 'Planned return',
                 },
               }),
               repeating: true,
@@ -96,161 +122,16 @@ export default (configContext) => {
                 },
               },
             },
-            depositor: {
-              [config]: {
-                messages: defineMessages({
-                  fullName: {
-                    id: 'field.heldintrusts_common.depositor.fullName',
-                    defaultMessage: 'Depositor name',
-                  },
-                  name: {
-                    id: 'field.heldintrusts_common.depositor.name',
-                    defaultMessage: 'Name',
-                  },
-                }),
-                view: {
-                  type: AutocompleteInput,
-                  props: {
-                    source: 'person/local,organization/local',
-                  },
-                },
-              },
-            },
-            depositorContact: {
-              [config]: {
-                messages: defineMessages({
-                  fullName: {
-                    id: 'field.heldintrusts_common.depositorContact.fullName',
-                    defaultMessage: 'Depositor contact',
-                  },
-                  name: {
-                    id: 'field.heldintrusts_common.depositorContact.name',
-                    defaultMessage: 'Contact',
-                  },
-                }),
-                view: {
-                  type: AutocompleteInput,
-                  props: {
-                    source: 'person/local',
-                  },
-                },
-              },
-            },
-            depositorContactType: {
-              [config]: {
-                messages: defineMessages({
-                  fullName: {
-                    id: 'field.heldintrusts_common.depositorContactType.fullName',
-                    defaultMessage: 'Depositor contact type',
-                  },
-                  name: {
-                    id: 'field.heldintrusts_common.depositorContactType.name',
-                    defaultMessage: 'Contact type',
-                  },
-                }),
-                view: {
-                  type: TermPickerInput,
-                  props: {
-                    source: 'depositorcontacttypes',
-                  },
-                },
-              },
-            },
-            depositorNote: {
-              [config]: {
-                messages: defineMessages({
-                  fullName: {
-                    id: 'field.heldintrusts_common.depositorNote.fullName',
-                    defaultMessage: 'Depositor note',
-                  },
-                  name: {
-                    id: 'field.heldintrusts_common.depositorNote.name',
-                    defaultMessage: 'Note',
-                  },
-                }),
-                view: {
-                  type: TextInput,
-                },
-              },
-            },
-          },
-        },
-        entryMethods: {
-          [config]: {
-            view: {
-              type: CompoundInput,
-            },
-          },
-          entryMethod: {
-            [config]: {
-              messages: defineMessages({
-                name: {
-                  id: 'field.heldintrusts_common.entryMethod.name',
-                  defaultMessage: 'Object entry method',
-                },
-              }),
-              repeating: true,
-              view: {
-                type: TermPickerInput,
-                props: {
-                  source: 'entrymethod',
-                },
-              },
-            },
-          },
-        },
-        agreementGroupList: {
-          [config]: {
-            view: {
-              type: CompoundInput,
-            },
-          },
-          agreementGroup: {
-            [config]: {
-              messages: defineMessages({
-                name: {
-                  id: 'field.heldintrusts_common.agreementGroup.name',
-                  defaultMessage: 'Agreement status',
-                },
-              }),
-              repeating: true,
-              view: {
-                type: CompoundInput,
-                props: {
-                  tabular: true,
-                },
-              },
-            },
-            agreementStatus: {
-              [config]: {
-                messages: defineMessages({
-                  fullName: {
-                    id: 'field.heldintrusts_common.agreementStatus.fullName',
-                    defaultMessage: 'Agreement status',
-                  },
-                  name: {
-                    id: 'field.heldintrusts_common.agreementStatus.name',
-                    defaultMessage: 'Status',
-                  },
-                }),
-                view: {
-                  type: TermPickerInput,
-                  props: {
-                    source: 'agreementstatuses',
-                  },
-                },
-              },
-            },
-            agreementStatusDate: {
+            plannedReturnDate: {
               [config]: {
                 dataType: DATA_TYPE_DATE,
                 messages: defineMessages({
                   fullName: {
-                    id: 'field.heldintrusts_common.agreementStatusDate.fullName',
-                    defaultMessage: 'Agreement status date',
+                    id: 'field.heldintrusts_common.plannedReturnDate.fullName',
+                    defaultMessage: 'Planned return date',
                   },
                   name: {
-                    id: 'field.heldintrusts_common.agreementStatusDate.name',
+                    id: 'field.heldintrusts_common.plannedReturnDate.name',
                     defaultMessage: 'Date',
                   },
                 }),
@@ -259,20 +140,44 @@ export default (configContext) => {
                 },
               },
             },
-            agreementStatusNote: {
+            plannedReturnNote: {
               [config]: {
                 messages: defineMessages({
                   fullName: {
-                    id: 'field.heldintrusts_common.agreementStatusNote.fullName',
-                    defaultMessage: 'Agreement status note',
+                    id: 'field.heldintrusts_common.plannedReturnNote.fullName',
+                    defaultMessage: 'Planned return note',
                   },
                   name: {
-                    id: 'field.heldintrusts_common.agreementStatusNote.name',
+                    id: 'field.heldintrusts_common.plannedReturnNote.name',
                     defaultMessage: 'Note',
                   },
                 }),
                 view: {
                   type: TextInput,
+                },
+              },
+            },
+          },
+        },
+        agreementDescriptions: {
+          [config]: {
+            view: {
+              type: CompoundInput,
+            },
+          },
+          agreementDescription: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.heldintrusts_common.agreementDescription.name',
+                  defaultMessage: 'Description of agreement',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: TextInput,
+                props: {
+                  multiline: true,
                 },
               },
             },
@@ -300,143 +205,92 @@ export default (configContext) => {
             },
           },
         },
-        entryReason: {
-          [config]: {
-            messages: defineMessages({
-              name: {
-                id: 'field.heldintrusts_common.entryReason.name',
-                defaultMessage: 'Object entry reason',
-              },
-            }),
-            view: {
-              type: TermPickerInput,
-              props: {
-                source: 'heldintrustentryreasons',
-              },
-            },
-          },
-        },
-        returnDate: {
-          [config]: {
-            dataType: DATA_TYPE_DATE,
-            messages: defineMessages({
-              name: {
-                id: 'field.heldintrusts_common.returnDate.name',
-                defaultMessage: 'Object return date',
-              },
-            }),
-            view: {
-              type: DateInput,
-            },
-          },
-        },
-        entryNote: {
-          [config]: {
-            messages: defineMessages({
-              name: {
-                id: 'field.heldintrusts_common.entryNote.name',
-                defaultMessage: 'Entry note',
-              },
-            }),
-            view: {
-              type: TextInput,
-              props: {
-                multiline: true,
-              },
-            },
-          },
-        },
-        internalApprovalGroupList: {
+        agreementApprovalGroupList: {
           [config]: {
             view: {
               type: CompoundInput,
             },
           },
-          internalApprovalGroup: {
+          agreementApprovalGroup: {
             [config]: {
               messages: defineMessages({
                 name: {
-                  id: 'field.heldintrusts_common.heldInTrustInternalApprovalGroup.name',
-                  defaultMessage: 'Internal approval',
+                  id: 'field.heldintrusts_common.agreementApprovalGroup.name',
+                  defaultMessage: 'Agreement approval',
                 },
               }),
               repeating: true,
               view: {
                 type: CompoundInput,
-                props: {
-                  tabular: true,
-                },
               },
             },
-            internalApprovalGroupName: {
+            agreementGroup: {
               [config]: {
                 messages: defineMessages({
                   fullName: {
-                    id: 'field.heldintrusts_common.internalApprovalGroupName.fullName',
-                    defaultMessage: 'Internal approval group',
+                    id: 'field.heldintrusts_common.agreementGroup.fullName',
+                    defaultMessage: 'Agreement approval group',
                   },
                   name: {
-                    id: 'field.heldintrusts_common.internalApprovalGroupName.name',
+                    id: 'field.heldintrusts_common.agreementGroup.name',
                     defaultMessage: 'Group',
                   },
                 }),
                 view: {
-                  type: TermPickerInput,
-                  props: {
-                    source: 'hitapprovalgroups',
-                  },
+                  type: TextInput,
                 },
               },
             },
-            internalApprovalIndividual: {
+            agreementIndividual: {
               [config]: {
                 messages: defineMessages({
                   fullName: {
-                    id: 'field.heldintrusts_common.internalApprovalIndividual.fullName',
-                    defaultMessage: 'Internal approval individual',
+                    id: 'field.heldintrusts_common.agreementIndividual.fullName',
+                    defaultMessage: 'Agreement approval individual',
                   },
                   name: {
-                    id: 'field.heldintrusts_common.internalApprovalIndividual.name',
+                    id: 'field.heldintrusts_common.agreementIndividual.name',
                     defaultMessage: 'Individual',
                   },
                 }),
                 view: {
                   type: AutocompleteInput,
                   props: {
-                    source: 'person/local',
+                    source: 'person/local,person/ulan',
                   },
                 },
               },
             },
-            internalApprovalStatus: {
+            agreementStatus: {
               [config]: {
                 messages: defineMessages({
                   fullName: {
-                    id: 'field.heldintrusts_common.internalApprovalStatus.fullName',
-                    defaultMessage: 'Internal approval status',
+                    id: 'field.heldintrusts_common.agreementStatus.fullName',
+                    defaultMessage: 'Agreement approval status',
                   },
                   name: {
-                    id: 'field.heldintrusts_common.internalApprovalStatus.name',
+                    id: 'field.heldintrusts_common.agreementStatus.name',
                     defaultMessage: 'Status',
                   },
                 }),
                 view: {
                   type: TermPickerInput,
                   props: {
-                    source: 'hitapprovaltypes',
+                    source: 'heldintruststatus',
                   },
                 },
               },
             },
-            internalApprovalDate: {
+            agreementDate: {
               [config]: {
+                dataType: DATA_TYPE_DATE,
                 messages: defineMessages({
                   fullName: {
-                    id: 'field.heldintrusts_common.internalApprovalDate.fullName',
-                    defaultMessage: 'Internal approval date',
+                    id: 'field.heldintrusts_common.agreementDate.fullName',
+                    defaultMessage: 'Agreement approval date',
                   },
                   name: {
-                    id: 'field.heldintrusts_common.internalApprovalDate.name',
+                    id: 'field.heldintrusts_common.agreementDate.name',
                     defaultMessage: 'Date',
                   },
                 }),
@@ -445,289 +299,23 @@ export default (configContext) => {
                 },
               },
             },
-            internalApprovalNote: {
+            agreementNote: {
               [config]: {
                 messages: defineMessages({
                   fullName: {
-                    id: 'field.heldintrusts_common.internalApprovalNote.fullName',
-                    defaultMessage: 'Internal approval note',
+                    id: 'field.heldintrusts_common.agreementNote.fullName',
+                    defaultMessage: 'Agreement approval note',
                   },
                   name: {
-                    id: 'field.heldintrusts_common.internalApprovalNote.name',
+                    id: 'field.heldintrusts_common.agreementNote.name',
                     defaultMessage: 'Note',
                   },
                 }),
                 view: {
                   type: TextInput,
-                },
-              },
-            },
-          },
-        },
-        externalApprovalGroupList: {
-          [config]: {
-            view: {
-              type: CompoundInput,
-            },
-          },
-          externalApprovalGroup: {
-            [config]: {
-              messages: defineMessages({
-                name: {
-                  id: 'field.heldintrusts_common.heldInTrustExternalApprovalGroup.name',
-                  defaultMessage: 'External approval',
-                },
-              }),
-              repeating: true,
-              view: {
-                type: CompoundInput,
-                props: {
-                  tabular: true,
-                },
-              },
-            },
-            externalApprovalGroupName: {
-              [config]: {
-                messages: defineMessages({
-                  fullName: {
-                    id: 'field.heldintrusts_common.externalApprovalGroupName.fullName',
-                    defaultMessage: 'External approval group',
-                  },
-                  name: {
-                    id: 'field.heldintrusts_common.externalApprovalGroupName.name',
-                    defaultMessage: 'Group',
-                  },
-                }),
-                view: {
-                  type: TermPickerInput,
                   props: {
-                    source: 'hitapprovalgroups',
+                    multiline: true,
                   },
-                },
-              },
-            },
-            externalApprovalIndividual: {
-              [config]: {
-                messages: defineMessages({
-                  fullName: {
-                    id: 'field.heldintrusts_common.externalApprovalIndividual.fullName',
-                    defaultMessage: 'External approval individual',
-                  },
-                  name: {
-                    id: 'field.heldintrusts_common.externalApprovalIndividual.name',
-                    defaultMessage: 'Individual',
-                  },
-                }),
-                view: {
-                  type: AutocompleteInput,
-                  props: {
-                    source: 'person/local',
-                  },
-                },
-              },
-            },
-            externalApprovalStatus: {
-              [config]: {
-                messages: defineMessages({
-                  fullName: {
-                    id: 'field.heldintrusts_common.externalApprovalStatus.fullName',
-                    defaultMessage: 'External approval status',
-                  },
-                  name: {
-                    id: 'field.heldintrusts_common.externalApprovalStatus.name',
-                    defaultMessage: 'Status',
-                  },
-                }),
-                view: {
-                  type: TermPickerInput,
-                  props: {
-                    source: 'hitapprovaltypes',
-                  },
-                },
-              },
-            },
-            externalApprovalDate: {
-              [config]: {
-                messages: defineMessages({
-                  fullName: {
-                    id: 'field.heldintrusts_common.externalApprovalDate.fullName',
-                    defaultMessage: 'External approval date',
-                  },
-                  name: {
-                    id: 'field.heldintrusts_common.externalApprovalDate.name',
-                    defaultMessage: 'Date',
-                  },
-                }),
-                view: {
-                  type: DateInput,
-                },
-              },
-            },
-            externalApprovalNote: {
-              [config]: {
-                messages: defineMessages({
-                  fullName: {
-                    id: 'field.heldintrusts_common.externalApprovalNote.fullName',
-                    defaultMessage: 'External approval note',
-                  },
-                  name: {
-                    id: 'field.heldintrusts_common.externalApprovalNote.name',
-                    defaultMessage: 'Note',
-                  },
-                }),
-                view: {
-                  type: TextInput,
-                },
-              },
-            },
-          },
-        },
-        handlingPreferences: {
-          [config]: {
-            messages: defineMessages({
-              name: {
-                id: 'field.heldintrusts_common.handlingPreferences.name',
-                defaultMessage: 'Handling preferences',
-              },
-            }),
-            view: {
-              type: TextInput,
-              props: {
-                multiline: true,
-              },
-            },
-          },
-        },
-        handlingLimitationsGroupList: {
-          [config]: {
-            view: {
-              type: CompoundInput,
-            },
-          },
-          handlingLimitationsGroup: {
-            [config]: {
-              messages: defineMessages({
-                name: {
-                  id: 'field.heldintrusts_common.handlingLimitationsGroup.name',
-                  defaultMessage: 'Handling limitations',
-                },
-              }),
-              repeating: true,
-              view: {
-                type: CompoundInput,
-              },
-            },
-            handlingLimitationsType: {
-              [config]: {
-                messages: defineMessages({
-                  fullName: {
-                    id: 'field.heldintrusts_common.handlingLimitationsType.fullName',
-                    defaultMessage: 'Handling limitations type',
-                  },
-                  name: {
-                    id: 'field.heldintrusts_common.handlingLimitationsType.name',
-                    defaultMessage: 'Type',
-                  },
-                }),
-                view: {
-                  type: TermPickerInput,
-                  props: {
-                    source: 'handlinglimitationstypes',
-                  },
-                },
-              },
-            },
-            handlingLimitationsRequestor: {
-              [config]: {
-                messages: defineMessages({
-                  fullName: {
-                    id: 'field.heldintrusts_common.handlingLimitationsRequestor.fullName',
-                    defaultMessage: 'Handling limitations requestor',
-                  },
-                  name: {
-                    id: 'field.heldintrusts_common.handlingLimitationsRequestor.name',
-                    defaultMessage: 'Requestor',
-                  },
-                }),
-                view: {
-                  type: AutocompleteInput,
-                  props: {
-                    source: 'person/local,organization/local',
-                  },
-                },
-              },
-            },
-            handlingLimitationsLevel: {
-              [config]: {
-                messages: defineMessages({
-                  fullName: {
-                    id: 'field.heldintrusts_common.handlingLimitationsLevel.fullName',
-                    defaultMessage: 'Handling limitations level',
-                  },
-                  name: {
-                    id: 'field.heldintrusts_common.handlingLimitationsLevel.name',
-                    defaultMessage: 'Level',
-                  },
-                }),
-                view: {
-                  type: TermPickerInput,
-                  props: {
-                    source: 'handlinglimitationslevels',
-                  },
-                },
-              },
-            },
-            handlingLimitationsOnBehalfOf: {
-              [config]: {
-                messages: defineMessages({
-                  fullName: {
-                    id: 'field.heldintrusts_common.handlingLimitationsOnBehalfOf.fullName',
-                    defaultMessage: 'Handling limitations on behalf of',
-                  },
-                  name: {
-                    id: 'field.heldintrusts_common.handlingLimitationsOnBehalfOf.name',
-                    defaultMessage: 'On behalf of',
-                  },
-                }),
-                view: {
-                  type: AutocompleteInput,
-                  props: {
-                    source: 'person/local,organization/local',
-                  },
-                },
-              },
-            },
-            handlingLimitationsDetail: {
-              [config]: {
-                messages: defineMessages({
-                  fullName: {
-                    id: 'field.heldintrusts_common.handlingLimitationsDetail.fullName',
-                    defaultMessage: 'Handling limitations detail',
-                  },
-                  name: {
-                    id: 'field.heldintrusts_common.handlingLimitationsDetail.name',
-                    defaultMessage: 'Detail',
-                  },
-                }),
-                view: {
-                  type: TextInput,
-                },
-              },
-            },
-            handlingLimitationsDate: {
-              [config]: {
-                messages: defineMessages({
-                  fullName: {
-                    id: 'field.heldintrusts_common.handlingLimitationsDate.fullName',
-                    defaultMessage: 'Handling limitations date',
-                  },
-                  name: {
-                    id: 'field.heldintrusts_common.handlingLimitationsDate.name',
-                    defaultMessage: 'Date',
-                  },
-                }),
-                view: {
-                  type: DateInput,
                 },
               },
             },
@@ -750,13 +338,11 @@ export default (configContext) => {
               repeating: true,
               view: {
                 type: CompoundInput,
-                props: {
-                  tabular: true,
-                },
               },
             },
             correspondenceDate: {
               [config]: {
+                dataType: DATA_TYPE_DATE,
                 messages: defineMessages({
                   fullName: {
                     id: 'field.heldintrusts_common.correspondenceDate.fullName',
@@ -787,7 +373,7 @@ export default (configContext) => {
                 view: {
                   type: AutocompleteInput,
                   props: {
-                    source: 'person/local,organization/local',
+                    source: 'person/local,person/ulan,organization/local,organization/ulan',
                   },
                 },
               },
@@ -807,7 +393,7 @@ export default (configContext) => {
                 view: {
                   type: AutocompleteInput,
                   props: {
-                    source: 'person/local,organization/local',
+                    source: 'person/local,person/ulan,organization/local,organization/ulan',
                   },
                 },
               },
@@ -826,23 +412,29 @@ export default (configContext) => {
                 }),
                 view: {
                   type: TextInput,
+                  props: {
+                    multiline: true,
+                  },
                 },
               },
             },
-            correspondenceReference: {
+            correspondenceType: {
               [config]: {
                 messages: defineMessages({
                   fullName: {
-                    id: 'field.heldintrusts_common.correspondenceReference.fullName',
-                    defaultMessage: 'Correspondence reference',
+                    id: 'field.heldintrusts_common.correspondenceType.fullName',
+                    defaultMessage: 'Correspondence type',
                   },
                   name: {
-                    id: 'field.heldintrusts_common.correspondenceReference.name',
-                    defaultMessage: 'Reference',
+                    id: 'field.heldintrusts_common.correspondenceType.name',
+                    defaultMessage: 'Type',
                   },
                 }),
                 view: {
-                  type: TextInput,
+                  type: TermPickerInput,
+                  props: {
+                    source: 'correspondencetype',
+                  },
                 },
               },
             },

--- a/src/plugins/recordTypes/heldintrust/forms/default.jsx
+++ b/src/plugins/recordTypes/heldintrust/forms/default.jsx
@@ -22,104 +22,55 @@ const template = (configContext) => {
         <Cols>
           <Col>
             <Field name="heldInTrustNumber" />
-          </Col>
-          <Col>
-            <Field name="entryDate" />
-          </Col>
-        </Cols>
-        <Field name="heldInTrustDepositorGroupList">
-          <Field name="heldInTrustDepositorGroup">
-            <Field name="depositor" />
-            <Field name="depositorContact" />
-            <Field name="depositorContactType" />
-            <Field name="depositorNote" />
-          </Field>
-        </Field>
-
-        <Field name="agreementGroupList">
-          <Field name="agreementGroup">
-            <Field name="agreementStatus" />
-            <Field name="agreementStatusDate" />
-            <Field name="agreementStatusNote" />
-          </Field>
-        </Field>
-        <Cols>
-          <Col>
-            <Field name="entryMethods">
-              <Field name="entryMethod" />
+            <Field name="owners">
+              <Field name="owner" />
+            </Field>
+            <Field name="plannedReturnGroupList">
+              <Field name="plannedReturnGroup">
+                <Field name="plannedReturnDate" />
+                <Field name="plannedReturnNote" />
+              </Field>
             </Field>
           </Col>
           <Col>
-            <Col>
-              <Field name="agreementRenewalDates">
-                <Field name="agreementRenewalDate" />
-              </Field>
-            </Col>
+            <Field name="agreementDescriptions">
+              <Field name="agreementDescription" />
+            </Field>
+            <Field name="typeOfAgreement" />
+            <Field name="agreementRenewalDates">
+              <Field name="agreementRenewalDate" />
+            </Field>
           </Col>
         </Cols>
-        <Cols>
-          <Cols>
-            <Field name="entryReason" />
-          </Cols>
-          <Col>
-            <Field name="returnDate" />
-          </Col>
-        </Cols>
-        <Field name="entryNote" />
-        <Field name="internalApprovalGroupList">
-          <Field name="internalApprovalGroup">
-            <Field name="internalApprovalGroupName" />
-            <Field name="internalApprovalIndividual" />
-            <Field name="internalApprovalStatus" />
-            <Field name="internalApprovalDate" />
-            <Field name="internalApprovalNote" />
-          </Field>
-        </Field>
-        <Field name="externalApprovalGroupList">
-          <Field name="externalApprovalGroup">
-            <Field name="externalApprovalGroupName" />
-            <Field name="externalApprovalIndividual" />
-            <Field name="externalApprovalStatus" />
-            <Field name="externalApprovalDate" />
-            <Field name="externalApprovalNote" />
-          </Field>
-        </Field>
-      </Panel>
 
-      <Panel name="cultureCareAndHandling" collapsible collapsed>
-        <Field name="handlingPreferences" />
-        <Field name="handlingLimitationsGroupList">
-          <Field name="handlingLimitationsGroup">
+        <Field name="agreementApprovalGroupList">
+          <Field name="agreementApprovalGroup">
             <Panel>
               <Row>
-                <Col>
-                  <Field name="handlingLimitationsType" />
-                  <Field name="handlingLimitationsLevel" />
-                  <Field name="handlingLimitationsDetail" />
-                </Col>
-                <Col>
-                  <Field name="handlingLimitationsRequestor" />
-                  <Field name="handlingLimitationsOnBehalfOf" />
-                  <Field name="handlingLimitationsDate" />
-                </Col>
+                <Field name="agreementGroup" />
+                <Field name="agreementIndividual" />
+                <Field name="agreementStatus" />
+                <Field name="agreementDate" />
               </Row>
+              <Field name="agreementNote" />
+            </Panel>
+          </Field>
+        </Field>
+
+        <Field name="correspondenceGroupList">
+          <Field name="correspondenceGroup">
+            <Panel>
+              <Row>
+                <Field name="correspondenceSender" />
+                <Field name="correspondenceRecipient" />
+                <Field name="correspondenceType" />
+                <Field name="correspondenceDate" />
+              </Row>
+              <Field name="correspondenceSummary" />
             </Panel>
           </Field>
         </Field>
       </Panel>
-
-      <Panel name="correspondence" collapsible collapsed>
-        <Field name="correspondenceGroupList">
-          <Field name="correspondenceGroup">
-            <Field name="correspondenceDate" />
-            <Field name="correspondenceSender" />
-            <Field name="correspondenceRecipient" />
-            <Field name="correspondenceSummary" />
-            <Field name="correspondenceReference" />
-          </Field>
-        </Field>
-      </Panel>
-
     </Field>
   );
 };

--- a/src/plugins/recordTypes/heldintrust/idGenerators.js
+++ b/src/plugins/recordTypes/heldintrust/idGenerators.js
@@ -2,7 +2,7 @@ import { defineMessages } from 'react-intl';
 
 export default {
   heldintrust: {
-    csid: '038b61f2-2975-4b33-ac93-ce8d8b6042f0',
+    csid: '6b5bc008-34f9-40be-bd49-0440ee9f262d',
     messages: defineMessages({
       type: {
         id: 'idGenerator.heldintrust.type',

--- a/src/plugins/recordTypes/heldintrust/messages.js
+++ b/src/plugins/recordTypes/heldintrust/messages.js
@@ -14,17 +14,9 @@ export default {
     },
   }),
   panel: defineMessages({
-    heldintrust: {
+    info: {
       id: 'panel.heldintrust.info',
       defaultMessage: 'Held-in-Trust Information',
-    },
-    cultureCareAndHandling: {
-      id: 'panel.heldintrust.cultureCareAndHandling',
-      defaultMessage: 'Culture Care and Handling',
-    },
-    correspondence: {
-      id: 'panel.heldintrust.correspondence',
-      defaultMessage: 'Correspondence',
     },
   }),
 };

--- a/src/plugins/recordTypes/heldintrust/serviceConfig.js
+++ b/src/plugins/recordTypes/heldintrust/serviceConfig.js
@@ -1,8 +1,8 @@
 export default {
-  serviceName: 'Heldintrusts',
+  serviceName: 'HeldInTrust',
   servicePath: 'heldintrusts',
   serviceType: 'procedure',
 
-  objectName: 'Heldintrust',
+  objectName: 'HeldInTrust',
   documentName: 'heldintrusts',
 };

--- a/src/plugins/recordTypes/heldintrust/title.js
+++ b/src/plugins/recordTypes/heldintrust/title.js
@@ -19,7 +19,7 @@ export default (configContext) => (data) => {
   }
 
   const hitNumber = common.get('heldInTrustNumber');
-  const depositor = getDisplayName(deepGet(common, ['heldInTrustDepositorGroupList', 'heldInTrustDepositorGroup', 0, 'depositor']));
+  const depositor = getDisplayName(deepGet(common, ['owners', 'owner', 0]));
 
   return [hitNumber, depositor].filter((part) => !!part).join(' – ');
 };

--- a/src/plugins/recordTypes/index.js
+++ b/src/plugins/recordTypes/index.js
@@ -18,7 +18,7 @@ import dutyofcare from './dutyofcare';
 import exhibition from './exhibition';
 import exxport from './export';
 import group from './group';
-// import heldintrust from './heldintrust';
+import heldintrust from './heldintrust';
 import idgenerator from './idgenerator';
 import insurance from './insurance';
 import intake from './intake';
@@ -68,7 +68,7 @@ export default [
   exhibition,
   exxport,
   group,
-  // heldintrust,
+  heldintrust,
   idgenerator,
   insurance,
   intake,

--- a/test/specs/plugins/recordTypes/heldintrust/columns.spec.js
+++ b/test/specs/plugins/recordTypes/heldintrust/columns.spec.js
@@ -11,12 +11,12 @@ describe('heldintrust record columns', () => {
     columns.should.have.property('default').that.is.an('object');
   });
 
-  it('should have depositor source column that is formatted as a refname display name', () => {
-    const { depositor } = columns.default;
+  it('should have owner source column that is formatted as a refname display name', () => {
+    const { owner } = columns.default;
 
-    depositor.should.have.property('formatValue').that.is.a('function');
+    owner.should.have.property('formatValue').that.is.a('function');
 
-    depositor.formatValue('urn:cspace:core.collectionspace.org:personauthorities:name(person):item:name(johndoe)\'John Doe\'').should
+    owner.formatValue('urn:cspace:core.collectionspace.org:personauthorities:name(person):item:name(johndoe)\'John Doe\'').should
       .equal('John Doe');
   });
 });

--- a/test/specs/plugins/recordTypes/heldintrust/title.spec.js
+++ b/test/specs/plugins/recordTypes/heldintrust/title.spec.js
@@ -13,10 +13,10 @@ describe('heldintrust record title', () => {
       document: {
         'ns2:heldintrusts_common': {
           heldInTrustNumber: 'HIT2023.1',
-          heldInTrustDepositorGroupList: {
-            heldInTrustDepositorGroup: {
-              depositor: 'urn:cspace:core.collectionspace.org:personauthorities:name(person):item:name(Depositor)\'Depositor\'',
-            },
+          owners: {
+            owner: [
+              'urn:cspace:core.collectionspace.org:personauthorities:name(person):item:name(Depositor)\'Depositor\'',
+            ],
           },
         },
       },
@@ -30,10 +30,8 @@ describe('heldintrust record title', () => {
       document: {
         'ns2:heldintrusts_common': {
           heldInTrustNumber: 'HIT2023.1',
-          heldInTrustDepositorGroupList: {
-            heldInTrustDepositorGroup: {
-              depositor: '',
-            },
+          owners: {
+            owner: [],
           },
         },
       },
@@ -47,10 +45,8 @@ describe('heldintrust record title', () => {
       document: {
         'ns2:heldintrusts_common': {
           heldInTrustNumber: '',
-          heldInTrustDepositorGroupList: {
-            heldInTrustDepositorGroup: {
-              depositor: 'urn:cspace:core.collectionspace.org:personauthorities:name(person):item:name(Depositor)\'Depositor\'',
-            },
+          owners: {
+            owner: ['urn:cspace:core.collectionspace.org:personauthorities:name(person):item:name(Depositor)\'Depositor\''],
           },
         },
       },


### PR DESCRIPTION
**What does this do?**
* Update Held-in-Trust for NAGPRA workflows

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1358

This updates the Held-in-Trust procedure which was going to be added for 8.0 to be compatible with NAGPRA related workflows. It 

**How should this be tested? Do these changes have associated tests?**
* Run `npm run lint` and `npm run tests`
* Rebuild collectionspace with the core tenant enabled
* Start collectionspace
* Start the devserver `npm run devserver`
* Check that the Held-in-Trust procedure saves and loads as expected
  * With the exception of heldintrust type which needs default terms
* Optionally check the messages in the advanced search

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against a local instance