### PR TITLE
DRYD-1447: Remove default values for dynamic term lists

### DIFF
--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -385,7 +385,6 @@ export default (configContext) => {
           },
           publishTo: {
             [config]: {
-              defaultValue: 'urn:cspace:core.collectionspace.org:vocabularies:name(publishto):item:name(none)\'None\'',
               messages: defineMessages({
                 name: {
                   id: 'field.collectionobjects_common.publishTo.name',
@@ -410,7 +409,6 @@ export default (configContext) => {
           },
           inventoryStatus: {
             [config]: {
-              defaultValue: 'urn:cspace:core.collectionspace.org:vocabularies:name(inventorystatus):item:name(unknown)\'unknown\'',
               messages: defineMessages({
                 name: {
                   id: 'field.collectionobjects_common.inventoryStatus.name',


### PR DESCRIPTION
**What does this do?**
* Removes default values for dynamic term lists

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1447

A user is able to remove the default values from the sources (`publishto` and `inventorystatus`), which causes the display in the field to be invalid. Note - the ticket mentions `recordStatus` but that field is controlled by an option picker. I believe it was just a typo, and should have been `publishTo`.  

**How should this be tested? Do these changes have associated tests?**
* Run the devserver, e.g. `npm run devserver --back-end=https://core.dev.collectionspace.org`
* Go to create a collectionobject and see that the `Publish to` and `Inventory status` fields do not have default values

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally