### PR TITLE
Duty of Care Updates

### DIFF
--- a/src/plugins/recordTypes/dutyofcare/advancedSearch.js
+++ b/src/plugins/recordTypes/dutyofcare/advancedSearch.js
@@ -13,7 +13,7 @@ export default (configContext) => {
     value: [
       {
         op: OP_CONTAIN,
-        path: 'ns2:dutyofcares_common/dutyOfCareNumber',
+        path: 'ns2:dutiesofcare_common/dutyOfCareNumber',
       },
       ...extensions.core.advancedSearch,
     ],

--- a/src/plugins/recordTypes/dutyofcare/columns.js
+++ b/src/plugins/recordTypes/dutyofcare/columns.js
@@ -15,7 +15,7 @@ export default (configContext) => {
           },
         }),
         order: 10,
-        sortBy: 'dutyofcares_common:dutyOfCareNumber',
+        sortBy: 'dutiesofcare_common:dutyOfCareNumber',
         width: 200,
       },
       title: {
@@ -26,7 +26,7 @@ export default (configContext) => {
           },
         }),
         order: 20,
-        sortBy: 'dutyofcares_common:title',
+        sortBy: 'dutiesofcare_common:title',
         width: 200,
       },
       updatedAt: {

--- a/src/plugins/recordTypes/dutyofcare/columns.js
+++ b/src/plugins/recordTypes/dutyofcare/columns.js
@@ -18,15 +18,15 @@ export default (configContext) => {
         sortBy: 'dutiesofcare_common:dutyOfCareNumber',
         width: 200,
       },
-      title: {
+      dutyOfCareTitle: {
         messages: defineMessages({
           label: {
-            id: 'column.dutyofcare.default.title',
+            id: 'column.dutyofcare.default.dutyOfCareTitle',
             defaultMessage: 'Title',
           },
         }),
         order: 20,
-        sortBy: 'dutiesofcare_common:title',
+        sortBy: 'dutiesofcare_common:dutyOfCareTitle',
         width: 200,
       },
       updatedAt: {

--- a/src/plugins/recordTypes/dutyofcare/fields.js
+++ b/src/plugins/recordTypes/dutyofcare/fields.js
@@ -198,7 +198,7 @@ export default (configContext) => {
                 view: {
                   type: AutocompleteInput,
                   props: {
-                    source: 'person/local,person/ulan,organization/local,organization/ulan',
+                    source: 'person/local,organization/local',
                   },
                 },
               },
@@ -280,7 +280,7 @@ export default (configContext) => {
                 view: {
                   type: AutocompleteInput,
                   props: {
-                    source: 'person/local,person/ulan',
+                    source: 'person/local',
                   },
                 },
               },
@@ -300,7 +300,7 @@ export default (configContext) => {
                 view: {
                   type: AutocompleteInput,
                   props: {
-                    source: 'organization/local,organization/ulan',
+                    source: 'organization/local',
                   },
                 },
               },

--- a/src/plugins/recordTypes/dutyofcare/fields.js
+++ b/src/plugins/recordTypes/dutyofcare/fields.js
@@ -270,11 +270,11 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.dutyofcares_common.involvedParty.fullName',
-                    defaultMessage: 'Party involved name',
+                    defaultMessage: 'Party involved person',
                   },
                   name: {
                     id: 'field.dutyofcares_common.involvedParty.name',
-                    defaultMessage: 'Name',
+                    defaultMessage: 'Person',
                   },
                 }),
                 view: {

--- a/src/plugins/recordTypes/dutyofcare/fields.js
+++ b/src/plugins/recordTypes/dutyofcare/fields.js
@@ -87,11 +87,11 @@ export default (configContext) => {
             },
           },
         },
-        title: {
+        dutyOfCareTitle: {
           [config]: {
             messages: defineMessages({
               name: {
-                id: 'field.dutiesofcare_common.title.name',
+                id: 'field.dutiesofcare_common.dutyOfCareTitle.name',
                 defaultMessage: 'Title',
               },
             }),

--- a/src/plugins/recordTypes/dutyofcare/fields.js
+++ b/src/plugins/recordTypes/dutyofcare/fields.js
@@ -32,12 +32,12 @@ export default (configContext) => {
         view: {
           type: CompoundInput,
           props: {
-            defaultChildSubpath: 'ns2:dutyofcares_common',
+            defaultChildSubpath: 'ns2:dutiesofcare_common',
           },
         },
       },
       ...extensions.core.fields,
-      'ns2:dutyofcares_common': {
+      'ns2:dutiesofcare_common': {
         [config]: {
           service: {
             ns: 'http://collectionspace.org/services/dutyofcare',
@@ -48,11 +48,11 @@ export default (configContext) => {
             cloneable: false,
             messages: defineMessages({
               inUse: {
-                id: 'field.dutyofcares_common.dutyOfCareNumber.inUse',
+                id: 'field.dutiesofcare_common.dutyOfCareNumber.inUse',
                 defaultMessage: 'The identification number {value} is in use by another record.',
               },
               name: {
-                id: 'field.dutyofcares_common.dutyOfCareNumber.name',
+                id: 'field.dutiesofcare_common.dutyOfCareNumber.name',
                 defaultMessage: 'Duty of care number',
               },
             }),
@@ -63,7 +63,7 @@ export default (configContext) => {
             validate: (validationContext) => validateNotInUse({
               configContext,
               validationContext,
-              fieldName: 'dutyofcares_common:dutyOfCareNumber',
+              fieldName: 'dutiesofcare_common:dutyOfCareNumber',
             }),
             view: {
               type: IDGeneratorInput,
@@ -78,7 +78,7 @@ export default (configContext) => {
             dataType: DATA_TYPE_DATE,
             messages: defineMessages({
               name: {
-                id: 'field.dutyofcares_common.originationDate.name',
+                id: 'field.dutiesofcare_common.originationDate.name',
                 defaultMessage: 'Origination date',
               },
             }),
@@ -91,7 +91,7 @@ export default (configContext) => {
           [config]: {
             messages: defineMessages({
               name: {
-                id: 'field.dutyofcares_common.title.name',
+                id: 'field.dutiesofcare_common.title.name',
                 defaultMessage: 'Title',
               },
             }),
@@ -110,7 +110,7 @@ export default (configContext) => {
             [config]: {
               messages: defineMessages({
                 name: {
-                  id: 'field.dutyofcares_common.note.name',
+                  id: 'field.dutiesofcare_common.note.name',
                   defaultMessage: 'Note',
                 },
               }),
@@ -134,7 +134,7 @@ export default (configContext) => {
             [config]: {
               messages: defineMessages({
                 name: {
-                  id: 'field.dutyofcares_common.detailGroup.name',
+                  id: 'field.dutiesofcare_common.detailGroup.name',
                   defaultMessage: 'Duty of care detail',
                 },
               }),
@@ -147,11 +147,11 @@ export default (configContext) => {
               [config]: {
                 messages: defineMessages({
                   fullName: {
-                    id: 'field.dutyofcares_common.detailType.fullName',
+                    id: 'field.dutiesofcare_common.detailType.fullName',
                     defaultMessage: 'Duty of care detail type',
                   },
                   name: {
-                    id: 'field.dutyofcares_common.detailType.name',
+                    id: 'field.dutiesofcare_common.detailType.name',
                     defaultMessage: 'Type',
                   },
                 }),
@@ -167,11 +167,11 @@ export default (configContext) => {
               [config]: {
                 messages: defineMessages({
                   fullName: {
-                    id: 'field.dutyofcares_common.detailLevel.fullName',
+                    id: 'field.dutiesofcare_common.detailLevel.fullName',
                     defaultMessage: 'Duty of care detail level',
                   },
                   name: {
-                    id: 'field.dutyofcares_common.detailLevel.name',
+                    id: 'field.dutiesofcare_common.detailLevel.name',
                     defaultMessage: 'Level',
                   },
                 }),
@@ -187,11 +187,11 @@ export default (configContext) => {
               [config]: {
                 messages: defineMessages({
                   fullName: {
-                    id: 'field.dutyofcares_common.detailDeterminedBy.fullName',
+                    id: 'field.dutiesofcare_common.detailDeterminedBy.fullName',
                     defaultMessage: 'Duty of care detail determined by',
                   },
                   name: {
-                    id: 'field.dutyofcares_common.detailDeterminedBy.name',
+                    id: 'field.dutiesofcare_common.detailDeterminedBy.name',
                     defaultMessage: 'Determined by',
                   },
                 }),
@@ -208,11 +208,11 @@ export default (configContext) => {
                 dataType: DATA_TYPE_DATE,
                 messages: defineMessages({
                   fullName: {
-                    id: 'field.dutyofcares_common.detailDeterminationDate.fullName',
+                    id: 'field.dutiesofcare_common.detailDeterminationDate.fullName',
                     defaultMessage: 'Duty of care detail determination date',
                   },
                   name: {
-                    id: 'field.dutyofcares_common.detailDeterminationDate.name',
+                    id: 'field.dutiesofcare_common.detailDeterminationDate.name',
                     defaultMessage: 'Determination date',
                   },
                 }),
@@ -225,11 +225,11 @@ export default (configContext) => {
               [config]: {
                 messages: defineMessages({
                   fullName: {
-                    id: 'field.dutyofcares_common.detailNote.fullName',
+                    id: 'field.dutiesofcare_common.detailNote.fullName',
                     defaultMessage: 'Duty of care detail note',
                   },
                   name: {
-                    id: 'field.dutyofcares_common.detailNote.name',
+                    id: 'field.dutiesofcare_common.detailNote.name',
                     defaultMessage: 'Note',
                   },
                 }),
@@ -253,7 +253,7 @@ export default (configContext) => {
             [config]: {
               messages: defineMessages({
                 name: {
-                  id: 'field.dutyofcares_common.partiesInvolvedGroup.name',
+                  id: 'field.dutiesofcare_common.partiesInvolvedGroup.name',
                   defaultMessage: 'Party involved',
                 },
               }),
@@ -269,11 +269,11 @@ export default (configContext) => {
               [config]: {
                 messages: defineMessages({
                   fullName: {
-                    id: 'field.dutyofcares_common.involvedParty.fullName',
+                    id: 'field.dutiesofcare_common.involvedParty.fullName',
                     defaultMessage: 'Party involved person',
                   },
                   name: {
-                    id: 'field.dutyofcares_common.involvedParty.name',
+                    id: 'field.dutiesofcare_common.involvedParty.name',
                     defaultMessage: 'Person',
                   },
                 }),
@@ -289,11 +289,11 @@ export default (configContext) => {
               [config]: {
                 messages: defineMessages({
                   fullName: {
-                    id: 'field.dutyofcares_common.involvedOnBehalfOf.fullName',
+                    id: 'field.dutiesofcare_common.involvedOnBehalfOf.fullName',
                     defaultMessage: 'Party involved on behalf of',
                   },
                   name: {
-                    id: 'field.dutyofcares_common.involvedOnBehalfOf.name',
+                    id: 'field.dutiesofcare_common.involvedOnBehalfOf.name',
                     defaultMessage: 'On behalf of',
                   },
                 }),
@@ -309,11 +309,11 @@ export default (configContext) => {
               [config]: {
                 messages: defineMessages({
                   fullName: {
-                    id: 'field.dutyofcares_common.involvedRole.fullName',
+                    id: 'field.dutiesofcare_common.involvedRole.fullName',
                     defaultMessage: 'Party involved roles',
                   },
                   name: {
-                    id: 'field.dutyofcares_common.involvedRole.name',
+                    id: 'field.dutiesofcare_common.involvedRole.name',
                     defaultMessage: 'Role',
                   },
                 }),

--- a/src/plugins/recordTypes/dutyofcare/forms/default.jsx
+++ b/src/plugins/recordTypes/dutyofcare/forms/default.jsx
@@ -22,7 +22,7 @@ const template = (configContext) => {
         <Cols>
           <Col>
             <Field name="dutyOfCareNumber" />
-            <Field name="title" />
+            <Field name="dutyOfCareTitle" />
           </Col>
           <Col>
             <Field name="originationDate" />

--- a/src/plugins/recordTypes/dutyofcare/messages.js
+++ b/src/plugins/recordTypes/dutyofcare/messages.js
@@ -10,7 +10,7 @@ export default {
     collectionName: {
       id: 'record.dutyofcare.collectionName',
       description: 'The name of a collection of records of the type.',
-      defaultMessage: 'Duty of Cares',
+      defaultMessage: 'Duties of Care',
     },
   }),
   panel: defineMessages({

--- a/src/plugins/recordTypes/dutyofcare/serviceConfig.js
+++ b/src/plugins/recordTypes/dutyofcare/serviceConfig.js
@@ -1,6 +1,6 @@
 export default {
   serviceName: 'Dutyofcare',
-  servicePath: 'dutyofcares',
+  servicePath: 'dutiesofcare',
   serviceType: 'procedure',
 
   objectName: 'Dutyofcare',

--- a/src/plugins/recordTypes/dutyofcare/title.js
+++ b/src/plugins/recordTypes/dutyofcare/title.js
@@ -14,7 +14,7 @@ export default (configContext) => (data) => {
   }
 
   const referenceNumber = common.get('dutyOfCareNumber');
-  const title = common.get('title');
+  const dutyOfCareTitle = common.get('dutyOfCareTitle');
 
-  return [referenceNumber, title].filter((part) => !!part).join(' – ');
+  return [referenceNumber, dutyOfCareTitle].filter((part) => !!part).join(' – ');
 };

--- a/src/plugins/recordTypes/dutyofcare/title.js
+++ b/src/plugins/recordTypes/dutyofcare/title.js
@@ -7,7 +7,7 @@ export default (configContext) => (data) => {
     return '';
   }
 
-  const common = getPart(data, 'dutyofcares_common');
+  const common = getPart(data, 'dutiesofcare_common');
 
   if (!common) {
     return '';

--- a/test/specs/plugins/recordTypes/dutyofcare/title.spec.js
+++ b/test/specs/plugins/recordTypes/dutyofcare/title.spec.js
@@ -11,7 +11,7 @@ describe('dutyofcare record title', () => {
   it('should return the dutyofcare number and title when both are present', () => {
     const data = Immutable.fromJS({
       document: {
-        'ns2:dutyofcares_common': {
+        'ns2:dutiesofcare_common': {
           dutyOfCareNumber: 'DC',
           title: 'Title',
         },
@@ -24,7 +24,7 @@ describe('dutyofcare record title', () => {
   it('should return the dutyofcare number only when the title is missing', () => {
     const data = Immutable.fromJS({
       document: {
-        'ns2:dutyofcares_common': {
+        'ns2:dutiesofcare_common': {
           dutyOfCareNumber: 'DC',
         },
       },
@@ -36,7 +36,7 @@ describe('dutyofcare record title', () => {
   it('should return the title only when the dutyofcare number is missing', () => {
     const data = Immutable.fromJS({
       document: {
-        'ns2:dutyofcares_common': {
+        'ns2:dutiesofcare_common': {
           title: 'Title',
         },
       },
@@ -53,7 +53,7 @@ describe('dutyofcare record title', () => {
   it('should return an empty string if the common part is not present', () => {
     const data = Immutable.fromJS({
       document: {
-        'ns2:dutyofcares_extension': {
+        'ns2:dutiesofcare_extension': {
           dutyofcareAltTitle: 'Alt dutyofcare title',
         },
       },

--- a/test/specs/plugins/recordTypes/dutyofcare/title.spec.js
+++ b/test/specs/plugins/recordTypes/dutyofcare/title.spec.js
@@ -8,12 +8,12 @@ describe('dutyofcare record title', () => {
   const configContext = createConfigContext();
   const title = createTitleGetter(configContext);
 
-  it('should return the dutyofcare number and title when both are present', () => {
+  it('should return the dutyofcare number and dutyOfCareTitle when both are present', () => {
     const data = Immutable.fromJS({
       document: {
         'ns2:dutiesofcare_common': {
           dutyOfCareNumber: 'DC',
-          title: 'Title',
+          dutyOfCareTitle: 'Title',
         },
       },
     });
@@ -21,7 +21,7 @@ describe('dutyofcare record title', () => {
     title(data).should.equal('DC – Title');
   });
 
-  it('should return the dutyofcare number only when the title is missing', () => {
+  it('should return the dutyofcare number only when the dutyOfCareTitle is missing', () => {
     const data = Immutable.fromJS({
       document: {
         'ns2:dutiesofcare_common': {
@@ -33,11 +33,11 @@ describe('dutyofcare record title', () => {
     title(data).should.equal('DC');
   });
 
-  it('should return the title only when the dutyofcare number is missing', () => {
+  it('should return the dutyOfCareTitle only when the dutyofcare number is missing', () => {
     const data = Immutable.fromJS({
       document: {
         'ns2:dutiesofcare_common': {
-          title: 'Title',
+          dutyOfCareTitle: 'Title',
         },
       },
     });
@@ -54,7 +54,7 @@ describe('dutyofcare record title', () => {
     const data = Immutable.fromJS({
       document: {
         'ns2:dutiesofcare_extension': {
-          dutyofcareAltTitle: 'Alt dutyofcare title',
+          dutyofcareAltTitle: 'Alt dutyofcare dutyOfCareTitle',
         },
       },
     });


### PR DESCRIPTION
**What does this do?**
* Fix pluralization for duty of care
* Remove ulan from various sources
* Update involvedParty label
* Rename title to dutyOfCareTitle

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1332

These changes come from the testing done against Duty of Care. It changes the pluralization used in the ui and the schema, and updates the involvedParty label. I also noticed that the `title` was not always being pulled correctly from the services layer so it has been renamed to `dutyOfCareTitle`.

**How should this be tested? Do these changes have associated tests?**
* Run `npm run lint` and `npm run test`
* Rebuild the other PRs and start collectionspace
* Start the devserver, `npm run devserver`
* Check that the Duty of Care procedure still saves, loads, and can be searched
* Check that the pluralization of correct for Duties of Care
* Check that the label is correct for `involvedParties`
* Check that the title is returned correctly in searches

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against a local instance