### PR TITLE
DRYD-1311: Set lang attr

### DIFF
--- a/src/components/pages/RootPage.jsx
+++ b/src/components/pages/RootPage.jsx
@@ -52,6 +52,7 @@ function RootPage(props) {
       <Helmet
         defaultTitle={title}
         titleTemplate={`%s | ${title}`}
+        htmlAttributes={{ lang: intl.locale }}
       >
         {/*
           * TODO: Generate a full set of icons to support a range of platforms (e.g. using

--- a/src/service.jsx
+++ b/src/service.jsx
@@ -62,6 +62,7 @@ export default (uiConfig) => {
         <Helmet
           defaultTitle={title}
           titleTemplate={`%s | ${title}`}
+          htmlAttributes={{ lang: locale }}
         >
           {/*
             * TODO: Generate a full set of icons to support a range of platforms (e.g. using


### PR DESCRIPTION
**What does this do?**
* Set the lang attribute

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1311

This is part of the wcag focused work, and adds the lang attribute to the html tag through helmet. 

**How should this be tested? Do these changes have associated tests?**
* Run the devserver, e.g.
```
npm run devserver --back-end=https://core.dev.collectionspace.org
```
* Inspect the page and look at the `<html>` tag
* Ensure the `lang` attr is set to the current locale

**Dependencies for merging? Releasing to production?**
Currently this doesn't update the SSO login, logout, and password reset pages. I tried to update the pages themselves, as well as `service.jsx`, but none would add the lang attr. Still investigating what's going on there.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested with the default locale