### PR TITLE
DRYD-1269: Make field id value match field name

### DIFF
--- a/docs/configuration/messages.js
+++ b/docs/configuration/messages.js
@@ -4351,9 +4351,9 @@ export default {
 
   "field.uoc_common.feeValue.name": "Value",
 
-  "field.uoc_common.hoursSpent.fullName": "Start/ongoing date hours spent",
+  "field.uoc_common.useDateHoursSpent.fullName": "Start/ongoing date hours spent",
 
-  "field.uoc_common.hoursSpent.name": "Hours spent",
+  "field.uoc_common.useDateHoursSpent.name": "Hours spent",
 
   "field.uoc_common.location.name": "Location",
 

--- a/src/plugins/recordTypes/uoc/fields.js
+++ b/src/plugins/recordTypes/uoc/fields.js
@@ -322,11 +322,11 @@ export default (configContext) => {
               [config]: {
                 messages: defineMessages({
                   fullName: {
-                    id: 'field.uoc_common.hoursSpent.fullName',
+                    id: 'field.uoc_common.useDateHoursSpent.fullName',
                     defaultMessage: 'Start/ongoing date hours spent',
                   },
                   name: {
-                    id: 'field.uoc_common.hoursSpent.name',
+                    id: 'field.uoc_common.useDateHoursSpent.name',
                     defaultMessage: 'Hours spent',
                   },
                 }),


### PR DESCRIPTION
**What does this do?**
Fixes DRYD-1269

**Why are we doing this? (with JIRA link)**
So Kristina can remove stupid extra code from cspace-config-untangler, and so things will be slightly more consistent.

https://collectionspace.atlassian.net/browse/DRYD-1269

**How should this be tested? Do these changes have associated tests?**
I don't see any automated tests for field IDs. 

The UI config should output the new field ids on this field when this is fixed. 

**Dependencies for merging? Releasing to production?**
Don't think so

If we think anyone has done significant work on translating/customizing CollectionSpace depending on the changed field ID, might be considered breaking.

**Has the application documentation been updated for these changes?**

The docs/configuration/messages.js file is updated

**Did someone actually run this code to verify it works?**

no
