### PR TITLE
Held-in-Trust QA Updates

### DIFF
--- a/src/plugins/recordTypes/heldintrust/fields.js
+++ b/src/plugins/recordTypes/heldintrust/fields.js
@@ -229,7 +229,7 @@ export default (configContext) => {
               messages: defineMessages({
                 name: {
                   id: 'field.heldintrusts_common.agreementApprovalGroup.name',
-                  defaultMessage: 'Agreement approval',
+                  defaultMessage: 'Held-in-Trust status',
                 },
               }),
               repeating: true,
@@ -242,7 +242,7 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.heldintrusts_common.agreementGroup.fullName',
-                    defaultMessage: 'Agreement approval group',
+                    defaultMessage: 'Held-in-Trust status group',
                   },
                   name: {
                     id: 'field.heldintrusts_common.agreementGroup.name',
@@ -259,7 +259,7 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.heldintrusts_common.agreementIndividual.fullName',
-                    defaultMessage: 'Agreement approval individual',
+                    defaultMessage: 'Held-in-Trust status individual',
                   },
                   name: {
                     id: 'field.heldintrusts_common.agreementIndividual.name',
@@ -279,7 +279,7 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.heldintrusts_common.agreementStatus.fullName',
-                    defaultMessage: 'Agreement approval status',
+                    defaultMessage: 'Held-in-Trust status',
                   },
                   name: {
                     id: 'field.heldintrusts_common.agreementStatus.name',
@@ -300,7 +300,7 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.heldintrusts_common.agreementDate.fullName',
-                    defaultMessage: 'Agreement approval date',
+                    defaultMessage: 'Held-in-Trust status date',
                   },
                   name: {
                     id: 'field.heldintrusts_common.agreementDate.name',
@@ -317,7 +317,7 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.heldintrusts_common.agreementNote.fullName',
-                    defaultMessage: 'Agreement approval note',
+                    defaultMessage: 'Held-in-Trust status note',
                   },
                   name: {
                     id: 'field.heldintrusts_common.agreementNote.name',

--- a/src/plugins/recordTypes/heldintrust/fields.js
+++ b/src/plugins/recordTypes/heldintrust/fields.js
@@ -107,7 +107,7 @@ export default (configContext) => {
               view: {
                 type: AutocompleteInput,
                 props: {
-                  source: 'person/local,person/ulan',
+                  source: 'person/local',
                 },
               },
             },
@@ -269,7 +269,7 @@ export default (configContext) => {
                 view: {
                   type: AutocompleteInput,
                   props: {
-                    source: 'person/local,person/ulan',
+                    source: 'person/local',
                   },
                 },
               },
@@ -386,7 +386,7 @@ export default (configContext) => {
                 view: {
                   type: AutocompleteInput,
                   props: {
-                    source: 'person/local,person/ulan,organization/local,organization/ulan',
+                    source: 'person/local,organization/local',
                   },
                 },
               },
@@ -406,7 +406,7 @@ export default (configContext) => {
                 view: {
                   type: AutocompleteInput,
                   props: {
-                    source: 'person/local,person/ulan,organization/local,organization/ulan',
+                    source: 'person/local,organization/local',
                   },
                 },
               },

--- a/src/plugins/recordTypes/heldintrust/fields.js
+++ b/src/plugins/recordTypes/heldintrust/fields.js
@@ -250,7 +250,10 @@ export default (configContext) => {
                   },
                 }),
                 view: {
-                  type: TextInput,
+                  type: TermPickerInput,
+                  props: {
+                    source: 'deaccessionapprovalgroup',
+                  },
                 },
               },
             },

--- a/src/plugins/recordTypes/heldintrust/fields.js
+++ b/src/plugins/recordTypes/heldintrust/fields.js
@@ -289,7 +289,7 @@ export default (configContext) => {
                 view: {
                   type: TermPickerInput,
                   props: {
-                    source: 'heldintruststatus',
+                    source: 'deaccessionapprovalstatus',
                   },
                 },
               },


### PR DESCRIPTION
**What does this do?**
* Removes ulan from sources
* Update agreementGroup to use deaccessionapprovalgroup
* Update agreementStatus to use deaccessionapprovalstatus
* Update labels to use Held-in-Trust

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1358

This has the changes requested from initial testing that Jessi and Jadeen did on the new procedure. It's mostly minor changes involving relabeling fields and updating sources for terms and autocomplete fields.

**How should this be tested? Do these changes have associated tests?**
* Ensure all tests continue to pass: `npm run lint` and `npm run test`
* Run the devserver `npm run devserver`
* See that the changes exist:
  * `Agreement approval` should become `Held-in-Trust status`
  * `Held-in-Trust group` should be a term picker input using deaccessionapprovalgroup
  * `Held-in-Trust status` should be a term picker input using deaccessionapprovalstatus
  * No autocomplete fields should pull from `ulan` sources

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against a local install