### PR TITLE
DRYD-1270 Fix compressionStandard field id

### DIFF
--- a/docs/configuration/messages.js
+++ b/docs/configuration/messages.js
@@ -1265,9 +1265,9 @@ export default {
 
   "field.collectionobjects_common.comment.name": "Comment",
 
-  "field.collectionobjects_common.compressionstandard.fullName": "File codec compression standard",
+  "field.collectionobjects_common.compressionStandard.fullName": "File codec compression standard",
 
-  "field.collectionobjects_common.compressionstandard.name": "Compression standard",
+  "field.collectionobjects_common.compressionStandard.name": "Compression standard",
 
   "field.collectionobjects_common.computedCurrentLocation.name": "Computed current location",
 

--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -5346,11 +5346,11 @@ export default (configContext) => {
               [config]: {
                 messages: defineMessages({
                   fullName: {
-                    id: 'field.collectionobjects_common.compressionstandard.fullName',
+                    id: 'field.collectionobjects_common.compressionStandard.fullName',
                     defaultMessage: 'File codec compression standard',
                   },
                   name: {
-                    id: 'field.collectionobjects_common.compressionstandard.name',
+                    id: 'field.collectionobjects_common.compressionStandard.name',
                     defaultMessage: 'Compression standard',
                   },
                 }),


### PR DESCRIPTION
**What does this do?**
Fixes DRYD-1270

**Why are we doing this? (with JIRA link)**
So Kristina can remove stupid extra code from cspace-config-untangler, and so things will be slightly more consistent.

https://collectionspace.atlassian.net/browse/DRYD-1270

**How should this be tested? Do these changes have associated tests?**
I don't see any automated tests for field IDs. 

The UI config should output the new field ids on this field when this is fixed. 

**Dependencies for merging? Releasing to production?**
Don't think so

If we think anyone has done significant work on translating/customizing CollectionSpace depending on the changed field ID, might be considered breaking.

**Has the application documentation been updated for these changes?**

The docs/configuration/messages.js file is updated

**Did someone actually run this code to verify it works?**

no
