### PR TITLE
DRYD-1688: Fix failing test

### DIFF
--- a/test/specs/actions/tags.spec.js
+++ b/test/specs/actions/tags.spec.js
@@ -134,7 +134,7 @@ describe('tags action creator', () => {
         )),
       );
 
-      return store.dispatch(readServiceTags()).should.eventually.be.rejected
+      return store.dispatch(readServiceTags())
         .then(() => {
           const actions = store.getActions();
 


### PR DESCRIPTION
**What does this do?**
Fixes test failure for DRYD-1688

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1688

The logic for the tag action was updated to not reject the promise when a 403 is returned. This updates a test which returned a 403 to no longer expect a rejected promise.

**How should this be tested? Do these changes have associated tests?**
* Run `npm test`

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally