### PR TITLE
DRYD-1358: Held-in-Trust Updates

### DIFF
--- a/src/plugins/recordTypes/heldintrust/fields.js
+++ b/src/plugins/recordTypes/heldintrust/fields.js
@@ -453,6 +453,169 @@ export default (configContext) => {
             },
           },
         },
+        culturalCareNotes: {
+          [config]: {
+            view: {
+              type: CompoundInput,
+            },
+          },
+          culturalCareNote: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.heldintrusts_common.culturalCareNote.name',
+                  defaultMessage: 'Cultural care note',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: TextInput,
+                props: {
+                  multiline: true,
+                },
+              },
+            },
+          },
+        },
+        accessLimitationsGroupList: {
+          [config]: {
+            view: {
+              type: CompoundInput,
+            },
+          },
+          accessLimitationsGroup: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.heldintrusts_common.accessLimitationsGroup.name',
+                  defaultMessage: 'Access limitation',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: CompoundInput,
+                props: {
+                  tabular: true,
+                },
+              },
+            },
+            limitationType: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.heldintrusts_common.limitationType.fullName',
+                    defaultMessage: 'Access limitation type',
+                  },
+                  name: {
+                    id: 'field.heldintrusts_common.limitationType.name',
+                    defaultMessage: 'Type',
+                  },
+                }),
+                view: {
+                  type: TermPickerInput,
+                  props: {
+                    source: 'limitationtype',
+                  },
+                },
+              },
+            },
+            limitationLevel: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.heldintrusts_common.limitationLevel.fullName',
+                    defaultMessage: 'Access limitation level',
+                  },
+                  name: {
+                    id: 'field.heldintrusts_common.limitationLevel.name',
+                    defaultMessage: 'Level',
+                  },
+                }),
+                view: {
+                  type: TermPickerInput,
+                  props: {
+                    source: 'limitationlevel',
+                  },
+                },
+              },
+            },
+            limitationDetails: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.heldintrusts_common.limitationDetails.fullName',
+                    defaultMessage: 'Access limitation detail',
+                  },
+                  name: {
+                    id: 'field.heldintrusts_common.limitationDetails.name',
+                    defaultMessage: 'Detail',
+                  },
+                }),
+                view: {
+                  type: TextInput,
+                },
+              },
+            },
+            requester: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.heldintrusts_common.requester.fullName',
+                    defaultMessage: 'Access limitation requestor',
+                  },
+                  name: {
+                    id: 'field.heldintrusts_common.requester.name',
+                    defaultMessage: 'Requestor',
+                  },
+                }),
+                view: {
+                  type: AutocompleteInput,
+                  props: {
+                    source: 'person/local',
+                  },
+                },
+              },
+            },
+            requestOnBehalfOf: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.heldintrusts_common.requestOnBehalfOf.fullName',
+                    defaultMessage: 'Access limitation requested on behalf of',
+                  },
+                  name: {
+                    id: 'field.heldintrusts_common.requestOnBehalfOf.name',
+                    defaultMessage: 'On behalf of',
+                  },
+                }),
+                view: {
+                  type: AutocompleteInput,
+                  props: {
+                    source: 'organization/local',
+                  },
+                },
+              },
+            },
+            requestDate: {
+              [config]: {
+                dataType: DATA_TYPE_DATE,
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.heldintrusts_common.requestDate.fullName',
+                    defaultMessage: 'Access limitation request date',
+                  },
+                  name: {
+                    id: 'field.heldintrusts_common.requestDate.name',
+                    defaultMessage: 'Date',
+                  },
+                }),
+                view: {
+                  type: DateInput,
+                },
+              },
+            },
+          },
+        },
       },
     },
   };

--- a/src/plugins/recordTypes/heldintrust/forms/default.jsx
+++ b/src/plugins/recordTypes/heldintrust/forms/default.jsx
@@ -71,6 +71,23 @@ const template = (configContext) => {
           </Field>
         </Field>
       </Panel>
+
+      <Panel name="culturalCare" collapsible collapsed>
+        <Field name="culturalCareNotes">
+          <Field name="culturalCareNote" />
+        </Field>
+
+        <Field name="accessLimitationsGroupList">
+          <Field name="accessLimitationsGroup">
+            <Field name="limitationType" />
+            <Field name="limitationLevel" />
+            <Field name="limitationDetails" />
+            <Field name="requester" />
+            <Field name="requestOnBehalfOf" />
+            <Field name="requestDate" />
+          </Field>
+        </Field>
+      </Panel>
     </Field>
   );
 };

--- a/src/plugins/recordTypes/heldintrust/messages.js
+++ b/src/plugins/recordTypes/heldintrust/messages.js
@@ -18,5 +18,9 @@ export default {
       id: 'panel.heldintrust.info',
       defaultMessage: 'Held-in-Trust Information',
     },
+    culturalCare: {
+      id: 'panel.heldintrust.culturalCare',
+      defaultMessage: 'Cultural Care Information',
+    },
   }),
 };


### PR DESCRIPTION
**What does this do?**
* Adds cultural care to Held-in-Trust

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1358

Instead of creating a new CulturalCare procedure, we're opting to pull the cultural care fields directly into Held-in-Trust. This pulls in the fields and form from `cspace-ui-plugin-ext-culturalcare.js` with updates to be for heldintrust rather than collectionobject.

**How should this be tested? Do these changes have associated tests?**
* Run `npm run lint` and `npm run test` as a sanity check
* Start the devserver `npm run devserver`
* Create a Held-in-Trust record with the cultural care information filled out 

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against a local instance