### PR TITLE
DRYD-1356: New ObjectExit Procedure

### DIFF
--- a/src/plugins/recordTypes/exit/advancedSearch.js
+++ b/src/plugins/recordTypes/exit/advancedSearch.js
@@ -1,0 +1,21 @@
+export default (configContext) => {
+  const {
+    OP_CONTAIN,
+  } = configContext.searchOperators;
+
+  const {
+    defaultAdvancedSearchBooleanOp,
+    extensions,
+  } = configContext.config;
+
+  return {
+    op: defaultAdvancedSearchBooleanOp,
+    value: [
+      {
+        op: OP_CONTAIN,
+        path: 'ns2:exits_common/exitNumber',
+      },
+      ...extensions.core.advancedSearch,
+    ],
+  };
+};

--- a/src/plugins/recordTypes/exit/columns.js
+++ b/src/plugins/recordTypes/exit/columns.js
@@ -1,0 +1,48 @@
+import { defineMessages } from 'react-intl';
+
+export default (configContext) => {
+  const {
+    formatRefName,
+    formatTimestamp,
+  } = configContext.formatHelpers;
+
+  return {
+    default: {
+      exitNumber: {
+        messages: defineMessages({
+          label: {
+            id: 'column.exit.default.exitNumber',
+            defaultMessage: 'Exit number',
+          },
+        }),
+        order: 10,
+        sortBy: 'exits_common:exitNumber',
+        width: 200,
+      },
+      exitOwner: {
+        formatValue: formatRefName,
+        messages: defineMessages({
+          label: {
+            id: 'column.exit.default.exitOwner',
+            defaultMessage: 'Exit owner',
+          },
+        }),
+        order: 20,
+        sortBy: 'exits_common:owners/owner/0',
+        width: 200,
+      },
+      updatedAt: {
+        formatValue: formatTimestamp,
+        messages: defineMessages({
+          label: {
+            id: 'column.exit.default.updatedAt',
+            defaultMessage: 'Updated',
+          },
+        }),
+        order: 30,
+        sortBy: 'collectionspace_core:updatedAt',
+        width: 150,
+      },
+    },
+  };
+};

--- a/src/plugins/recordTypes/exit/fields.js
+++ b/src/plugins/recordTypes/exit/fields.js
@@ -71,7 +71,7 @@ export default (configContext) => {
             view: {
               type: IDGeneratorInput,
               props: {
-                source: 'exitnumber',
+                source: 'exit',
               },
             },
           },
@@ -86,6 +86,9 @@ export default (configContext) => {
             }),
             view: {
               type: TextInput,
+              props: {
+                multiline: true,
+              },
             },
           },
         },
@@ -336,7 +339,7 @@ export default (configContext) => {
               view: {
                 type: CompoundInput,
                 props: {
-                  tabular: true,
+                  tabular: false,
                 },
               },
             },

--- a/src/plugins/recordTypes/exit/fields.js
+++ b/src/plugins/recordTypes/exit/fields.js
@@ -1,0 +1,455 @@
+import { defineMessages } from 'react-intl';
+
+export default (configContext) => {
+  const {
+    AutocompleteInput,
+    CompoundInput,
+    DateInput,
+    IDGeneratorInput,
+    StructuredDateInput,
+    TermPickerInput,
+    TextInput,
+  } = configContext.inputComponents;
+
+  const {
+    configKey: config,
+  } = configContext.configHelpers;
+
+  const {
+    DATA_TYPE_DATE,
+    DATA_TYPE_INT,
+    DATA_TYPE_STRUCTURED_DATE,
+  } = configContext.dataTypes;
+
+  const {
+    extensions,
+  } = configContext.config;
+
+  const {
+    validateNotInUse,
+  } = configContext.validationHelpers;
+
+  return {
+    document: {
+      [config]: {
+        view: {
+          type: CompoundInput,
+          props: {
+            defaultChildSubpath: 'ns2:exits_common',
+          },
+        },
+      },
+      ...extensions.core.fields,
+      'ns2:exits_common': {
+        [config]: {
+          service: {
+            ns: 'http://collectionspace.org/services/exit',
+          },
+        },
+        exitNumber: {
+          [config]: {
+            cloneable: false,
+            messages: defineMessages({
+              inUse: {
+                id: 'field.exits_common.exitNumber.inUse',
+                defaultMessage: 'The exit number {value} is in use by another record.',
+              },
+              name: {
+                id: 'field.exits_common.exitNumber.name',
+                defaultMessage: 'Exit number',
+              },
+            }),
+            required: true,
+            searchView: {
+              type: TextInput,
+            },
+            validate: (validationContext) => validateNotInUse({
+              configContext,
+              validationContext,
+              fieldName: 'exits_common:exitNumber',
+            }),
+            view: {
+              type: IDGeneratorInput,
+              props: {
+                source: 'exitnumber',
+              },
+            },
+          },
+        },
+        exitCountNote: {
+          [config]: {
+            messages: defineMessages({
+              name: {
+                id: 'field.exits_common.exitCountNote.name',
+                defaultMessage: 'Exit count note',
+              },
+            }),
+            view: {
+              type: TextInput,
+            },
+          },
+        },
+        exitDate: {
+          [config]: {
+            dataType: DATA_TYPE_DATE,
+            messages: defineMessages({
+              name: {
+                id: 'field.exits_common.exitDate.name',
+                defaultMessage: 'Exit date',
+              },
+            }),
+            view: {
+              type: DateInput,
+            },
+          },
+        },
+        reason: {
+          [config]: {
+            messages: defineMessages({
+              name: {
+                id: 'field.exits_common.reason.name',
+                defaultMessage: 'Exit reason',
+              },
+            }),
+            view: {
+              type: TermPickerInput,
+              props: {
+                source: 'objexitreason',
+              },
+            },
+          },
+        },
+        saleCurrency: {
+          [config]: {
+            messages: defineMessages({
+              name: {
+                id: 'field.exits_common.saleCurrency.name',
+                defaultMessage: 'Sale/auction currency',
+              },
+            }),
+            view: {
+              type: TermPickerInput,
+              props: {
+                source: 'currency',
+              },
+            },
+          },
+        },
+        saleValue: {
+          [config]: {
+            dataType: DATA_TYPE_INT,
+            messages: defineMessages({
+              name: {
+                id: 'field.exits_common.saleValue.name',
+                defaultMessage: 'Sale/auction value',
+              },
+            }),
+            view: {
+              type: TextInput,
+            },
+          },
+        },
+        saleDate: {
+          [config]: {
+            dataType: DATA_TYPE_STRUCTURED_DATE,
+            messages: defineMessages({
+              name: {
+                id: 'field.exits_common.saleDate.name',
+                defaultMessage: 'Sale/auction date',
+              },
+            }),
+            view: {
+              type: StructuredDateInput,
+            },
+          },
+          ...extensions.structuredDate.fields,
+        },
+        saleNumber: {
+          [config]: {
+            messages: defineMessages({
+              name: {
+                id: 'field.exits_common.saleNumber.name',
+                defaultMessage: 'Sale/auction number',
+              },
+            }),
+            view: {
+              type: TextInput,
+            },
+          },
+        },
+        saleLot: {
+          [config]: {
+            messages: defineMessages({
+              name: {
+                id: 'field.exits_common.saleLot.name',
+                defaultMessage: 'Sale/auction lot',
+              },
+            }),
+            view: {
+              type: TextInput,
+            },
+          },
+        },
+        saleNote: {
+          [config]: {
+            messages: defineMessages({
+              name: {
+                id: 'field.exits_common.saleNote.name',
+                defaultMessage: 'Sale/auction note',
+              },
+            }),
+            view: {
+              type: TextInput,
+              props: {
+                multiline: true,
+              },
+            },
+          },
+        },
+        owners: {
+          [config]: {
+            view: {
+              type: CompoundInput,
+            },
+          },
+          owner: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.exits_common.owner.name',
+                  defaultMessage: 'Owner after exit',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: AutocompleteInput,
+                props: {
+                  source: 'person/local,organization/local',
+                },
+              },
+            },
+          },
+        },
+        methods: {
+          [config]: {
+            view: {
+              type: CompoundInput,
+            },
+          },
+          method: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.exits_common.method.name',
+                  defaultMessage: 'Exit method',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: TermPickerInput,
+                props: {
+                  source: 'objexitmethod',
+                },
+              },
+            },
+          },
+        },
+        exitAgentGroupList: {
+          [config]: {
+            view: {
+              type: CompoundInput,
+            },
+          },
+          exitAgentGroup: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.exits_common.exitAgentGroup.name',
+                  defaultMessage: 'Exit agent',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: CompoundInput,
+                props: {
+                  tabular: true,
+                },
+              },
+            },
+            agent: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.exits_common.agent.fullName',
+                    defaultMessage: 'Exit agent name',
+                  },
+                  name: {
+                    id: 'field.exits_common.agent.name',
+                    defaultMessage: 'Name',
+                  },
+                }),
+                view: {
+                  type: AutocompleteInput,
+                  props: {
+                    source: 'person/local,organization/local',
+                  },
+                },
+              },
+            },
+            role: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.exits_common.role.fullName',
+                    defaultMessage: 'Exit agent role',
+                  },
+                  name: {
+                    id: 'field.exits_common.role.name',
+                    defaultMessage: 'Role',
+                  },
+                }),
+                view: {
+                  type: TermPickerInput,
+                  props: {
+                    source: 'objexitagentrole',
+                  },
+                },
+              },
+            },
+          },
+        },
+        approvalStatusGroupList: {
+          [config]: {
+            view: {
+              type: CompoundInput,
+            },
+          },
+          approvalStatusGroup: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.exits_common.approvalStatusGroup.name',
+                  defaultMessage: 'Approval status',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: CompoundInput,
+                props: {
+                  tabular: true,
+                },
+              },
+            },
+            group: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.exits_common.group.fullName',
+                    defaultMessage: 'Approval status group',
+                  },
+                  name: {
+                    id: 'field.exits_common.group.name',
+                    defaultMessage: 'Group',
+                  },
+                }),
+                view: {
+                  type: TermPickerInput,
+                  props: {
+                    source: 'deaccessionapprovalgroup',
+                  },
+                },
+              },
+            },
+            individual: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.exits_common.individual.fullName',
+                    defaultMessage: 'Approval status individual',
+                  },
+                  name: {
+                    id: 'field.exits_common.individual.name',
+                    defaultMessage: 'Individual',
+                  },
+                }),
+                view: {
+                  type: AutocompleteInput,
+                  props: {
+                    source: 'person/local',
+                  },
+                },
+              },
+            },
+            status: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.exits_common.status.fullName',
+                    defaultMessage: 'Approval status',
+                  },
+                  name: {
+                    id: 'field.exits_common.status.name',
+                    defaultMessage: 'Status',
+                  },
+                }),
+                view: {
+                  type: TermPickerInput,
+                  props: {
+                    source: 'deaccessionapprovalstatus',
+                  },
+                },
+              },
+            },
+            date: {
+              [config]: {
+                dataType: DATA_TYPE_DATE,
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.exits_common.date.fullName',
+                    defaultMessage: 'Approval status date',
+                  },
+                  name: {
+                    id: 'field.exits_common.date.name',
+                    defaultMessage: 'Date',
+                  },
+                }),
+                view: {
+                  type: DateInput,
+                },
+              },
+            },
+            approvalStatusNotes: {
+              [config]: {
+                view: {
+                  type: CompoundInput,
+                },
+              },
+              approvalStatusNote: {
+                [config]: {
+                  messages: defineMessages({
+                    fullName: {
+                      id: 'field.exits_common.approvalStatusNote.fullName',
+                      defaultMessage: 'Approval status note',
+                    },
+                    name: {
+                      id: 'field.exits_common.approvalStatusNote.name',
+                      defaultMessage: 'Note',
+                    },
+                  }),
+                  repeating: true,
+                  view: {
+                    type: TextInput,
+                    props: {
+                      height: 46,
+                      multiline: true,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+};

--- a/src/plugins/recordTypes/exit/forms/default.jsx
+++ b/src/plugins/recordTypes/exit/forms/default.jsx
@@ -1,0 +1,33 @@
+import { defineMessages } from 'react-intl';
+
+const template = (configContext) => {
+  const {
+    React,
+  } = configContext.lib;
+
+  const {
+    Panel,
+  } = configContext.layoutComponents;
+
+  const {
+    Field,
+  } = configContext.recordComponents;
+
+  return (
+    <Field name="document">
+      <Panel name="info" collapsible>
+        <Field name="exitNumber" />
+      </Panel>
+    </Field>
+  );
+};
+
+export default (configContext) => ({
+  messages: defineMessages({
+    name: {
+      id: 'form.exit.default.name',
+      defaultMessage: 'Standard Template',
+    },
+  }),
+  template: template(configContext),
+});

--- a/src/plugins/recordTypes/exit/forms/default.jsx
+++ b/src/plugins/recordTypes/exit/forms/default.jsx
@@ -6,7 +6,10 @@ const template = (configContext) => {
   } = configContext.lib;
 
   const {
+    Col,
+    Cols,
     Panel,
+    Row,
   } = configContext.layoutComponents;
 
   const {
@@ -16,7 +19,55 @@ const template = (configContext) => {
   return (
     <Field name="document">
       <Panel name="info" collapsible>
-        <Field name="exitNumber" />
+        <Cols>
+          <Col>
+            <Field name="exitNumber" />
+            <Field name="exitDate" />
+            <Field name="reason" />
+            <Field name="methods">
+              <Field name="method" />
+            </Field>
+          </Col>
+          <Col>
+            <Field name="owners">
+              <Field name="owner" />
+            </Field>
+            <Field name="exitAgentGroupList">
+              <Field name="exitAgentGroup">
+                <Field name="agent" />
+                <Field name="role" />
+              </Field>
+            </Field>
+            <Field name="exitCountNote" />
+          </Col>
+        </Cols>
+
+        <Field name="approvalStatusGroupList">
+          <Field name="approvalStatusGroup">
+            <Panel>
+              <Row>
+                <Field name="group" />
+                <Field name="individual" />
+                <Field name="status" />
+                <Field name="date" />
+              </Row>
+              <Field name="approvalStatusNotes">
+                <Field name="approvalStatusNote" />
+              </Field>
+            </Panel>
+          </Field>
+        </Field>
+      </Panel>
+
+      <Panel name="sale" collapsible collapsed>
+        <Row>
+          <Field name="saleCurrency" />
+          <Field name="saleValue" />
+          <Field name="saleDate" />
+          <Field name="saleNumber" />
+          <Field name="saleLot" />
+        </Row>
+        <Field name="saleNote" />
       </Panel>
     </Field>
   );

--- a/src/plugins/recordTypes/exit/forms/index.js
+++ b/src/plugins/recordTypes/exit/forms/index.js
@@ -1,0 +1,5 @@
+import defaultForm from './default';
+
+export default (configContext) => ({
+  default: defaultForm(configContext),
+});

--- a/src/plugins/recordTypes/exit/idGenerators.js
+++ b/src/plugins/recordTypes/exit/idGenerators.js
@@ -1,0 +1,13 @@
+import { defineMessages } from 'react-intl';
+
+export default {
+  exit: {
+    csid: 'd4eea707-d473-4367-853a-728fbcd9be17',
+    messages: defineMessages({
+      type: {
+        id: 'idGenerator.exit.type',
+        defaultMessage: 'Object Exit',
+      },
+    }),
+  },
+};

--- a/src/plugins/recordTypes/exit/index.js
+++ b/src/plugins/recordTypes/exit/index.js
@@ -1,0 +1,23 @@
+import advancedSearch from './advancedSearch';
+import columns from './columns';
+import fields from './fields';
+import forms from './forms';
+import idGenerators from './idGenerators';
+import messages from './messages';
+import serviceConfig from './serviceConfig';
+import title from './title';
+
+export default () => (configContext) => ({
+  idGenerators,
+  recordTypes: {
+    exit: {
+      messages,
+      serviceConfig,
+      advancedSearch: advancedSearch(configContext),
+      columns: columns(configContext),
+      fields: fields(configContext),
+      forms: forms(configContext),
+      title: title(configContext),
+    },
+  },
+});

--- a/src/plugins/recordTypes/exit/messages.js
+++ b/src/plugins/recordTypes/exit/messages.js
@@ -1,0 +1,22 @@
+import { defineMessages } from 'react-intl';
+
+export default {
+  record: defineMessages({
+    name: {
+      id: 'record.exit.name',
+      description: 'The name of the record',
+      defaultMessage: 'Object Exit',
+    },
+    collectionName: {
+      id: 'record.exit.collectionName',
+      description: 'The name of a collection of records of the type.',
+      defaultMessage: 'Object Exits',
+    },
+  }),
+  panel: defineMessages({
+    info: {
+      id: 'panel.exit.info',
+      defaultMessage: 'Object Exit Information',
+    },
+  }),
+};

--- a/src/plugins/recordTypes/exit/messages.js
+++ b/src/plugins/recordTypes/exit/messages.js
@@ -18,5 +18,9 @@ export default {
       id: 'panel.exit.info',
       defaultMessage: 'Object Exit Information',
     },
+    sale: {
+      id: 'panel.exit.sale',
+      defaultMessage: 'Sale Information',
+    },
   }),
 };

--- a/src/plugins/recordTypes/exit/serviceConfig.js
+++ b/src/plugins/recordTypes/exit/serviceConfig.js
@@ -1,0 +1,8 @@
+export default {
+  serviceName: 'Exit',
+  servicePath: 'exits',
+  serviceType: 'procedure',
+
+  objectName: 'Exit',
+  documentName: 'exits',
+};

--- a/src/plugins/recordTypes/exit/title.js
+++ b/src/plugins/recordTypes/exit/title.js
@@ -1,0 +1,25 @@
+export default (configContext) => (data) => {
+  const {
+    deepGet,
+    getPart,
+  } = configContext.recordDataHelpers;
+
+  const {
+    getDisplayName,
+  } = configContext.refNameHelpers;
+
+  if (!data) {
+    return '';
+  }
+
+  const common = getPart(data, 'exits_common');
+
+  if (!common) {
+    return '';
+  }
+
+  const referenceNumber = common.get('exitNumber');
+  const owner = getDisplayName(deepGet(common, ['owners', 'owner', 0]));
+
+  return [referenceNumber, owner].filter((part) => !!part).join(' – ');
+};

--- a/src/plugins/recordTypes/index.js
+++ b/src/plugins/recordTypes/index.js
@@ -18,6 +18,7 @@ import contact from './contact';
 import deaccession from './deaccession';
 import dutyofcare from './dutyofcare';
 import exhibition from './exhibition';
+import exit from './exit';
 import exxport from './export';
 import group from './group';
 import heldintrust from './heldintrust';
@@ -71,6 +72,7 @@ export default [
   deaccession,
   dutyofcare,
   exhibition,
+  exit,
   exxport,
   group,
   heldintrust,

--- a/src/plugins/recordTypes/objectexit/messages.js
+++ b/src/plugins/recordTypes/objectexit/messages.js
@@ -5,12 +5,12 @@ export default {
     name: {
       id: 'record.objectexit.name',
       description: 'The name of the record type.',
-      defaultMessage: 'Object Exit',
+      defaultMessage: 'Object Exit (Legacy)',
     },
     collectionName: {
       id: 'record.objectexit.collectionName',
       description: 'The name of a collection of records of the type.',
-      defaultMessage: 'Object Exits',
+      defaultMessage: 'Object Exits (Legacy)',
     },
   }),
   panel: defineMessages({

--- a/test/specs/plugins/recordTypes/exit/advancedSearch.spec.js
+++ b/test/specs/plugins/recordTypes/exit/advancedSearch.spec.js
@@ -1,0 +1,23 @@
+import createConfigContext from '../../../../../src/helpers/createConfigContext';
+import advancedSearch from '../../../../../src/plugins/recordTypes/exit/advancedSearch';
+
+chai.should();
+
+describe('exit record advanced search', () => {
+  const configContext = createConfigContext();
+
+  it('should contain a top level property `op`', () => {
+    advancedSearch(configContext).should.have.property('op');
+  });
+
+  it('should contain a top level property `value` that is an array', () => {
+    advancedSearch(configContext).should.have.property('value').that.is.an('array');
+  });
+
+  it('should include a search operation for `exitNumber`', () => {
+    advancedSearch(configContext).value.should.include({
+      op: configContext.searchOperators.OP_CONTAIN,
+      path: 'ns2:exits_common/exitNumber',
+    });
+  });
+});

--- a/test/specs/plugins/recordTypes/exit/columns.spec.js
+++ b/test/specs/plugins/recordTypes/exit/columns.spec.js
@@ -1,0 +1,22 @@
+import createColumns from '../../../../../src/plugins/recordTypes/exit/columns';
+import createConfigContext from '../../../../../src/helpers/createConfigContext';
+
+chai.should();
+
+describe('exit record columns', () => {
+  const configContext = createConfigContext();
+  const columns = createColumns(configContext);
+
+  it('should have the correct shape', () => {
+    columns.should.have.property('default').that.is.an('object');
+  });
+
+  it('should have exit owner column that can format a refname', () => {
+    const { exitOwner } = columns.default;
+
+    exitOwner.should.have.property('formatValue').that.is.a('function');
+
+    exitOwner.formatValue('urn:cspace:core.collectionspace.org:personauthorities:name(person):item:name(johndoe)\'John Doe\'').should
+      .equal('John Doe');
+  });
+});

--- a/test/specs/plugins/recordTypes/exit/forms/default.spec.js
+++ b/test/specs/plugins/recordTypes/exit/forms/default.spec.js
@@ -1,0 +1,14 @@
+import Field from '../../../../../../src/components/record/Field';
+import form from '../../../../../../src/plugins/recordTypes/exit/forms/default';
+import createConfigContext from '../../../../../../src/helpers/createConfigContext';
+
+chai.should();
+
+describe('exit record default form', () => {
+  it('should be a Field', () => {
+    const configContext = createConfigContext();
+    const { template } = form(configContext);
+
+    template.type.should.equal(Field);
+  });
+});

--- a/test/specs/plugins/recordTypes/exit/index.spec.js
+++ b/test/specs/plugins/recordTypes/exit/index.spec.js
@@ -1,0 +1,30 @@
+import exitRecordTypePluginFactor from '../../../../../src/plugins/recordTypes/exit';
+import createConfigContext from '../../../../../src/helpers/createConfigContext';
+
+chai.should();
+
+describe('exit record plugin', () => {
+  const config = {};
+  const exitRecordType = exitRecordTypePluginFactor(config);
+  const configContext = createConfigContext();
+
+  it('should have the correct shape', () => {
+    const pluginConfigContribution = exitRecordType(configContext);
+
+    const {
+      recordTypes,
+    } = pluginConfigContribution;
+
+    recordTypes.should.have.property('exit');
+
+    const exitRecordTypes = recordTypes.exit;
+
+    exitRecordTypes.should.have.property('messages').that.is.an('object');
+    exitRecordTypes.should.have.property('serviceConfig').that.is.an('object');
+    exitRecordTypes.should.have.property('title').that.is.a('function');
+    exitRecordTypes.should.have.property('forms').that.is.an('object');
+    exitRecordTypes.should.have.property('fields').that.is.a('object');
+    exitRecordTypes.should.have.property('columns').that.is.an('object');
+    exitRecordTypes.should.have.property('advancedSearch').that.is.an('object');
+  });
+});

--- a/test/specs/plugins/recordTypes/exit/messages.spec.js
+++ b/test/specs/plugins/recordTypes/exit/messages.spec.js
@@ -1,0 +1,17 @@
+import messages from '../../../../../src/plugins/recordTypes/exit/messages';
+
+chai.should();
+
+describe('exit record messages', () => {
+  it('should contain properties with id and defaultMessage properties', () => {
+    messages.should.be.an('object');
+
+    Object.keys(messages).forEach((messageGroup) => {
+      const definedMessages = messages[messageGroup];
+
+      Object.keys(definedMessages).forEach((name) => {
+        definedMessages[name].should.contain.all.keys(['id', 'defaultMessage']);
+      });
+    });
+  });
+});

--- a/test/specs/plugins/recordTypes/exit/serviceConfig.spec.js
+++ b/test/specs/plugins/recordTypes/exit/serviceConfig.spec.js
@@ -1,0 +1,13 @@
+import serviceConfig from '../../../../../src/plugins/recordTypes/exit/serviceConfig';
+
+chai.should();
+
+describe('exit record serviceConfig', () => {
+  it('should have servicePath property', () => {
+    serviceConfig.should.have.property('servicePath').that.is.a('string');
+    serviceConfig.should.have.property('serviceName').that.is.a('string');
+    serviceConfig.should.have.property('serviceType').that.is.a('string');
+    serviceConfig.should.have.property('objectName').that.is.a('string');
+    serviceConfig.should.have.property('documentName').that.is.a('string');
+  });
+});

--- a/test/specs/plugins/recordTypes/exit/title.spec.js
+++ b/test/specs/plugins/recordTypes/exit/title.spec.js
@@ -1,0 +1,74 @@
+import Immutable from 'immutable';
+import createTitleGetter from '../../../../../src/plugins/recordTypes/exit/title';
+import createConfigContext from '../../../../../src/helpers/createConfigContext';
+
+chai.should();
+
+describe('exit record title', () => {
+  const configContext = createConfigContext();
+  const title = createTitleGetter(configContext);
+
+  it('should concat the exit number and the owner', () => {
+    const data = Immutable.fromJS({
+      document: {
+        'ns2:exits_common': {
+          exitNumber: 'EX2024.1',
+          owners: {
+            owner: [
+              'urn:cspace:core.collectionspace.org:personauthorities:name(person):item:name(Owner)\'Owner\'',
+            ],
+          },
+        },
+      },
+    });
+
+    title(data).should.equal('EX2024.1 – Owner');
+  });
+
+  it('should return the exit number when the owner is empty', () => {
+    const data = Immutable.fromJS({
+      document: {
+        'ns2:exits_common': {
+          exitNumber: 'EX2024.1',
+          owners: {
+            owner: [],
+          },
+        },
+      },
+    });
+
+    title(data).should.equal('EX2024.1');
+  });
+
+  it('should return the owner when the exit number is empty', () => {
+    const data = Immutable.fromJS({
+      document: {
+        'ns2:exits_common': {
+          exitNumber: '',
+          owners: {
+            owner: ['urn:cspace:core.collectionspace.org:personauthorities:name(person):item:name(Owner)\'Owner\''],
+          },
+        },
+      },
+    });
+
+    title(data).should.equal('Owner');
+  });
+
+  it('should return empty string if no data is passed', () => {
+    title(null).should.equal('');
+    title(undefined).should.equal('');
+  });
+
+  it('should return empty string if the common part is not present', () => {
+    const data = Immutable.fromJS({
+      data: {
+        'ns2:exits_extension': {
+          exitNumber: 'Something',
+        },
+      },
+    });
+
+    title(data).should.equal('');
+  });
+});


### PR DESCRIPTION
**What does this do?**
* Add Exit service for new ObjectExit workflow
* Add Exit client
* Add ExitValidationHandler
* Add xsd for exits_common schema

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1356

The existing Object Exit procedure is being deprecated in favor of it being split into two procedures - the Deaccession and Object Exit. This handles the creation of a new Object Exit, named Exit, which will replace existing use.

**How should this be tested? Do these changes have associated tests?**
* Run `npm run lint` and `npm run test` as a sanity check
* Pull the related services and application PRs
* Rebuild and deploy collectionspace with the required tenants enabled for running the integration tests
* Run the devserver: `npm run devserver`
* Create a new Object Exit with all fields filled out
* Use the advanced search to check that the fields don't collide

**Dependencies for merging? Releasing to production?**
This does not replace the existing id generator and instead reuses it. Should get clarification if this is ok or not.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against a local instance