### PR TITLE
SummaryDocumentation QA Updates

### DIFF
--- a/src/plugins/recordTypes/summarydocumentation/columns.js
+++ b/src/plugins/recordTypes/summarydocumentation/columns.js
@@ -7,7 +7,7 @@ export default (configContext) => {
 
   return {
     default: {
-      referenceNumber: {
+      documentationNumber: {
         messages: defineMessages({
           label: {
             id: 'column.summarydocumentation.default.documentationNumber',

--- a/src/plugins/recordTypes/summarydocumentation/fields.js
+++ b/src/plugins/recordTypes/summarydocumentation/fields.js
@@ -207,11 +207,11 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.summarydocumentations_common.involvedParty.fullName',
-                    defaultMessage: 'Party involved name',
+                    defaultMessage: 'Party involved person',
                   },
                   name: {
                     id: 'field.summarydocumentations_common.involvedParty.name',
-                    defaultMessage: 'Name',
+                    defaultMessage: 'Person',
                   },
                 }),
                 view: {

--- a/src/plugins/recordTypes/summarydocumentation/fields.js
+++ b/src/plugins/recordTypes/summarydocumentation/fields.js
@@ -482,7 +482,7 @@ export default (configContext) => {
                 view: {
                   type: TermPickerInput,
                   props: {
-                    source: 'nagprastatus',
+                    source: 'nagpradocumentationstatus',
                   },
                 },
               },

--- a/src/plugins/recordTypes/summarydocumentation/fields.js
+++ b/src/plugins/recordTypes/summarydocumentation/fields.js
@@ -564,7 +564,7 @@ export default (configContext) => {
                 view: {
                   type: AutocompleteInput,
                   props: {
-                    source: 'place/local,place/tgn',
+                    source: 'place/local',
                   },
                 },
               },

--- a/src/plugins/recordTypes/summarydocumentation/fields.js
+++ b/src/plugins/recordTypes/summarydocumentation/fields.js
@@ -217,7 +217,7 @@ export default (configContext) => {
                 view: {
                   type: AutocompleteInput,
                   props: {
-                    source: 'person/local,person/ulan',
+                    source: 'person/local',
                   },
                 },
               },
@@ -237,7 +237,7 @@ export default (configContext) => {
                 view: {
                   type: AutocompleteInput,
                   props: {
-                    source: 'organization/local,organization/ulan',
+                    source: 'organization/local',
                   },
                 },
               },
@@ -298,7 +298,7 @@ export default (configContext) => {
                 view: {
                   type: AutocompleteInput,
                   props: {
-                    source: 'organization/local,organization/ulan',
+                    source: 'organization/local',
                   },
                 },
               },
@@ -345,7 +345,7 @@ export default (configContext) => {
                   view: {
                     type: AutocompleteInput,
                     props: {
-                      source: 'person/local,person/ulan,organization/local,organization/ulan',
+                      source: 'person/local,organization/local',
                     },
                   },
                 },
@@ -462,7 +462,7 @@ export default (configContext) => {
                 view: {
                   type: AutocompleteInput,
                   props: {
-                    source: 'person/local,person/ulan',
+                    source: 'person/local',
                   },
                 },
               },

--- a/src/plugins/recordTypes/summarydocumentation/fields.js
+++ b/src/plugins/recordTypes/summarydocumentation/fields.js
@@ -288,11 +288,11 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.summarydocumentations_common.tribeOrNation.fullName',
-                    defaultMessage: 'Summary affiliation tribe',
+                    defaultMessage: 'Summary affiliation tribe/nation',
                   },
                   name: {
                     id: 'field.summarydocumentations_common.tribeOrNation.name',
-                    defaultMessage: 'Tribe',
+                    defaultMessage: 'Tribe/Nation',
                   },
                 }),
                 view: {

--- a/src/plugins/recordTypes/summarydocumentation/fields.js
+++ b/src/plugins/recordTypes/summarydocumentation/fields.js
@@ -427,7 +427,10 @@ export default (configContext) => {
               }),
               repeating: true,
               view: {
-                type: CompoundInput,
+                type: TermPickerInput,
+                props: {
+                  source: 'documentationgroup',
+                },
               },
             },
             statusGroupType: {

--- a/src/plugins/recordTypes/summarydocumentation/fields.js
+++ b/src/plugins/recordTypes/summarydocumentation/fields.js
@@ -264,17 +264,17 @@ export default (configContext) => {
             },
           },
         },
-        culturalAffiliationGroupList: {
+        affiliationGroupList: {
           [config]: {
             view: {
               type: CompoundInput,
             },
           },
-          culturalAffiliationGroup: {
+          affiliationGroup: {
             [config]: {
               messages: defineMessages({
                 name: {
-                  id: 'field.summarydocumentations_common.culturalAffiliationGroup.name',
+                  id: 'field.summarydocumentations_common.affiliationGroup.name',
                   defaultMessage: 'Summary affiliation',
                 },
               }),

--- a/src/plugins/recordTypes/summarydocumentation/fields.js
+++ b/src/plugins/recordTypes/summarydocumentation/fields.js
@@ -686,7 +686,7 @@ export default (configContext) => {
                 view: {
                   type: AutocompleteInput,
                   props: {
-                    source: 'concept/ethculture',
+                    source: 'concept/ethculture,concept/archculture',
                   },
                 },
               },

--- a/src/plugins/recordTypes/summarydocumentation/fields.js
+++ b/src/plugins/recordTypes/summarydocumentation/fields.js
@@ -427,10 +427,7 @@ export default (configContext) => {
               }),
               repeating: true,
               view: {
-                type: TermPickerInput,
-                props: {
-                  source: 'documentationgroup',
-                },
+                type: CompoundInput,
               },
             },
             statusGroupType: {
@@ -446,7 +443,10 @@ export default (configContext) => {
                   },
                 }),
                 view: {
-                  type: TextInput,
+                  type: TermPickerInput,
+                  props: {
+                    source: 'documentationgroup',
+                  },
                 },
               },
             },

--- a/src/plugins/recordTypes/summarydocumentation/forms/default.jsx
+++ b/src/plugins/recordTypes/summarydocumentation/forms/default.jsx
@@ -48,8 +48,8 @@ const template = (configContext) => {
           </Field>
         </Field>
 
-        <Field name="culturalAffiliationGroupList">
-          <Field name="culturalAffiliationGroup">
+        <Field name="affiliationGroupList">
+          <Field name="affiliationGroup">
             <Panel>
               <Row>
                 <Field name="tribeOrNation" />


### PR DESCRIPTION
**What does this do?**
* Remove ulan from sources
* Remove tgn from sources
* Update statusGroupType to be a TermPickerInput
* Add archculture to culture source
* Use nagpradocumentationstatus for statusGroup.status source
* Rename culturalAffiliationGroup to affiliationGroup
* Relabel some fields
* Fix incorrect field name

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1333

These are changes that came from the initial testing that Jessi and Jadeen did.

**How should this be tested? Do these changes have associated tests?**
* Rebuild and start collectionspace
* Run `npm run lint` and `npm run test`
* Start the devserver
* Create a Summary Documentation procedure and see the changes to the form are as expected
* Search for Summary Documentations and see the Documentation Number populated

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally