### PR TITLE
DRYD-1495: Relabel culture authorities

### DIFF
--- a/src/plugins/recordTypes/concept/vocabularies.js
+++ b/src/plugins/recordTypes/concept/vocabularies.js
@@ -139,17 +139,17 @@ export default {
       name: {
         id: 'vocab.concept.ethculture.name',
         description: 'The name of the vocabulary.',
-        defaultMessage: 'Culture',
+        defaultMessage: 'Cultural Group',
       },
       collectionName: {
         id: 'vocab.concept.ethculture.collectionName',
         description: 'The name of a collection of records from the vocabulary.',
-        defaultMessage: 'Culture Concepts',
+        defaultMessage: 'Cultural Groups',
       },
       itemName: {
         id: 'vocab.concept.ethculture.itemName',
         description: 'The name of a record from the vocabulary.',
-        defaultMessage: 'Culture Concept',
+        defaultMessage: 'Cultural Group',
       },
     }),
     serviceConfig: {

--- a/src/plugins/recordTypes/concept/vocabularies.js
+++ b/src/plugins/recordTypes/concept/vocabularies.js
@@ -166,12 +166,12 @@ export default {
       collectionName: {
         id: 'vocab.concept.archculture.collectionName',
         description: 'The name of a collection of records from the vocabulary.',
-        defaultMessage: 'Archaeological Culture Concepts',
+        defaultMessage: 'Archaeological Cultures',
       },
       itemName: {
         id: 'vocab.concept.archculture.itemName',
         description: 'The name of a record from the vocabulary.',
-        defaultMessage: 'Archaeological Culture Concept',
+        defaultMessage: 'Archaeological Culture',
       },
     }),
     serviceConfig: {


### PR DESCRIPTION
**What does this do?**
* Relabel culture authorities

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1495

This is to update the label of ethculture to cultural group, which makes more sense conceptually with how it works. I also noticed that archculture was labeled differently compared to anthro so I adjusted it to be in line with that.

**How should this be tested? Do these changes have associated tests?**
* Run the devserver `npm run devserver --back-end=https://core.dev.collectionspace.org`
* Check that ethculture and archculture display their updated labels

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested using core.dev as a backend