### PR TITLE
Claim QA Updates

### DIFF
--- a/src/plugins/recordTypes/repatriationclaim/fields.js
+++ b/src/plugins/recordTypes/repatriationclaim/fields.js
@@ -473,7 +473,7 @@ export default (configContext) => {
                 view: {
                   type: AutocompleteInput,
                   props: {
-                    source: 'concept/ethculture',
+                    source: 'concept/ethculture,concept/archculture',
                   },
                 },
               },

--- a/src/plugins/recordTypes/repatriationclaim/fields.js
+++ b/src/plugins/recordTypes/repatriationclaim/fields.js
@@ -261,7 +261,7 @@ export default (configContext) => {
                   },
                   name: {
                     id: 'field.repatriationclaims_common.involvedParty.name',
-                    defaultMessage: 'Name',
+                    defaultMessage: 'Person',
                   },
                 }),
                 view: {

--- a/src/plugins/recordTypes/repatriationclaim/fields.js
+++ b/src/plugins/recordTypes/repatriationclaim/fields.js
@@ -241,7 +241,7 @@ export default (configContext) => {
               messages: defineMessages({
                 name: {
                   id: 'field.repatriationclaims_common.partiesInvolvedGroup.name',
-                  defaultMessage: 'Party involved',
+                  defaultMessage: 'Parties involved',
                 },
               }),
               repeating: true,
@@ -257,7 +257,7 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.repatriationclaims_common.involvedParty.fullName',
-                    defaultMessage: 'Party involved name',
+                    defaultMessage: 'Parties involved person',
                   },
                   name: {
                     id: 'field.repatriationclaims_common.involvedParty.name',
@@ -277,7 +277,7 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.repatriationclaims_common.involvedOnBehalfOf.fullName',
-                    defaultMessage: 'Party involved on behalf of',
+                    defaultMessage: 'Parties involved on behalf of',
                   },
                   name: {
                     id: 'field.repatriationclaims_common.involvedOnBehalfOf.name',
@@ -297,7 +297,7 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.repatriationclaims_common.involvedRole.fullName',
-                    defaultMessage: 'Party involved role',
+                    defaultMessage: 'Parties involved role',
                   },
                   name: {
                     id: 'field.repatriationclaims_common.involvedRole.name',
@@ -622,11 +622,11 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.repatriationclaims_common.status.fullName',
-                    defaultMessage: 'Claim status value',
+                    defaultMessage: 'Claim status',
                   },
                   name: {
                     id: 'field.repatriationclaims_common.status.name',
-                    defaultMessage: 'Value',
+                    defaultMessage: 'Status',
                   },
                 }),
                 view: {
@@ -689,7 +689,7 @@ export default (configContext) => {
               messages: defineMessages({
                 fullName: {
                   id: 'field.repatriationclaims_common.documentationGroup.fullName',
-                  defaultMessage: 'Claim documentation',
+                  defaultMessage: 'Claim documentation status',
                 },
               }),
               repeating: true,
@@ -702,7 +702,7 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.repatriationclaims_common.documentationNote.fullName',
-                    defaultMessage: 'Claim documentation note',
+                    defaultMessage: 'Claim documentation status note',
                   },
                   name: {
                     id: 'field.repatriationclaims_common.documentationNote.name',
@@ -725,7 +725,7 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.repatriationclaims_common.documentationDate.fullName',
-                    defaultMessage: 'Claim documentation date',
+                    defaultMessage: 'Claim documentation status date',
                   },
                   name: {
                     id: 'field.repatriationclaims_common.documentationDate.name',
@@ -762,7 +762,7 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.repatriationclaims_common.documentationIndividual.fullName',
-                    defaultMessage: 'Claim documentation individual',
+                    defaultMessage: 'Claim documentation status individual',
                   },
                   name: {
                     id: 'field.repatriationclaims_common.documentationIndividual.name',
@@ -782,7 +782,7 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.repatriationclaims_common.documentationGroupType.fullName',
-                    defaultMessage: 'Claim documentation group',
+                    defaultMessage: 'Claim documentation status group',
                   },
                   name: {
                     id: 'field.repatriationclaims_common.documentationGroupType.name',

--- a/src/plugins/recordTypes/repatriationclaim/fields.js
+++ b/src/plugins/recordTypes/repatriationclaim/fields.js
@@ -632,7 +632,7 @@ export default (configContext) => {
                 view: {
                   type: TermPickerInput,
                   props: {
-                    source: 'nagprastatus',
+                    source: 'deaccessionapprovalstatus',
                   },
                 },
               },
@@ -792,7 +792,7 @@ export default (configContext) => {
                 view: {
                   type: TermPickerInput,
                   props: {
-                    source: 'deaccessionapprovalgroup',
+                    source: 'documentationgroup',
                   },
                 },
               },

--- a/src/plugins/recordTypes/repatriationclaim/fields.js
+++ b/src/plugins/recordTypes/repatriationclaim/fields.js
@@ -267,7 +267,7 @@ export default (configContext) => {
                 view: {
                   type: AutocompleteInput,
                   props: {
-                    source: 'person/local,person/ulan',
+                    source: 'person/local',
                   },
                 },
               },
@@ -287,7 +287,7 @@ export default (configContext) => {
                 view: {
                   type: AutocompleteInput,
                   props: {
-                    source: 'organization/local,organization/ulan',
+                    source: 'organization/local',
                   },
                 },
               },
@@ -612,7 +612,7 @@ export default (configContext) => {
                 view: {
                   type: AutocompleteInput,
                   props: {
-                    source: 'person/local,person/ulan',
+                    source: 'person/local',
                   },
                 },
               },
@@ -772,7 +772,7 @@ export default (configContext) => {
                 view: {
                   type: AutocompleteInput,
                   props: {
-                    source: 'person/local,person/ulan',
+                    source: 'person/local',
                   },
                 },
               },

--- a/src/plugins/recordTypes/repatriationclaim/fields.js
+++ b/src/plugins/recordTypes/repatriationclaim/fields.js
@@ -351,7 +351,7 @@ export default (configContext) => {
                 view: {
                   type: AutocompleteInput,
                   props: {
-                    source: 'place/local,place/tgn',
+                    source: 'place/local',
                   },
                 },
               },

--- a/src/plugins/recordTypes/repatriationclaim/messages.js
+++ b/src/plugins/recordTypes/repatriationclaim/messages.js
@@ -28,7 +28,7 @@ export default {
     },
     documentation: {
       id: 'panel.repatriationclaim.documentation',
-      defaultMessage: 'Claim Documentation',
+      defaultMessage: 'Claim Documentation Status',
     },
   }),
 };


### PR DESCRIPTION
**What does this do?**
* Remove ulan and tgn from sources
* Relabel fields
* Claim Status use deaccessionapprovalstatus
* Claim Documentation Group use doumentationgroup
* Cultural Group pull from both archculture and ethculture

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1330

These are changes that came from the first pass of QA testing. Fairly minor changes, just updating sources for fields and updating labels.

**How should this be tested? Do these changes have associated tests?**
* Check that `npm run lint` and `npm run test` still pass
* Run the devserver `npm run devserver --back-end=https://core.dev.collectionspace.org`
* Create a claim and see the update fields and sources

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested using core.dev as a backend