### PR TITLE
DRYD-1393: Support Multiple Related Record Sidebars

### DIFF
--- a/src/actions/search.js
+++ b/src/actions/search.js
@@ -186,6 +186,7 @@ export const search = (config, searchName, searchDescriptor, listType = 'common'
       pgSz: searchQuery.get('size'),
       rtSbj: searchQuery.get('rel'),
       rtPredicate: searchQuery.get('relType'),
+      servicetag: searchQuery.get('serviceTag'),
       sn: searchQuery.get('sn'), // accounts screen name
       dn: searchQuery.get('dn'), // role display name
       wf_deleted: false,

--- a/src/components/record/RecordSidebar.jsx
+++ b/src/components/record/RecordSidebar.jsx
@@ -123,11 +123,14 @@ export default function RecordSidebar(props) {
 
     relatedRecords = relatedRecordDescriptors.map((relatedRecordDescriptor) => {
       const {
+        id,
         sort,
         serviceTag,
         recordType: relatedRecordType,
         columnSet = 'narrow',
       } = relatedRecordDescriptor;
+
+      const panelName = id ? `related${upperFirst(id)}Panel` : `related${upperFirst(relatedRecordType)}Panel`;
 
       return (
         <RelatedRecordPanelContainer
@@ -136,8 +139,8 @@ export default function RecordSidebar(props) {
           columnSetName={columnSet}
           config={config}
           initialSort={sort}
-          key={relatedRecordType}
-          name={`related${upperFirst(relatedRecordType)}Panel`}
+          key={panelName}
+          name={panelName}
           recordType={recordType}
           relatedRecordType={relatedRecordType}
           showAddButton={isRelatable}

--- a/src/components/record/RecordSidebar.jsx
+++ b/src/components/record/RecordSidebar.jsx
@@ -141,6 +141,7 @@ export default function RecordSidebar(props) {
           initialSort={sort}
           key={panelName}
           name={panelName}
+          panelId={id}
           recordType={recordType}
           relatedRecordType={relatedRecordType}
           showAddButton={isRelatable}

--- a/src/components/record/RecordSidebar.jsx
+++ b/src/components/record/RecordSidebar.jsx
@@ -124,6 +124,7 @@ export default function RecordSidebar(props) {
     relatedRecords = relatedRecordDescriptors.map((relatedRecordDescriptor) => {
       const {
         sort,
+        serviceTag,
         recordType: relatedRecordType,
         columnSet = 'narrow',
       } = relatedRecordDescriptor;
@@ -140,6 +141,7 @@ export default function RecordSidebar(props) {
           recordType={recordType}
           relatedRecordType={relatedRecordType}
           showAddButton={isRelatable}
+          serviceTag={serviceTag}
         />
       );
     });

--- a/src/components/record/RelatedRecordPanel.jsx
+++ b/src/components/record/RelatedRecordPanel.jsx
@@ -29,6 +29,7 @@ const getSearchDescriptor = (props) => {
     initialSort,
     recordRelationUpdatedTimestamp,
     relatedRecordType,
+    serviceTag,
   } = props;
 
   return Immutable.fromJS({
@@ -39,6 +40,7 @@ const getSearchDescriptor = (props) => {
       p: 0,
       size: config.defaultSearchPanelSize || 5,
       sort: initialSort,
+      serviceTag,
     },
     seqID: recordRelationUpdatedTimestamp,
   });
@@ -69,6 +71,7 @@ const propTypes = {
   recordType: PropTypes.string,
   relatedRecordType: PropTypes.string,
   selectedItems: PropTypes.instanceOf(Immutable.Map),
+  serviceTag: PropTypes.string,
   showCheckboxColumn: PropTypes.bool,
   showSearchButton: PropTypes.bool,
   showAddButton: PropTypes.bool,

--- a/src/components/record/RelatedRecordPanel.jsx
+++ b/src/components/record/RelatedRecordPanel.jsx
@@ -75,6 +75,7 @@ const propTypes = {
   showCheckboxColumn: PropTypes.bool,
   showSearchButton: PropTypes.bool,
   showAddButton: PropTypes.bool,
+  panelId: PropTypes.string, // not set on this prop name yet
   openModalName: PropTypes.string,
   closeModal: PropTypes.func,
   openModal: PropTypes.func,
@@ -363,12 +364,17 @@ export default class RelatedRecordPanel extends Component {
   renderTitle() {
     const {
       config,
+      recordType,
       relatedRecordType,
+      panelId,
     } = this.props;
 
+    const sidebarMessage = get(config, ['recordTypes', recordType, 'messages', 'sidebar', panelId]);
     const collectionNameMessage = get(config, ['recordTypes', relatedRecordType, 'messages', 'record', 'collectionName']);
 
-    const collectionName = <FormattedMessage {...collectionNameMessage} />;
+    const collectionName = sidebarMessage != null
+      ? <FormattedMessage {...sidebarMessage} />
+      : <FormattedMessage {...collectionNameMessage} />;
 
     return <FormattedMessage {...messages.title} values={{ collectionName }} />;
   }

--- a/test/specs/components/record/RelatedRecordPanel.spec.jsx
+++ b/test/specs/components/record/RelatedRecordPanel.spec.jsx
@@ -81,6 +81,7 @@ describe('RelatedRecordPanel', () => {
     const relatedRecordType = 'group';
     const recordRelationUpdatedTimestamp = '2017-03-06T12:05:34.000Z';
     const sort = 'objectNumber';
+    const serviceTag = 'ownership';
 
     const shallowRenderer = createRenderer();
 
@@ -93,6 +94,7 @@ describe('RelatedRecordPanel', () => {
         relatedRecordType={relatedRecordType}
         recordRelationUpdatedTimestamp={recordRelationUpdatedTimestamp}
         initialSort={sort}
+        serviceTag={serviceTag}
       />,
     );
 
@@ -111,6 +113,7 @@ describe('RelatedRecordPanel', () => {
         relType: 'affects',
         p: 0,
         size: 5,
+        serviceTag,
       },
       seqID: recordRelationUpdatedTimestamp,
     }));


### PR DESCRIPTION
**What does this do?**
* Allow for multiple related records panels
* Add serviceTag for querying on sets of records

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1393

This is a WIP atm I'll update later with a full description

**How should this be tested? Do these changes have associated tests?**
* Add a sidebar.js (e.g. `heldintrust/sidebar.js`)
```
export default {
  relatedRecords: [{
    recordType: 'collectionobject',
  }, {
    recordType: 'procedure',
    serviceTag: '-nagpra',
  }, {
    id: 'nagpra',
    recordType: 'procedure',
    serviceTag: 'nagpra',
  }],
};
```
* Update the index.js to include the sidebar
* Add a message for the new record panel to messages.js
```
   sidebar: defineMessages({
     nagpra: {
       id: 'panel.heldintrust.nagpra',
       defaultMessage: 'NAGPRA',
     },
   }),
```

**Dependencies for merging? Releasing to production?**

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
