### PR TITLE
DRYD-1688: Login Error When No Roles

### DIFF
--- a/src/actions/tags.js
+++ b/src/actions/tags.js
@@ -74,5 +74,8 @@ export default () => (dispatch) => {
         type: SERVICE_TAGS_READ_REJECTED,
         payload: error,
       });
+
+      const status = get(error, ['response', 'status']);
+      return status === 403 ? undefined : Promise.reject(error);
     });
 };

--- a/src/actions/tags.js
+++ b/src/actions/tags.js
@@ -74,7 +74,5 @@ export default () => (dispatch) => {
         type: SERVICE_TAGS_READ_REJECTED,
         payload: error,
       });
-
-      return Promise.reject(error);
     });
 };

--- a/src/actions/tags.js
+++ b/src/actions/tags.js
@@ -59,6 +59,12 @@ const readProcedures = (response, dispatch) => {
     .catch((error) => Promise.reject(error));
 };
 
+/**
+ * Action for reading the service tags from the servicegroups resource
+ *
+ * If a user has no read permissions and a 403 is encountered, return
+ * without doing anything
+ */
 export default () => (dispatch) => {
   dispatch({ type: SERVICE_TAGS_READ_STARTED });
 


### PR DESCRIPTION
**What does this do?**
* Remove the promise rejection when the servicegroup call fails with a 403

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1688

When the response fails and the promise is rejected, this causes the entire login task chain to fail. This results in a blank screen being shown instead of any useful error, because nothing is being propagated back to the user correctly.

**How should this be tested? Do these changes have associated tests?**
* Start collectionspace and run the devserver
* Login as the admin user and create a new user
  * Don't assign any roles, just give an email and password
* Logout
* Try to sign in as the new user and get greeted with a ui (although non-functional as you have no roles)

**Dependencies for merging? Releasing to production?**
There's more work that could be done to make the user aware of any failed calls, but with ui work in the pipeline I don't think it's worth it to do anything atm.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally