### PR TITLE
Fix time period era label

### DIFF
--- a/src/plugins/recordTypes/nagprainventory/fields.js
+++ b/src/plugins/recordTypes/nagprainventory/fields.js
@@ -749,11 +749,11 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.nagprainventories_common.timePeriod.fullName',
-                    defaultMessage: 'Time period name',
+                    defaultMessage: 'Time period era',
                   },
                   name: {
                     id: 'field.nagprainventories_common.timePeriod.name',
-                    defaultMessage: 'Name',
+                    defaultMessage: 'Era',
                   },
                 }),
                 view: {


### PR DESCRIPTION
**What does this do?**
* Fixes the label used for era in NAGPRA Inventory

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1331

This was a typo noticed during QA

**How should this be tested? Do these changes have associated tests?**
* Run the devserver: `npm run devserver --back-end=https://core.dev.collectionspace.org`
* Create a NAGPRA Inventory and check that the `Time period` field is labelled `Era`
* In the advanced search, check that `Time period era` shows up in the field search

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested with core.dev as a backend