### PR TITLE
Update search columns for NAGPRA procedures

### DIFF
--- a/src/plugins/recordTypes/exit/columns.js
+++ b/src/plugins/recordTypes/exit/columns.js
@@ -19,7 +19,7 @@ export default (configContext) => {
         sortBy: 'exits_common:exitNumber',
         width: 200,
       },
-      exitOwner: {
+      owner: {
         formatValue: formatRefName,
         messages: defineMessages({
           label: {
@@ -28,7 +28,7 @@ export default (configContext) => {
           },
         }),
         order: 20,
-        sortBy: 'exits_common:owners/owner/0',
+        sortBy: 'exits_common:owners/0',
         width: 200,
       },
       updatedAt: {

--- a/src/plugins/recordTypes/exit/columns.js
+++ b/src/plugins/recordTypes/exit/columns.js
@@ -23,8 +23,8 @@ export default (configContext) => {
         formatValue: formatRefName,
         messages: defineMessages({
           label: {
-            id: 'column.exit.default.exitOwner',
-            defaultMessage: 'Exit owner',
+            id: 'column.exit.default.owner',
+            defaultMessage: 'Owner after exit',
           },
         }),
         order: 20,

--- a/src/plugins/recordTypes/heldintrust/columns.js
+++ b/src/plugins/recordTypes/heldintrust/columns.js
@@ -28,7 +28,7 @@ export default (configContext) => {
           },
         }),
         order: 20,
-        sortBy: 'heldintrusts_common:owners/owner/0',
+        sortBy: 'heldintrusts_common:owners/0',
         width: 450,
       },
       updatedAt: {

--- a/src/plugins/recordTypes/summarydocumentation/columns.js
+++ b/src/plugins/recordTypes/summarydocumentation/columns.js
@@ -26,7 +26,7 @@ export default (configContext) => {
           },
         }),
         order: 20,
-        sortBy: 'summarydocumentations_common:titles/title/0',
+        sortBy: 'summarydocumentations_common:titles/0',
         width: 200,
       },
       updatedAt: {

--- a/test/specs/plugins/recordTypes/exit/columns.spec.js
+++ b/test/specs/plugins/recordTypes/exit/columns.spec.js
@@ -11,12 +11,12 @@ describe('exit record columns', () => {
     columns.should.have.property('default').that.is.an('object');
   });
 
-  it('should have exit owner column that can format a refname', () => {
-    const { exitOwner } = columns.default;
+  it('should have owner column that can format a refname', () => {
+    const { owner } = columns.default;
 
-    exitOwner.should.have.property('formatValue').that.is.a('function');
+    owner.should.have.property('formatValue').that.is.a('function');
 
-    exitOwner.formatValue('urn:cspace:core.collectionspace.org:personauthorities:name(person):item:name(johndoe)\'John Doe\'').should
+    owner.formatValue('urn:cspace:core.collectionspace.org:personauthorities:name(person):item:name(johndoe)\'John Doe\'').should
       .equal('John Doe');
   });
 });


### PR DESCRIPTION
**What does this do?**
* Fix name for exit owner search result
* Change exit owner to Owner after exit 
* Fix sort by values for repeating fields


**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1618

This was noticed as part of the regression testing that the new `Object Exit` was not pulling back the `Exit Owner` and when trying to sort we saw an `ERR_API`. This turned out to be two separate issues - the first is that the response used `owner` as the field returned for search results. The fix for this is just to align the field name defined in `columns.js` for the object exit with the search result.

The second issue was caused by the `sortBy` field being incorrect for repeating fields. It only needs to specify the top level field and doesn't need the inner part.

**How should this be tested? Do these changes have associated tests?**
* Run the devserver with dev as a backend, e.g.
```
npm run devserver --back-end=https://core.dev.collectionspace.org
```
* Search for ObjectExit
  * See that `Owner after exit` is populated
  * Sort by `Owner after exit` 
* Search for Held-in-Trusts
  * Sort by `Owner`
* Search for SummaryDocumentations
  * Sort by `Titles`  

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested using core.dev as a backend