### PR TITLE
DRYD-1517: Chronology Search Sort Order

### DIFF
--- a/src/plugins/recordTypes/chronology/columns.js
+++ b/src/plugins/recordTypes/chronology/columns.js
@@ -25,7 +25,7 @@ export default (configContext) => {
           },
         }),
         order: 20,
-        sortBy: 'chronologies_common:citationTermGroupList/0/termDisplayName',
+        sortBy: 'chronologies_common:chronologyTermGroupList/0/termDisplayName',
         width: 250,
       },
       termStatus: {
@@ -37,7 +37,7 @@ export default (configContext) => {
           },
         }),
         order: 30,
-        sortBy: 'chronologies_common:citationTermGroupList/0/termStatus',
+        sortBy: 'chronologies_common:chronologyTermGroupList/0/termStatus',
         width: 250,
       },
       vocabulary: {


### PR DESCRIPTION
**What does this do?**
* Fixes typo in field names for chronology search

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1517

This fixes a bug when searching on Chronology authorities. Currently the wrong field is being used, so `ERR_API` is being returned in the search form (a 400 from the back end). This is being caused by the terms having the wrong name (citationTermGroupList), which does not exist in the chronology schema.

**How should this be tested? Do these changes have associated tests?**
* Run the devserver, e.g. `npm run devserver --back-end https://core.dev.collectionspace.org`
* Search on Chronology authorities
* Use the sort functionality to sort by display name and term status

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally