### PR TITLE
Consultation Updates

### DIFF
--- a/src/plugins/recordTypes/consultation/fields.js
+++ b/src/plugins/recordTypes/consultation/fields.js
@@ -164,7 +164,7 @@ export default (configContext) => {
                 view: {
                   type: AutocompleteInput,
                   props: {
-                    source: 'person/local,person/ulan',
+                    source: 'person/local',
                   },
                 },
               },
@@ -184,7 +184,7 @@ export default (configContext) => {
                 view: {
                   type: AutocompleteInput,
                   props: {
-                    source: 'organization/local,organization/ulan',
+                    source: 'organization/local',
                   },
                 },
               },
@@ -272,7 +272,7 @@ export default (configContext) => {
                   view: {
                     type: AutocompleteInput,
                     props: {
-                      source: 'person/local,person/ulan',
+                      source: 'person/local',
                     },
                   },
                 },

--- a/src/plugins/recordTypes/consultation/fields.js
+++ b/src/plugins/recordTypes/consultation/fields.js
@@ -261,11 +261,11 @@ export default (configContext) => {
                   messages: defineMessages({
                     fullName: {
                       id: 'field.consultations_common.consultParty.fullName',
-                      defaultMessage: 'Consultation log party',
+                      defaultMessage: 'Consultation log recipient',
                     },
                     name: {
                       id: 'field.consultations_common.consultParty.name',
-                      defaultMessage: 'Party',
+                      defaultMessage: 'Recipient',
                     },
                   }),
                   repeating: true,

--- a/src/plugins/recordTypes/consultation/fields.js
+++ b/src/plugins/recordTypes/consultation/fields.js
@@ -154,11 +154,11 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.consultations_common.involvedParty.fullName',
-                    defaultMessage: 'Parties involved party',
+                    defaultMessage: 'Parties involved person',
                   },
                   name: {
                     id: 'field.consultations_common.involvedParty.name',
-                    defaultMessage: 'Party',
+                    defaultMessage: 'Person',
                   },
                 }),
                 view: {


### PR DESCRIPTION
**What does this do?**
* Remove ulan from autocomplete sources
* Relabel party involved name to person
* Relabel consultParty to recipient

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1390

These are changes requested based on preliminary testing of the consultation procedure. Fairly minor requests - just removing ulan from sources so they only use the `{person,org}/local` authority and some relabeling of fields.

**How should this be tested? Do these changes have associated tests?**
* Run the devserver
* See that the autocomplete sources for `involvedParty`, `involvedOnBehalfOf`, and `consultParty` are restricted to local authorities
* See updates labels for `involvedParty` and `consultParty`

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally