### PR TITLE
DRYD-1550: Fix typo in requester display name

### DIFF
--- a/src/plugins/recordTypes/heldintrust/fields.js
+++ b/src/plugins/recordTypes/heldintrust/fields.js
@@ -564,11 +564,11 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.heldintrusts_common.requester.fullName',
-                    defaultMessage: 'Access limitation requestor',
+                    defaultMessage: 'Access limitation requester',
                   },
                   name: {
                     id: 'field.heldintrusts_common.requester.name',
-                    defaultMessage: 'Requestor',
+                    defaultMessage: 'Requester',
                   },
                 }),
                 view: {


### PR DESCRIPTION
**What does this do?**
* Fix typo in requester display

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1550

**How should this be tested? Do these changes have associated tests?**
* Run the devserver with core as a backend `npm run devserver --back-end=https://core.dev.collectionspace.org`
* Create a Held-in-Trust record and see 'Requester' spelled correctly
* In the advanced search interface, check the 'Access limitation requester' is spelled correctly

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested with core.dev as a backend