### PR TITLE
DRYD-1390: Consultation

### DIFF
--- a/src/plugins/recordTypes/consultation/advancedSearch.js
+++ b/src/plugins/recordTypes/consultation/advancedSearch.js
@@ -1,0 +1,21 @@
+export default (configContext) => {
+  const {
+    OP_CONTAIN,
+  } = configContext.searchOperators;
+
+  const {
+    defaultAdvancedSearchBooleanOp,
+    extensions,
+  } = configContext.config;
+
+  return {
+    op: defaultAdvancedSearchBooleanOp,
+    value: [
+      {
+        op: OP_CONTAIN,
+        path: 'ns2:consultations_common/consultationNumber',
+      },
+      ...extensions.core.advancedSearch,
+    ],
+  };
+};

--- a/src/plugins/recordTypes/consultation/columns.js
+++ b/src/plugins/recordTypes/consultation/columns.js
@@ -1,0 +1,35 @@
+import { defineMessages } from 'react-intl';
+
+export default (configContext) => {
+  const {
+    formatTimestamp,
+  } = configContext.formatHelpers;
+
+  return {
+    default: {
+      consultationNumber: {
+        messages: defineMessages({
+          label: {
+            id: 'column.consultation.default.Number',
+            defaultMessage: 'Consultation number',
+          },
+        }),
+        order: 10,
+        sortBy: 'consultations_common:consultationNumber',
+        width: 200,
+      },
+      updatedAt: {
+        formatValue: formatTimestamp,
+        messages: defineMessages({
+          label: {
+            id: 'column.consultation.default.updatedAt',
+            defaultMessage: 'Updated',
+          },
+        }),
+        order: 30,
+        sortBy: 'collectionspace_core:updatedAt',
+        width: 150,
+      },
+    },
+  };
+};

--- a/src/plugins/recordTypes/consultation/fields.js
+++ b/src/plugins/recordTypes/consultation/fields.js
@@ -1,0 +1,345 @@
+import { defineMessages } from 'react-intl';
+
+export default (configContext) => {
+  const {
+    AutocompleteInput,
+    CompoundInput,
+    DateInput,
+    IDGeneratorInput,
+    TextInput,
+    TermPickerInput,
+  } = configContext.inputComponents;
+
+  const {
+    configKey: config,
+  } = configContext.configHelpers;
+
+  const {
+    DATA_TYPE_DATE,
+  } = configContext.dataTypes;
+
+  const {
+    extensions,
+  } = configContext.config;
+
+  const {
+    validateNotInUse,
+  } = configContext.validationHelpers;
+
+  return {
+    document: {
+      [config]: {
+        view: {
+          type: CompoundInput,
+          props: {
+            defaultChildSubpath: 'ns2:consultations_common',
+          },
+        },
+      },
+      ...extensions.core.fields,
+      'ns2:consultations_common': {
+        [config]: {
+          service: {
+            ns: 'http://collectionspace.org/services/consultation',
+          },
+        },
+        consultationNumber: {
+          [config]: {
+            cloneable: false,
+            messages: defineMessages({
+              inUse: {
+                id: 'field.consultations_common.consultationNumber.inUse',
+                defaultMessage: 'The identification number {value} is in use by another record.',
+              },
+              name: {
+                id: 'field.consultations_common.consultationNumber.name',
+                defaultMessage: 'Consultation number',
+              },
+            }),
+            required: true,
+            searchView: {
+              type: TextInput,
+            },
+            validate: (validationContext) => validateNotInUse({
+              configContext,
+              validationContext,
+              fieldName: 'consultations_common:consultationNumber',
+            }),
+            view: {
+              type: IDGeneratorInput,
+              props: {
+                source: 'consultation',
+              },
+            },
+          },
+        },
+        consultationDate: {
+          [config]: {
+            messages: defineMessages({
+              name: {
+                id: 'field.consultations_common.consultationDate.name',
+                defaultMessage: 'Initial consultation date',
+              },
+            }),
+            dataType: DATA_TYPE_DATE,
+            view: {
+              type: DateInput,
+            },
+          },
+        },
+        reason: {
+          [config]: {
+            messages: defineMessages({
+              name: {
+                id: 'field.consultations_common.reason.name',
+                defaultMessage: 'Consultation reason',
+              },
+            }),
+            view: {
+              type: TermPickerInput,
+              props: {
+                source: 'consultationreason',
+              },
+            },
+          },
+        },
+        notes: {
+          [config]: {
+            view: {
+              type: CompoundInput,
+            },
+          },
+          note: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.consultations_common.note.name',
+                  defaultMessage: 'Consultation note',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: TextInput,
+                props: {
+                  multiline: true,
+                },
+              },
+            },
+          },
+        },
+        partiesInvolvedGroupList: {
+          [config]: {
+            view: {
+              type: CompoundInput,
+            },
+          },
+          partiesInvolvedGroup: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.consultations_common.partiesInvolvedGroup.name',
+                  defaultMessage: 'Parties involved',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: CompoundInput,
+                props: {
+                  tabular: true,
+                },
+              },
+            },
+            involvedParty: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.consultations_common.involvedParty.fullName',
+                    defaultMessage: 'Parties involved party',
+                  },
+                  name: {
+                    id: 'field.consultations_common.involvedParty.name',
+                    defaultMessage: 'Party',
+                  },
+                }),
+                view: {
+                  type: AutocompleteInput,
+                  props: {
+                    source: 'person/local,person/ulan',
+                  },
+                },
+              },
+            },
+            involvedOnBehalfOf: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.consultations_common.involvedOnBehalfOf.fullName',
+                    defaultMessage: 'Parties involved on behalf of',
+                  },
+                  name: {
+                    id: 'field.consultations_common.involvedOnBehalfOf.name',
+                    defaultMessage: 'On behalf of',
+                  },
+                }),
+                view: {
+                  type: AutocompleteInput,
+                  props: {
+                    source: 'organization/local,organization/ulan',
+                  },
+                },
+              },
+            },
+            involvedRole: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.consultations_common.involvedRole.fullName',
+                    defaultMessage: 'Parties involved role',
+                  },
+                  name: {
+                    id: 'field.consultations_common.involvedRole.name',
+                    defaultMessage: 'Role',
+                  },
+                }),
+                view: {
+                  type: TermPickerInput,
+                  props: {
+                    source: 'nagprainvolvedrole',
+                  },
+                },
+              },
+            },
+          },
+        },
+        consultationLogGroupList: {
+          [config]: {
+            view: {
+              type: CompoundInput,
+            },
+          },
+          consultationLogGroup: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.consultations_common.consultationLogGroup.name',
+                  defaultMessage: 'Consultation log',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: CompoundInput,
+              },
+            },
+            consultType: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.consultations_common.consultType.fullName',
+                    defaultMessage: 'Consultation log type',
+                  },
+                  name: {
+                    id: 'field.consultations_common.consultType.name',
+                    defaultMessage: 'Type',
+                  },
+                }),
+                view: {
+                  type: TermPickerInput,
+                  props: {
+                    source: 'consultationtype',
+                  },
+                },
+              },
+            },
+            consultParties: {
+              [config]: {
+                view: {
+                  type: CompoundInput,
+                },
+              },
+              consultParty: {
+                [config]: {
+                  messages: defineMessages({
+                    fullName: {
+                      id: 'field.consultations_common.consultParty.fullName',
+                      defaultMessage: 'Consultation log party',
+                    },
+                    name: {
+                      id: 'field.consultations_common.consultParty.name',
+                      defaultMessage: 'Party',
+                    },
+                  }),
+                  repeating: true,
+                  view: {
+                    type: AutocompleteInput,
+                    props: {
+                      source: 'person/local,person/ulan',
+                    },
+                  },
+                },
+              },
+            },
+            consultStatus: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.consultations_common.consultStatus.fullName',
+                    defaultMessage: 'Consultation log status',
+                  },
+                  name: {
+                    id: 'field.consultations_common.consultStatus.name',
+                    defaultMessage: 'Status',
+                  },
+                }),
+                view: {
+                  type: TermPickerInput,
+                  props: {
+                    source: 'consultationstatus',
+                  },
+                },
+              },
+            },
+            consultDate: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.consultations_common.consultDate.fullName',
+                    defaultMessage: 'Consultation log date',
+                  },
+                  name: {
+                    id: 'field.consultations_common.consultDate.name',
+                    defaultMessage: 'Date',
+                  },
+                }),
+                dataType: DATA_TYPE_DATE,
+                view: {
+                  type: DateInput,
+                },
+              },
+            },
+            consultNote: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.consultations_common.consultNote.fullName',
+                    defaultMessage: 'Consultation log note',
+                  },
+                  name: {
+                    id: 'field.consultations_common.consultNote.name',
+                    defaultMessage: 'Note',
+                  },
+                }),
+                view: {
+                  type: TextInput,
+                  props: {
+                    height: 46,
+                    multiline: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+};

--- a/src/plugins/recordTypes/consultation/forms/default.jsx
+++ b/src/plugins/recordTypes/consultation/forms/default.jsx
@@ -1,0 +1,71 @@
+import { defineMessages } from 'react-intl';
+
+const template = (configContext) => {
+  const {
+    React,
+  } = configContext.lib;
+
+  const {
+    Col,
+    Cols,
+    Panel,
+    Row,
+  } = configContext.layoutComponents;
+
+  const {
+    Field,
+  } = configContext.recordComponents;
+
+  return (
+    <Field name="document">
+      <Panel name="info" collapsible>
+        <Cols>
+          <Col>
+            <Field name="consultationNumber" />
+            <Field name="consultationDate" />
+          </Col>
+          <Col>
+            <Field name="reason" />
+            <Field name="notes">
+              <Field name="note" />
+            </Field>
+          </Col>
+        </Cols>
+
+        <Field name="partiesInvolvedGroupList">
+          <Field name="partiesInvolvedGroup">
+            <Field name="involvedParty" />
+            <Field name="involvedOnBehalfOf" />
+            <Field name="involvedRole" />
+          </Field>
+        </Field>
+
+        <Field name="consultationLogGroupList">
+          <Field name="consultationLogGroup">
+            <Panel>
+              <Row>
+                <Field name="consultType" />
+                <Field name="consultParties">
+                  <Field name="consultParty" />
+                </Field>
+                <Field name="consultStatus" />
+                <Field name="consultDate" />
+              </Row>
+              <Field name="consultNote" />
+            </Panel>
+          </Field>
+        </Field>
+      </Panel>
+    </Field>
+  );
+};
+
+export default (configContext) => ({
+  messages: defineMessages({
+    name: {
+      id: 'form.consultation.default.name',
+      defaultMessage: 'Standard Template',
+    },
+  }),
+  template: template(configContext),
+});

--- a/src/plugins/recordTypes/consultation/forms/index.js
+++ b/src/plugins/recordTypes/consultation/forms/index.js
@@ -1,0 +1,5 @@
+import defaultForm from './default';
+
+export default (configContext) => ({
+  default: defaultForm(configContext),
+});

--- a/src/plugins/recordTypes/consultation/idGenerators.js
+++ b/src/plugins/recordTypes/consultation/idGenerators.js
@@ -1,0 +1,13 @@
+import { defineMessages } from 'react-intl';
+
+export default {
+  consultation: {
+    csid: '48dfa8e6-6c18-4d6e-bb2d-bbc69cc2cb36',
+    messages: defineMessages({
+      type: {
+        id: 'idGenerator.consultation.type',
+        defaultMessage: 'Consultation',
+      },
+    }),
+  },
+};

--- a/src/plugins/recordTypes/consultation/index.js
+++ b/src/plugins/recordTypes/consultation/index.js
@@ -1,0 +1,23 @@
+import advancedSearch from './advancedSearch';
+import columns from './columns';
+import fields from './fields';
+import forms from './forms';
+import idGenerators from './idGenerators';
+import messages from './messages';
+import serviceConfig from './serviceConfig';
+import title from './title';
+
+export default () => (configContext) => ({
+  idGenerators,
+  recordTypes: {
+    consultation: {
+      messages,
+      serviceConfig,
+      advancedSearch: advancedSearch(configContext),
+      columns: columns(configContext),
+      fields: fields(configContext),
+      forms: forms(configContext),
+      title: title(configContext),
+    },
+  },
+});

--- a/src/plugins/recordTypes/consultation/messages.js
+++ b/src/plugins/recordTypes/consultation/messages.js
@@ -1,0 +1,22 @@
+import { defineMessages } from 'react-intl';
+
+export default {
+  record: defineMessages({
+    name: {
+      id: 'record.consultation.name',
+      description: 'The name of the record type',
+      defaultMessage: 'Consultation',
+    },
+    collectionName: {
+      id: 'record.consultation.collectionName',
+      description: 'The name of a collection of records of the type.',
+      defaultMessage: 'Consultations',
+    },
+  }),
+  panel: defineMessages({
+    info: {
+      id: 'panel.consultation.info',
+      defaultMessage: 'Consultation Information',
+    },
+  }),
+};

--- a/src/plugins/recordTypes/consultation/serviceConfig.js
+++ b/src/plugins/recordTypes/consultation/serviceConfig.js
@@ -1,0 +1,8 @@
+export default {
+  serviceName: 'Consultation',
+  servicePath: 'consultations',
+  serviceType: 'procedure',
+
+  objectName: 'Consultation',
+  documentName: 'consultations',
+};

--- a/src/plugins/recordTypes/consultation/title.js
+++ b/src/plugins/recordTypes/consultation/title.js
@@ -1,0 +1,25 @@
+export default (configContext) => (data) => {
+  const {
+    getPart,
+    deepGet,
+  } = configContext.recordDataHelpers;
+
+  const {
+    getDisplayName,
+  } = configContext.refNameHelpers;
+
+  if (!data) {
+    return '';
+  }
+
+  const common = getPart(data, 'consultations_common');
+
+  if (!common) {
+    return '';
+  }
+
+  const consultationNumber = common.get('consultationNumber');
+  const involvedParty = getDisplayName(deepGet(common, ['partiesInvolvedGroupList', 'partiesInvolvedGroup', 0, 'involvedParty']));
+
+  return [consultationNumber, involvedParty].filter((part) => !!part).join(' – ');
+};

--- a/src/plugins/recordTypes/index.js
+++ b/src/plugins/recordTypes/index.js
@@ -13,6 +13,7 @@ import collectionobject from './collectionobject';
 import concept from './concept';
 import conditioncheck from './conditioncheck';
 import conservation from './conservation';
+import consultation from './consultation';
 import contact from './contact';
 import dutyofcare from './dutyofcare';
 import exhibition from './exhibition';
@@ -63,6 +64,7 @@ export default [
   concept,
   conditioncheck,
   conservation,
+  consultation,
   contact,
   dutyofcare,
   exhibition,

--- a/test/specs/plugins/recordTypes/consultation/advancedSearch.spec.js
+++ b/test/specs/plugins/recordTypes/consultation/advancedSearch.spec.js
@@ -1,0 +1,16 @@
+import createConfigContext from '../../../../../src/helpers/createConfigContext';
+import advancedSearch from '../../../../../src/plugins/recordTypes/consultation/advancedSearch';
+
+chai.should();
+
+describe('consultation record advanced search', () => {
+  const configContext = createConfigContext();
+
+  it('should contain a top level property `op`', () => {
+    advancedSearch(configContext).should.have.property('op');
+  });
+
+  it('should contain a top level property `value` that is an array', () => {
+    advancedSearch(configContext).should.have.property('value').that.is.an('array');
+  });
+});

--- a/test/specs/plugins/recordTypes/consultation/columns.spec.js
+++ b/test/specs/plugins/recordTypes/consultation/columns.spec.js
@@ -1,0 +1,15 @@
+import consultationRecordTypePluginFactory from '../../../../../src/plugins/recordTypes/consultation';
+import createColumns from '../../../../../src/plugins/recordTypes/consultation/columns';
+import createConfigContext from '../../../../../src/helpers/createConfigContext';
+
+chai.should();
+
+describe('consultation record columns', () => {
+  const consultationRecordTypePlugin = consultationRecordTypePluginFactory({});
+  const configContext = createConfigContext(consultationRecordTypePlugin);
+  const columns = createColumns(configContext);
+
+  it('should have the correct shape', () => {
+    columns.should.have.property('default').that.is.an('object');
+  });
+});

--- a/test/specs/plugins/recordTypes/consultation/forms/default.spec.js
+++ b/test/specs/plugins/recordTypes/consultation/forms/default.spec.js
@@ -1,0 +1,14 @@
+import Field from '../../../../../../src/components/record/Field';
+import form from '../../../../../../src/plugins/recordTypes/consultation/forms/default';
+import createConfigContext from '../../../../../../src/helpers/createConfigContext';
+
+chai.should();
+
+describe('consultation record default form', () => {
+  it('should be a Field', () => {
+    const configContext = createConfigContext();
+    const { template } = form(configContext);
+
+    template.type.should.equal(Field);
+  });
+});

--- a/test/specs/plugins/recordTypes/consultation/index.spec.js
+++ b/test/specs/plugins/recordTypes/consultation/index.spec.js
@@ -1,0 +1,29 @@
+import consultationRecordTypePluginFactory from '../../../../../src/plugins/recordTypes/consultation';
+import createConfigContext from '../../../../../src/helpers/createConfigContext';
+
+chai.should();
+
+describe('consultation record plugin', () => {
+  const config = {};
+  const consultationRecordTypePlugin = consultationRecordTypePluginFactory(config);
+  const configContext = createConfigContext(consultationRecordTypePlugin);
+
+  it('should have the correct shape', () => {
+    const pluginConfiguration = consultationRecordTypePlugin(configContext);
+
+    const {
+      recordTypes,
+    } = pluginConfiguration;
+
+    recordTypes.should.have.property('consultation');
+
+    const consultationRecordType = recordTypes.consultation;
+
+    consultationRecordType.should.have.property('title').that.is.a('function');
+    consultationRecordType.should.have.property('forms').that.is.an('object');
+    consultationRecordType.should.have.property('messages').that.is.an('object');
+    consultationRecordType.should.have.property('serviceConfig').that.is.an('object');
+
+    consultationRecordType.title().should.be.a('string');
+  });
+});

--- a/test/specs/plugins/recordTypes/consultation/messages.spec.js
+++ b/test/specs/plugins/recordTypes/consultation/messages.spec.js
@@ -1,0 +1,17 @@
+import messages from '../../../../../src/plugins/recordTypes/consultation/messages';
+
+chai.should();
+
+describe('consultation record messages', () => {
+  it('should contain properties with an id and defaultMessage properties', () => {
+    messages.should.be.an('object');
+
+    Object.keys(messages).forEach((consultationName) => {
+      const consultationMessages = messages[consultationName];
+
+      Object.keys(consultationMessages).forEach((name) => {
+        consultationMessages[name].should.contain.all.keys(['id', 'defaultMessage']);
+      });
+    });
+  });
+});

--- a/test/specs/plugins/recordTypes/consultation/serviceConfig.spec.js
+++ b/test/specs/plugins/recordTypes/consultation/serviceConfig.spec.js
@@ -1,0 +1,13 @@
+import serviceConfig from '../../../../../src/plugins/recordTypes/consultation/serviceConfig';
+
+chai.should();
+
+describe('consultation record serviceConfig', () => {
+  it('should have a servicePath property', () => {
+    serviceConfig.should.have.property('servicePath').that.is.a('string');
+    serviceConfig.should.have.property('serviceName').that.is.a('string');
+    serviceConfig.should.have.property('serviceType').that.is.a('string');
+    serviceConfig.should.have.property('objectName').that.is.a('string');
+    serviceConfig.should.have.property('documentName').that.is.a('string');
+  });
+});

--- a/test/specs/plugins/recordTypes/consultation/title.spec.js
+++ b/test/specs/plugins/recordTypes/consultation/title.spec.js
@@ -1,0 +1,74 @@
+import Immutable from 'immutable';
+import createTitleGetter from '../../../../../src/plugins/recordTypes/consultation/title';
+import createConfigContext from '../../../../../src/helpers/createConfigContext';
+
+chai.should();
+
+describe('consultation record title', () => {
+  const configContext = createConfigContext();
+  const title = createTitleGetter(configContext);
+
+  it('should return the consultation number and ? when both are present', () => {
+    const data = Immutable.fromJS({
+      document: {
+        'ns2:consultations_common': {
+          consultationNumber: 'CN',
+          partiesInvolvedGroupList: {
+            partiesInvolvedGroup: {
+              involvedParty: 'urn:cspace:core.collectionspace.org:personauthorities:name(person):item:name(Party)\'Party\'',
+              involvedOnBehalfOf: 'urn:cspace:core.collectionspace.org:orgauthorities:name(organization):item:name(OnBehalfOf)\'OnBehalfOf\'',
+            },
+          },
+        },
+      },
+    });
+
+    title(data).should.equal('CN – Party');
+  });
+
+  it('should return the consultation number only when the title is missing', () => {
+    const data = Immutable.fromJS({
+      document: {
+        'ns2:consultations_common': {
+          consultationNumber: 'CN',
+        },
+      },
+    });
+
+    title(data).should.equal('CN');
+  });
+
+  it('should return the ? only when the consultation number is missing', () => {
+    const data = Immutable.fromJS({
+      document: {
+        'ns2:consultations_common': {
+          partiesInvolvedGroupList: {
+            partiesInvolvedGroup: {
+              involvedParty: 'urn:cspace:core.collectionspace.org:personauthorities:name(person):item:name(Party)\'Party\'',
+              involvedOnBehalfOf: 'urn:cspace:core.collectionspace.org:orgauthorities:name(organization):item:name(OnBehalfOf)\'OnBehalfOf\'',
+            },
+          },
+        },
+      },
+    });
+
+    title(data).should.equal('Party');
+  });
+
+  it('should return an empty string if no document is passed', () => {
+    title(null).should.equal('');
+    title(undefined).should.equal('');
+  });
+
+  it('should return an empty string if the common part is not present', () => {
+    const data = Immutable.fromJS({
+      document: {
+        'ns2:consultations_extension': {
+          consultationAltTitle: 'Alt title',
+        },
+      },
+    });
+
+    title(data).should.equal('');
+  });
+});


### PR DESCRIPTION
**What does this do?**
* Add consultation recordtype
* Add tests for consultation record

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1390

The consultation procedure is part of the 8.1 updates for improving NAGPRA workflows. It adds the ability to document the consultation process itself. 

**How should this be tested? Do these changes have associated tests?**
* Run `npm run lint` and `npm run test` as a sanity check
* Start collectionspace using the related services and application PRs
* Run the devserver `npm run devserver`
* Create and save a consultation
* Use the advanced search and check that field names make sense

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against a local instance