### PR TITLE
DRYD-1399: RestrictedMedia Procedure

### DIFF
--- a/src/plugins/recordTypes/index.js
+++ b/src/plugins/recordTypes/index.js
@@ -40,6 +40,7 @@ import relation from './relation';
 import repatriationclaim from './repatriationclaim';
 import report from './report';
 import reportinvocation from './reportinvocation';
+import restrictedmedia from './restrictedmedia';
 import structdateparser from './structdateparser';
 import summarydocumentation from './summarydocumentation';
 import transport from './transport';
@@ -93,6 +94,7 @@ export default [
   relation,
   report,
   reportinvocation,
+  restrictedmedia,
   structdateparser,
   summarydocumentation,
   valuation,

--- a/src/plugins/recordTypes/restrictedmedia/advancedSearch.js
+++ b/src/plugins/recordTypes/restrictedmedia/advancedSearch.js
@@ -1,0 +1,59 @@
+export default (configContext) => {
+  const {
+    OP_EQ,
+    OP_CONTAIN,
+    OP_RANGE,
+  } = configContext.searchOperators;
+
+  const {
+    defaultAdvancedSearchBooleanOp,
+    extensions,
+  } = configContext.config;
+
+  return {
+    op: defaultAdvancedSearchBooleanOp,
+    value: [
+      {
+        op: OP_CONTAIN,
+        path: 'ns2:restrictedmedia_common/identificationNumber',
+      },
+      {
+        op: OP_CONTAIN,
+        path: 'ns2:restrictedmedia_common/title',
+      },
+      {
+        op: OP_EQ,
+        path: 'ns2:restrictedmedia_common/creator',
+      },
+      {
+        op: OP_EQ,
+        path: 'ns2:restrictedmedia_common/languageList/language',
+      },
+      {
+        op: OP_EQ,
+        path: 'ns2:restrictedmedia_common/publisher',
+      },
+      {
+        op: OP_EQ,
+        path: 'ns2:restrictedmedia_common/typeList/type',
+      },
+      {
+        op: OP_RANGE,
+        path: 'ns2:restrictedmedia_common/dateGroupList/dateGroup',
+      },
+      {
+        op: OP_CONTAIN,
+        path: 'ns2:restrictedmedia_common/source',
+      },
+      {
+        op: OP_CONTAIN,
+        path: 'ns2:restrictedmedia_common/subjectList/subject',
+      },
+      {
+        op: OP_EQ,
+        path: 'ns2:restrictedmedia_common/rightsHolder',
+      },
+      ...extensions.core.advancedSearch,
+    ],
+  };
+};

--- a/src/plugins/recordTypes/restrictedmedia/columns.js
+++ b/src/plugins/recordTypes/restrictedmedia/columns.js
@@ -1,0 +1,58 @@
+import { defineMessages } from 'react-intl';
+
+export default (configContext) => {
+  const {
+    formatTimestamp,
+    thumbnailImage,
+  } = configContext.formatHelpers;
+
+  return {
+    default: {
+      blobCsid: {
+        formatValue: thumbnailImage,
+        messages: defineMessages({
+          label: {
+            id: 'column.restrictedmedia.default.blobCsid',
+            defaultMessage: 'Thumbnail',
+          },
+        }),
+        order: 10,
+        width: 70,
+      },
+      identificationNumber: {
+        messages: defineMessages({
+          label: {
+            id: 'column.restrictedmedia.default.identificationNumber',
+            defaultMessage: 'Identification number',
+          },
+        }),
+        order: 20,
+        sortBy: 'restrictedmedia_common:identificationNumber',
+        width: 200,
+      },
+      title: {
+        messages: defineMessages({
+          label: {
+            id: 'column.restrictedmedia.default.title',
+            defaultMessage: 'Title',
+          },
+        }),
+        order: 30,
+        sortBy: 'restrictedmedia_common:title',
+        width: 380,
+      },
+      updatedAt: {
+        formatValue: formatTimestamp,
+        messages: defineMessages({
+          label: {
+            id: 'column.restrictedmedia.default.updatedAt',
+            defaultMessage: 'Updated',
+          },
+        }),
+        order: 40,
+        sortBy: 'collectionspace_core:updatedAt',
+        width: 150,
+      },
+    },
+  };
+};

--- a/src/plugins/recordTypes/restrictedmedia/fields.js
+++ b/src/plugins/recordTypes/restrictedmedia/fields.js
@@ -1,0 +1,475 @@
+import { defineMessages } from 'react-intl';
+
+export default (configContext) => {
+  const {
+    AutocompleteInput,
+    CompoundInput,
+    IDGeneratorInput,
+    TextInput,
+    OptionPickerInput,
+    StructuredDateInput,
+    TermPickerInput,
+    URLInput,
+    DateInput,
+  } = configContext.inputComponents;
+
+  const {
+    configKey: config,
+  } = configContext.configHelpers;
+
+  const {
+    extensions,
+  } = configContext.config;
+
+  const {
+    DATA_TYPE_DATE,
+    DATA_TYPE_STRUCTURED_DATE,
+  } = configContext.dataTypes;
+
+  const {
+    validateNotInUse,
+  } = configContext.validationHelpers;
+
+  return {
+    document: {
+      [config]: {
+        view: {
+          type: CompoundInput,
+          props: {
+            defaultChildSubpath: 'ns2:restrictedmedia_common',
+          },
+        },
+      },
+      ...extensions.core.fields,
+      'ns2:restrictedmedia_common': {
+        [config]: {
+          service: {
+            ns: 'http://collectionspace.org/services/restrictedmedia',
+          },
+        },
+        identificationNumber: {
+          [config]: {
+            cloneable: false,
+            messages: defineMessages({
+              inUse: {
+                id: 'field.restrictedmedia_common.identificationNumber.inUse',
+                defaultMessage: 'The identification number {value} is in use by another record.',
+              },
+              name: {
+                id: 'field.restrictedmedia_common.identificationNumber.name',
+                defaultMessage: 'Identification number',
+              },
+            }),
+            required: true,
+            searchView: {
+              type: TextInput,
+            },
+            validate: (validationContext) => validateNotInUse({
+              configContext,
+              validationContext,
+              fieldName: 'restrictedmedia_common:identificationNumber',
+            }),
+            view: {
+              type: IDGeneratorInput,
+              props: {
+                source: 'restrictedmedia',
+              },
+            },
+          },
+        },
+        title: {
+          [config]: {
+            messages: defineMessages({
+              name: {
+                id: 'field.restrictedmedia_common.title.name',
+                defaultMessage: 'Title',
+              },
+            }),
+            view: {
+              type: TextInput,
+            },
+          },
+        },
+        externalUrl: {
+          [config]: {
+            // FIXME: Computed fields should recalculate when subrecord fields are committed.
+            compute: ({ subrecordData }) => {
+              const blobData = subrecordData.get('blob');
+
+              if (blobData) {
+                const file = blobData.getIn(['document', 'ns2:blobs_common', 'file']);
+
+                if (typeof file === 'string') {
+                  return file;
+                }
+              }
+
+              return undefined;
+            },
+            messages: defineMessages({
+              name: {
+                id: 'field.restrictedmedia_common.externalUrl.name',
+                defaultMessage: 'External URL',
+              },
+            }),
+            view: {
+              type: URLInput,
+            },
+          },
+        },
+        ...extensions.dimension.fields,
+        contributor: {
+          [config]: {
+            messages: defineMessages({
+              name: {
+                id: 'field.restrictedmedia_common.contributor.name',
+                defaultMessage: 'Contributor',
+              },
+            }),
+            view: {
+              type: AutocompleteInput,
+              props: {
+                source: 'person/local,person/shared,organization/local,organization/shared',
+              },
+            },
+          },
+        },
+        creator: {
+          [config]: {
+            messages: defineMessages({
+              name: {
+                id: 'field.restrictedmedia_common.creator.name',
+                defaultMessage: 'Creator',
+              },
+            }),
+            view: {
+              type: AutocompleteInput,
+              props: {
+                source: 'person/local,person/shared,organization/local,organization/shared',
+              },
+            },
+          },
+        },
+        languageList: {
+          [config]: {
+            view: {
+              type: CompoundInput,
+            },
+          },
+          language: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.restrictedmedia_common.language.name',
+                  defaultMessage: 'Language',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: TermPickerInput,
+                props: {
+                  source: 'languages',
+                },
+              },
+            },
+          },
+        },
+        publisher: {
+          [config]: {
+            messages: defineMessages({
+              name: {
+                id: 'field.restrictedmedia_common.publisher.name',
+                defaultMessage: 'Publisher',
+              },
+            }),
+            view: {
+              type: AutocompleteInput,
+              props: {
+                source: 'person/local,person/shared,organization/local,organization/shared',
+              },
+            },
+          },
+        },
+        relationList: {
+          [config]: {
+            view: {
+              type: CompoundInput,
+            },
+          },
+          relation: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.restrictedmedia_common.relation.name',
+                  defaultMessage: 'Relation',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: TextInput,
+              },
+            },
+          },
+        },
+        copyrightStatement: {
+          [config]: {
+            messages: defineMessages({
+              name: {
+                id: 'field.restrictedmedia_common.copyrightStatement.name',
+                defaultMessage: 'Copyright statement',
+              },
+            }),
+            view: {
+              type: TextInput,
+            },
+          },
+        },
+        typeList: {
+          [config]: {
+            view: {
+              type: CompoundInput,
+            },
+          },
+          type: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.restrictedmedia_common.type.name',
+                  defaultMessage: 'Type',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: OptionPickerInput,
+                props: {
+                  source: 'mediaTypes',
+                },
+              },
+            },
+          },
+        },
+        coverage: {
+          [config]: {
+            messages: defineMessages({
+              name: {
+                id: 'field.restrictedmedia_common.coverage.name',
+                defaultMessage: 'Coverage',
+              },
+            }),
+            view: {
+              type: TextInput,
+            },
+          },
+        },
+        dateGroupList: {
+          [config]: {
+            view: {
+              type: CompoundInput,
+            },
+          },
+          dateGroup: {
+            [config]: {
+              dataType: DATA_TYPE_STRUCTURED_DATE,
+              messages: defineMessages({
+                name: {
+                  id: 'field.restrictedmedia_common.dateGroup.name',
+                  defaultMessage: 'Date',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: StructuredDateInput,
+              },
+            },
+            ...extensions.structuredDate.fields,
+          },
+        },
+        source: {
+          [config]: {
+            messages: defineMessages({
+              name: {
+                id: 'field.restrictedmedia_common.source.name',
+                defaultMessage: 'Source',
+              },
+            }),
+            view: {
+              type: TextInput,
+            },
+          },
+        },
+        subjectList: {
+          [config]: {
+            view: {
+              type: CompoundInput,
+            },
+          },
+          subject: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.restrictedmedia_common.subject.name',
+                  defaultMessage: 'Subject',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: TextInput,
+              },
+            },
+          },
+        },
+        rightsHolder: {
+          [config]: {
+            messages: defineMessages({
+              name: {
+                id: 'field.restrictedmedia_common.rightsHolder.name',
+                defaultMessage: 'Rights holder',
+              },
+            }),
+            view: {
+              type: AutocompleteInput,
+              props: {
+                source: 'person/local,person/shared,organization/local,organization/shared',
+              },
+            },
+          },
+        },
+        description: {
+          [config]: {
+            messages: defineMessages({
+              name: {
+                id: 'field.restrictedmedia_common.description.name',
+                defaultMessage: 'Description',
+              },
+            }),
+            view: {
+              type: TextInput,
+              props: {
+                multiline: true,
+              },
+            },
+          },
+        },
+        publishToList: {
+          [config]: {
+            view: {
+              type: CompoundInput,
+            },
+          },
+          publishTo: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.restrictedmedia_common.publishTo.name',
+                  defaultMessage: 'Publish to',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: TermPickerInput,
+                props: {
+                  source: 'publishto',
+                },
+              },
+            },
+          },
+        },
+        altText: {
+          [config]: {
+            messages: defineMessages({
+              name: {
+                id: 'field.restrictedmedia_common.altText.name',
+                defaultMessage: 'Alt text',
+              },
+            }),
+            view: {
+              type: TextInput,
+              props: {
+                multiline: true,
+              },
+            },
+          },
+        },
+        checksumGroupList: {
+          [config]: {
+            view: {
+              type: CompoundInput,
+            },
+          },
+          checksumGroup: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.restrictedmedia_common.checksumGroup.name',
+                  defaultMessage: 'Checksum',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: CompoundInput,
+                props: {
+                  tabular: true,
+                },
+              },
+            },
+            checksumValue: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.restrictedmedia_common.checksumValue.fullName',
+                    defaultMessage: 'Checksum value',
+                  },
+                  name: {
+                    id: 'field.restrictedmedia_common.checksumValue.name',
+                    defaultMessage: 'Value',
+                  },
+                }),
+                view: {
+                  type: TextInput,
+                },
+              },
+            },
+            checksumType: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.restrictedmedia_common.checksumType.fullName',
+                    defaultMessage: 'Checksum type',
+                  },
+                  name: {
+                    id: 'field.restrictedmedia_common.checksumType.name',
+                    defaultMessage: 'Type',
+                  },
+                }),
+                view: {
+                  type: TermPickerInput,
+                  props: {
+                    source: 'checksumtypes',
+                  },
+                },
+              },
+            },
+            checksumDate: {
+              [config]: {
+                dataType: DATA_TYPE_DATE,
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.restrictedmedia_common.checksumDate.fullName',
+                    defaultMessage: 'Checksum date',
+                  },
+                  name: {
+                    id: 'field.restrictedmedia_common.checksumDate.name',
+                    defaultMessage: 'Date',
+                  },
+                }),
+                view: {
+                  type: DateInput,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+};

--- a/src/plugins/recordTypes/restrictedmedia/forms/default.jsx
+++ b/src/plugins/recordTypes/restrictedmedia/forms/default.jsx
@@ -1,0 +1,109 @@
+import { defineMessages } from 'react-intl';
+
+const template = (configContext) => {
+  const {
+    React,
+  } = configContext.lib;
+
+  const {
+    Col,
+    Cols,
+    Panel,
+  } = configContext.layoutComponents;
+
+  const {
+    Field,
+    Subrecord,
+  } = configContext.recordComponents;
+
+  const {
+    extensions,
+  } = configContext.config;
+
+  return (
+    <Field name="document">
+      <Panel name="media" collapsible>
+        <Cols>
+          <Col>
+            <Field name="identificationNumber" />
+            <Field name="title" />
+          </Col>
+
+          <Col>
+            <Field name="publishToList">
+              <Field name="publishTo" />
+            </Field>
+          </Col>
+        </Cols>
+
+        <Panel name="file" collapsible>
+          <Subrecord name="blob" showDetachButton />
+        </Panel>
+
+        <Field name="externalUrl" />
+
+        {extensions.dimension.form}
+
+        <Field name="checksumGroupList">
+          <Field name="checksumGroup">
+            <Field name="checksumValue" />
+            <Field name="checksumType" />
+            <Field name="checksumDate" />
+          </Field>
+        </Field>
+
+        <Cols>
+          <Col>
+            <Field name="contributor" />
+            <Field name="creator" />
+
+            <Field name="languageList">
+              <Field name="language" />
+            </Field>
+
+            <Field name="publisher" />
+
+            <Field name="relationList">
+              <Field name="relation" />
+            </Field>
+
+            <Field name="copyrightStatement" />
+          </Col>
+
+          <Col>
+            <Field name="typeList">
+              <Field name="type" />
+            </Field>
+
+            <Field name="coverage" />
+
+            <Field name="dateGroupList">
+              <Field name="dateGroup" />
+            </Field>
+
+            <Field name="source" />
+
+            <Field name="subjectList">
+              <Field name="subject" />
+            </Field>
+
+            <Field name="rightsHolder" />
+          </Col>
+        </Cols>
+
+        <Field name="description" />
+        <Field name="altText" />
+      </Panel>
+    </Field>
+  );
+};
+
+export default (configContext) => ({
+  messages: defineMessages({
+    name: {
+      id: 'form.restrictedmedia.default.name',
+      defaultMessage: 'Standard Template',
+    },
+  }),
+  template: template(configContext),
+});

--- a/src/plugins/recordTypes/restrictedmedia/forms/index.js
+++ b/src/plugins/recordTypes/restrictedmedia/forms/index.js
@@ -1,0 +1,5 @@
+import defaultForm from './default';
+
+export default (configContext) => ({
+  default: defaultForm(configContext),
+});

--- a/src/plugins/recordTypes/restrictedmedia/idGenerators.js
+++ b/src/plugins/recordTypes/restrictedmedia/idGenerators.js
@@ -2,7 +2,7 @@ import { defineMessages } from 'react-intl';
 
 export default {
   restrictedmedia: {
-    csid: 'cd91d8b8-f346-4925-a425-93e02bd1c5c9',
+    csid: '17772cbd-8de1-4969-ac2e-c51798bc4e75',
     messages: defineMessages({
       type: {
         id: 'idGenerator.restrictedmedia.type',

--- a/src/plugins/recordTypes/restrictedmedia/idGenerators.js
+++ b/src/plugins/recordTypes/restrictedmedia/idGenerators.js
@@ -1,0 +1,13 @@
+import { defineMessages } from 'react-intl';
+
+export default {
+  restrictedmedia: {
+    csid: 'cd91d8b8-f346-4925-a425-93e02bd1c5c9',
+    messages: defineMessages({
+      type: {
+        id: 'idGenerator.restrictedmedia.type',
+        defaultMessage: 'Restricted Media Resource',
+      },
+    }),
+  },
+};

--- a/src/plugins/recordTypes/restrictedmedia/index.js
+++ b/src/plugins/recordTypes/restrictedmedia/index.js
@@ -1,0 +1,27 @@
+import advancedSearch from './advancedSearch';
+import columns from './columns';
+import fields from './fields';
+import forms from './forms';
+import idGenerators from './idGenerators';
+import messages from './messages';
+import optionLists from './optionLists';
+import serviceConfig from './serviceConfig';
+import subrecords from './subrecords';
+import title from './title';
+
+export default () => (configContext) => ({
+  idGenerators,
+  optionLists,
+  recordTypes: {
+    restrictedmedia: {
+      messages,
+      serviceConfig,
+      advancedSearch: advancedSearch(configContext),
+      columns: columns(configContext),
+      fields: fields(configContext),
+      forms: forms(configContext),
+      subrecords: subrecords(configContext),
+      title: title(configContext),
+    },
+  },
+});

--- a/src/plugins/recordTypes/restrictedmedia/messages.js
+++ b/src/plugins/recordTypes/restrictedmedia/messages.js
@@ -1,0 +1,26 @@
+import { defineMessages } from 'react-intl';
+
+export default {
+  record: defineMessages({
+    name: {
+      id: 'record.restrictedmedia.name',
+      description: 'The name of the record type.',
+      defaultMessage: 'Restricted Media Handling',
+    },
+    collectionName: {
+      id: 'record.restrictedmedia.collectionName',
+      description: 'The name of a collection of records of the type.',
+      defaultMessage: 'Restricted Media Handling',
+    },
+  }),
+  panel: defineMessages({
+    media: {
+      id: 'panel.restrictedmedia.media',
+      defaultMessage: 'Media Handling Information',
+    },
+    file: {
+      id: 'panel.restrictedmedia.file',
+      defaultMessage: 'File Information',
+    },
+  }),
+};

--- a/src/plugins/recordTypes/restrictedmedia/optionLists.js
+++ b/src/plugins/recordTypes/restrictedmedia/optionLists.js
@@ -1,0 +1,35 @@
+import { defineMessages } from 'react-intl';
+
+export default {
+  mediaTypes: {
+    values: [
+      'dataset',
+      'document',
+      'moving_image',
+      'still_image',
+      'sound',
+    ],
+    messages: defineMessages({
+      dataset: {
+        id: 'option.mediaTypes.dataset',
+        defaultMessage: 'dataset',
+      },
+      document: {
+        id: 'option.mediaTypes.document',
+        defaultMessage: 'document',
+      },
+      moving_image: {
+        id: 'option.mediaTypes.moving_image',
+        defaultMessage: 'moving image',
+      },
+      still_image: {
+        id: 'option.mediaTypes.still_image',
+        defaultMessage: 'still image',
+      },
+      sound: {
+        id: 'option.mediaTypes.sound',
+        defaultMessage: 'sound',
+      },
+    }),
+  },
+};

--- a/src/plugins/recordTypes/restrictedmedia/serviceConfig.js
+++ b/src/plugins/recordTypes/restrictedmedia/serviceConfig.js
@@ -1,0 +1,8 @@
+export default {
+  serviceName: 'RestrictedMedia',
+  servicePath: 'restrictedmedia',
+  serviceType: 'procedure',
+
+  objectName: 'RestrictedMedia',
+  documentName: 'restrictedmedia',
+};

--- a/src/plugins/recordTypes/restrictedmedia/subrecords.js
+++ b/src/plugins/recordTypes/restrictedmedia/subrecords.js
@@ -1,0 +1,28 @@
+export default (configContext) => {
+  const {
+    isNewRecord,
+  } = configContext.recordDataHelpers;
+
+  return {
+    blob: {
+      recordType: 'blob',
+      csidField: ['document', 'ns2:restrictedmedia_common', 'blobCsid'],
+      saveStage: 'before',
+      saveCondition: (data) => {
+        // Only save new records that have the file field set.
+
+        if (!isNewRecord(data)) {
+          return false;
+        }
+
+        const file = data.getIn(['document', 'ns2:blobs_common', 'file']);
+
+        if (!file) {
+          return false;
+        }
+
+        return ((file instanceof Array && file.length > 0) || typeof file === 'string');
+      },
+    },
+  };
+};

--- a/src/plugins/recordTypes/restrictedmedia/title.js
+++ b/src/plugins/recordTypes/restrictedmedia/title.js
@@ -1,0 +1,20 @@
+export default (configContext) => (data) => {
+  const {
+    getPart,
+  } = configContext.recordDataHelpers;
+
+  if (!data) {
+    return '';
+  }
+
+  const common = getPart(data, 'restrictedmedia_common');
+
+  if (!common) {
+    return '';
+  }
+
+  const identificationNumber = common.get('identificationNumber');
+  const title = common.get('title');
+
+  return [identificationNumber, title].filter((part) => !!part).join(' – ');
+};

--- a/test/specs/plugins/recordTypes/restrictedmedia/fields.spec.js
+++ b/test/specs/plugins/recordTypes/restrictedmedia/fields.spec.js
@@ -1,0 +1,64 @@
+import Immutable from 'immutable';
+import get from 'lodash/get';
+import createFields from '../../../../../src/plugins/recordTypes/restrictedmedia/fields';
+import { configKey } from '../../../../../src/helpers/configHelpers';
+import createConfigContext from '../../../../../src/helpers/createConfigContext';
+
+const { expect } = chai;
+
+chai.should();
+
+describe('restrictedmedia record fields', () => {
+  const configContext = createConfigContext();
+  const fields = createFields(configContext);
+
+  describe('externalUrl field computation', () => {
+    it('should set the value to the value of the blob\'s file field', () => {
+      const externalUrlFieldConfig = get(fields, ['document', 'ns2:restrictedmedia_common', 'externalUrl', configKey]);
+
+      externalUrlFieldConfig.should.be.an('object');
+
+      const fileUrl = 'http://some/file/url';
+
+      const subrecordData = Immutable.fromJS({
+        blob: {
+          document: {
+            'ns2:blobs_common': {
+              file: fileUrl,
+            },
+          },
+        },
+      });
+
+      externalUrlFieldConfig.compute({ subrecordData }).should.equal(fileUrl);
+    });
+
+    it('should not set the value (should return undefined) if there is no blob data', () => {
+      const externalUrlFieldConfig = get(fields, ['document', 'ns2:restrictedmedia_common', 'externalUrl', configKey]);
+
+      externalUrlFieldConfig.should.be.an('object');
+
+      const subrecordData = Immutable.Map();
+
+      expect(externalUrlFieldConfig.compute({ subrecordData })).to.equal(undefined);
+    });
+
+    it('should not set the value (should return undefined) if the blob\'s file field is not a string', () => {
+      const externalUrlFieldConfig = get(fields, ['document', 'ns2:restrictedmedia_common', 'externalUrl', configKey]);
+
+      externalUrlFieldConfig.should.be.an('object');
+
+      const subrecordData = Immutable.fromJS({
+        blob: {
+          document: {
+            'ns2:blobs_common': {
+              file: {},
+            },
+          },
+        },
+      });
+
+      expect(externalUrlFieldConfig.compute({ subrecordData })).to.equal(undefined);
+    });
+  });
+});

--- a/test/specs/plugins/recordTypes/restrictedmedia/index.spec.js
+++ b/test/specs/plugins/recordTypes/restrictedmedia/index.spec.js
@@ -1,0 +1,71 @@
+import Immutable from 'immutable';
+import restrictedmediaRecordTypePluginFactory from '../../../../../src/plugins/recordTypes/restrictedmedia';
+import createConfigContext from '../../../../../src/helpers/createConfigContext';
+
+chai.should();
+
+describe('restrictedmedia record plugin', () => {
+  const config = {};
+  const restrictedmediaRecordTypePlugin = restrictedmediaRecordTypePluginFactory(config);
+  const configContext = createConfigContext();
+  const pluginConfigContribution = restrictedmediaRecordTypePlugin(configContext);
+
+  context('blob subrecord save condition', () => {
+    const { saveCondition } = pluginConfigContribution.recordTypes.restrictedmedia.subrecords.blob;
+
+    it('should return false for existing records', () => {
+      const data = Immutable.fromJS({
+        document: {
+          'ns2:collectionspace_core': {
+            // uri is present, so it's an existing record.
+            uri: 'something',
+          },
+        },
+      });
+
+      saveCondition(data).should.equal(false);
+    });
+
+    it('should return true for new records that have a file', () => {
+      const data = Immutable.fromJS({
+        document: {
+          'ns2:collectionspace_core': {
+            // uri is not present, so it's a new record.
+          },
+          'ns2:blobs_common': {
+            file: 'something',
+          },
+        },
+      });
+
+      saveCondition(data).should.equal(true);
+    });
+
+    it('should return false for new records that do not have a file', () => {
+      const data = Immutable.fromJS({
+        document: {
+          'ns2:collectionspace_core': {
+            // uri is not present, so it's a new record.
+          },
+        },
+      });
+
+      saveCondition(data).should.equal(false);
+    });
+
+    it('should return false for new records that have an empty file array', () => {
+      const data = Immutable.fromJS({
+        document: {
+          'ns2:collectionspace_core': {
+            // uri is not present, so it's a new record.
+          },
+          'ns2:blobs_common': {
+            file: [],
+          },
+        },
+      });
+
+      saveCondition(data).should.equal(false);
+    });
+  });
+});

--- a/test/specs/plugins/recordTypes/restrictedmedia/title.spec.js
+++ b/test/specs/plugins/recordTypes/restrictedmedia/title.spec.js
@@ -1,0 +1,66 @@
+import Immutable from 'immutable';
+import createTitleGetter from '../../../../../src/plugins/recordTypes/restrictedmedia/title';
+import createConfigContext from '../../../../../src/helpers/createConfigContext';
+
+chai.should();
+
+describe('restrictedmedia record title', () => {
+  const configContext = createConfigContext();
+  const title = createTitleGetter(configContext);
+
+  it('should concat the identification number and title', () => {
+    const data = Immutable.fromJS({
+      document: {
+        'ns2:restrictedmedia_common': {
+          identificationNumber: 'MR2017.1.1',
+          title: 'Media Title',
+        },
+      },
+    });
+
+    title(data).should.equal('MR2017.1.1 – Media Title');
+  });
+
+  it('should return the identificatino number when title is empty', () => {
+    const data = Immutable.fromJS({
+      document: {
+        'ns2:restrictedmedia_common': {
+          identificationNumber: 'MR2017.1.1',
+          title: '',
+        },
+      },
+    });
+
+    title(data).should.equal('MR2017.1.1');
+  });
+
+  it('should return the title when identification number is empty', () => {
+    const data = Immutable.fromJS({
+      document: {
+        'ns2:restrictedmedia_common': {
+          identificationNumber: '',
+          title: 'Media Title',
+        },
+      },
+    });
+
+    title(data).should.equal('Media Title');
+  });
+
+  it('should return empty string if no data is passed', () => {
+    title(null).should.equal('');
+    title(undefined).should.equal('');
+  });
+
+  it('should return empty string if the common part is not present', () => {
+    const data = Immutable.fromJS({
+      document: {
+        'ns2:restrictedmedia_extension': {
+          foo: 'bar',
+        },
+      },
+    });
+
+    title(data).should.equal('');
+  });
+});


### PR DESCRIPTION
**What does this do?**
* Add RestrictedMedia record type
* Add RestrictedMedia tests

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1399

This adds record type for RestrictedMedia, which is intended for use in workflows where there may be sensitive media which should not be immediately accessible. 

**How should this be tested? Do these changes have associated tests?**

* Run `npm run lint` and `npm run test` as a sanity check
* Run the devserver `npm run devserver`
* Test that the restrictedmedia resource can save and upload blobs

**Dependencies for merging? Releasing to production?**
This will eventually need a new type of view for the blob to prevent the thumbnail from automatically showing.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally
