### PR TITLE
Set row aria-label for search results

### DIFF
--- a/src/components/search/SearchResultTable.jsx
+++ b/src/components/search/SearchResultTable.jsx
@@ -448,7 +448,7 @@ export default class SearchResultTable extends Component {
       }
 
       const height = (heightBasis * rowHeight) + rowHeight;
-      const renderWithTotal = (params) => this.renderRow(params, totalItems);
+      const renderRowWithTotal = (params) => this.renderRow(params, totalItems);
 
       return (
         <div style={{ height }}>
@@ -463,7 +463,7 @@ export default class SearchResultTable extends Component {
             sortBy={sortColumnName}
             sortDirection={sortDir === 'desc' ? Table.SortDirection.DESC : Table.SortDirection.ASC}
             noRowsRenderer={this.renderNoItems}
-            rowRenderer={renderWithTotal}
+            rowRenderer={renderRowWithTotal}
           />
         </div>
       );

--- a/test/specs/components/search/SearchResultTable.spec.jsx
+++ b/test/specs/components/search/SearchResultTable.spec.jsx
@@ -145,6 +145,10 @@ const searchResult = Immutable.fromJS({
   },
 });
 
+const intl = {
+  formatMessage: (message) => `formatted ${message.id}`,
+};
+
 describe('SearchResultTable', () => {
   beforeEach(function before() {
     this.container = createTestContainer(this);
@@ -153,7 +157,10 @@ describe('SearchResultTable', () => {
   it('should render as a div', function test() {
     render(
       <Router>
-        <SearchResultTable config={config} />
+        <SearchResultTable
+          config={config}
+          intl={intl}
+        />
       </Router>, this.container,
     );
 
@@ -166,6 +173,7 @@ describe('SearchResultTable', () => {
         <SearchResultTable
           columnSetName="narrow"
           config={config}
+          intl={intl}
           searchDescriptor={searchDescriptor}
           searchResult={searchResult}
         />
@@ -183,6 +191,7 @@ describe('SearchResultTable', () => {
         <SearchResultTable
           columnSetName="foobar"
           config={config}
+          intl={intl}
           searchDescriptor={searchDescriptor}
           searchResult={searchResult}
         />
@@ -200,6 +209,7 @@ describe('SearchResultTable', () => {
         <SearchResultTable
           columnSetName="foobar"
           config={config}
+          intl={intl}
           searchDescriptor={groupSearchDescriptor}
           searchResult={searchResult}
         />
@@ -216,6 +226,7 @@ describe('SearchResultTable', () => {
       <Router>
         <SearchResultTable
           config={config}
+          intl={intl}
           searchDescriptor={searchDescriptor}
           searchResult={searchResult}
         />
@@ -230,6 +241,7 @@ describe('SearchResultTable', () => {
       <Router>
         <SearchResultTable
           config={config}
+          intl={intl}
           searchDescriptor={searchDescriptor}
           searchResult={searchResult}
         />
@@ -244,6 +256,7 @@ describe('SearchResultTable', () => {
       <Router>
         <SearchResultTable
           config={config}
+          intl={intl}
           linkItems={false}
           searchDescriptor={searchDescriptor}
           searchResult={searchResult}
@@ -259,6 +272,7 @@ describe('SearchResultTable', () => {
       <Router>
         <SearchResultTable
           config={config}
+          intl={intl}
           listType="foo"
           searchDescriptor={searchDescriptor}
           searchResult={searchResult}
@@ -274,6 +288,7 @@ describe('SearchResultTable', () => {
       <Router>
         <SearchResultTable
           config={config}
+          intl={intl}
           listType="bar"
           searchDescriptor={searchDescriptor}
           searchResult={searchResult}
@@ -298,6 +313,7 @@ describe('SearchResultTable', () => {
       <Router>
         <SearchResultTable
           config={config}
+          intl={intl}
           searchDescriptor={searchDescriptor}
           searchResult={emptySearchResult}
         />
@@ -322,6 +338,7 @@ describe('SearchResultTable', () => {
         <Router>
           <SearchResultTable
             config={config}
+            intl={intl}
             isSearchPending
             searchDescriptor={searchDescriptor}
             searchResult={emptySearchResult}
@@ -353,6 +370,7 @@ describe('SearchResultTable', () => {
     render(
       <Router>
         <SearchResultTable
+          intl={intl}
           config={config}
           searchDescriptor={searchDescriptor}
           searchResult={singleSearchResult}
@@ -376,6 +394,7 @@ describe('SearchResultTable', () => {
     render(
       <Router>
         <SearchResultTable
+          intl={intl}
           config={config}
           searchDescriptor={searchDescriptor}
           searchResult={singleSearchResult}
@@ -390,6 +409,7 @@ describe('SearchResultTable', () => {
     render(
       <Router>
         <SearchResultTable
+          intl={intl}
           config={config}
           searchDescriptor={searchDescriptor}
           searchResult={searchResult}
@@ -413,6 +433,7 @@ describe('SearchResultTable', () => {
     render(
       <Router>
         <SearchResultTable
+          intl={intl}
           config={config}
           searchDescriptor={searchDescriptor}
           searchResult={searchResult}
@@ -442,6 +463,7 @@ describe('SearchResultTable', () => {
     render(
       <Router>
         <SearchResultTable
+          intl={intl}
           config={config}
           searchDescriptor={searchDescriptor}
           searchResult={searchResult}
@@ -469,6 +491,7 @@ describe('SearchResultTable', () => {
     render(
       <Router>
         <SearchResultTable
+          intl={intl}
           config={config}
           searchDescriptor={searchDescriptor}
           searchResult={searchResult}
@@ -500,6 +523,7 @@ describe('SearchResultTable', () => {
     render(
       <Router>
         <SearchResultTable
+          intl={intl}
           config={config}
           searchDescriptor={searchDescriptor}
           searchResult={searchResult}
@@ -537,6 +561,7 @@ describe('SearchResultTable', () => {
     render(
       <Router>
         <SearchResultTable
+          intl={intl}
           config={config}
           searchDescriptor={searchDescriptor}
           searchResult={searchResult}
@@ -567,6 +592,7 @@ describe('SearchResultTable', () => {
     render(
       <Router>
         <SearchResultTable
+          intl={intl}
           config={config}
           searchName={searchName}
           searchDescriptor={searchDescriptor}
@@ -596,6 +622,7 @@ describe('SearchResultTable', () => {
       <Router>
         <SearchResultTable
           config={config}
+          intl={intl}
           searchName={searchName}
           searchDescriptor={searchDescriptor}
           searchResult={searchResult}


### PR DESCRIPTION
**What does this do?**
* Sets the row label using the data from the highest order column

**Why are we doing this? (with JIRA link)**
Jira:
* https://collectionspace.atlassian.net/browse/DRYD-1308
* https://collectionspace.atlassian.net/browse/DRYD-1310

The labels were previously only 'row' which is not descriptive of the row itself. This adds a label based on the example DRYD-1308 to each row in the SearchResultTables.

**How should this be tested? Do these changes have associated tests?**
* Run `npm run lint` and `npm run test` as a sanity check
* Run `npm run devserver --back-end=https://core.dev.collectionspace.org`
* Run a search and look at the resulting table
  * For each row, an aria-label should exist that reads something like `{primary-column-data} selected row {index} of {total}`
  * The aria-label is attached to the `<a>` of the row as it has `role=row`

**Dependencies for merging? Releasing to production?**
This adds `intl` as a prop to SearchResultTable, which should be fine as it is already handled as part of the SearchResultTableContainer.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested w/ core.dev as a backend