### PR TITLE
DRYD-1436: Add related link group

### DIFF
--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -3881,6 +3881,64 @@ export default (configContext) => {
             },
           },
         },
+        publishedRelatedLinkGroupList: {
+          [config]: {
+            view: {
+              type: CompoundInput,
+            },
+          },
+          publishedRelatedLinkGroup: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.procedure.publishedRelatedLinkGroup.name',
+                  defaultMessage: 'Published related link',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: CompoundInput,
+                props: {
+                  tabular: true,
+                },
+              },
+            },
+            relatedLink: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.collectionobjects_common.relatedLink.fullName',
+                    defaultMessage: 'Published related link url',
+                  },
+                  name: {
+                    id: 'field.collectionobjects_common.relatedLink.name',
+                    defaultMessage: 'URL',
+                  },
+                }),
+                view: {
+                  type: URLInput,
+                },
+              },
+            },
+            descriptiveTitle: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.collectionobjects_common.descriptiveTitle.fullName',
+                    defaultMessage: 'Published related link descriptive title',
+                  },
+                  name: {
+                    id: 'field.collectionobjects_common.descriptiveTitle.name',
+                    defaultMessage: 'Descriptive title',
+                  },
+                }),
+                view: {
+                  type: TextInput,
+                },
+              },
+            },
+          },
+        },
         referenceGroupList: {
           [config]: {
             view: {

--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -577,6 +577,13 @@ const template = (configContext) => {
             <Field name="referenceNote" />
           </Field>
         </Field>
+
+        <Field name="publishedRelatedLinkGroupList">
+          <Field name="publishedRelatedLinkGroup">
+            <Field name="relatedLink" />
+            <Field name="descriptiveTitle" />
+          </Field>
+        </Field>
       </Panel>
 
       <Panel name="collect" collapsible collapsed>

--- a/src/plugins/recordTypes/collectionobject/forms/public.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/public.jsx
@@ -162,6 +162,16 @@ const template = (configContext) => {
       <Panel name="viewer" collapsible>
         <Field name="viewersContributionNote" />
       </Panel>
+
+      <Panel name="reference" collapsible>
+        <Field name="publishedRelatedLinkGroupList">
+          <Field name="publishedRelatedLinkGroup">
+            <Field name="relatedLink" />
+            <Field name="descriptiveTitle" />
+          </Field>
+        </Field>
+      </Panel>
+
     </Field>
   );
 };


### PR DESCRIPTION
**What does this do?**
* Add related link group to collectionobject

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1436

This adds related links to the reference information section for collectionobjects.

**How should this be tested? Do these changes have associated tests?**
* Rebuild collectionspace using the related application PR
* Run the devserver (`npm run devserver`) 
* Create a collectionobject and scroll to the Reference Information section
* See that the related link group exists and can be filled out
* Switch to the public browser template and see the same as the above

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally