### PR TITLE
Fix typo in label id

### DIFF
--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -3889,7 +3889,7 @@ export default (configContext) => {
             [config]: {
               messages: defineMessages({
                 name: {
-                  id: 'field.procedure.publishedRelatedLinkGroup.name',
+                  id: 'field.collectionobjects_common.publishedRelatedLinkGroup.name',
                   defaultMessage: 'Published related link',
                 },
               }),


### PR DESCRIPTION
**What does this do?**
Fixes a typo in the message id

**Why are we doing this? (with JIRA link)**
No jira

This typo impacts the ability to override this message because it doesn't properly reflect what procedure it's a part of.

**How should this be tested? Do these changes have associated tests?**
n/a

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
No