### PR TITLE
Downcase documentName serviceConfig for Duty of Care, Deaccession

### DIFF
--- a/src/plugins/recordTypes/deaccession/serviceConfig.js
+++ b/src/plugins/recordTypes/deaccession/serviceConfig.js
@@ -4,5 +4,5 @@ export default {
   serviceType: 'procedure',
 
   objectName: 'Deaccession',
-  documentName: 'Deaccessions',
+  documentName: 'deaccessions',
 };

--- a/src/plugins/recordTypes/dutyofcare/serviceConfig.js
+++ b/src/plugins/recordTypes/dutyofcare/serviceConfig.js
@@ -4,5 +4,5 @@ export default {
   serviceType: 'procedure',
 
   objectName: 'Dutyofcare',
-  documentName: 'Dutyofcares',
+  documentName: 'dutyofcares',
 };


### PR DESCRIPTION
**What does this do?**

Makes serviceConfig documentName property downcased for Duty of Care and Deaccession procedures

**Why are we doing this? (with JIRA link)**

Other documentName properties are downcased. We don't need MORE inconsistency in CollectionSpace. 

**How should this be tested? Do these changes have associated tests?**

Not sure. Discussed with @mikejritter that this property doesn't really appear to be used for anything, but defer to him how to verify.

**Dependencies for merging? Releasing to production?**
??

**Has the application documentation been updated for these changes?**
n/a - [The documentation on this](https://github.com/collectionspace/cspace-ui.js/blob/master/docs/configuration/RecordServiceConfiguration.md) is not really informative

**Did someone actually run this code to verify it works?**

no, YOLO