### PR TITLE
Add documentation to status group labels

### DIFF
--- a/src/plugins/recordTypes/nagprainventory/fields.js
+++ b/src/plugins/recordTypes/nagprainventory/fields.js
@@ -427,7 +427,7 @@ export default (configContext) => {
               messages: defineMessages({
                 name: {
                   id: 'field.nagprainventories_common.inventoryStatusGroup.name',
-                  defaultMessage: 'Inventory status',
+                  defaultMessage: 'Inventory documentation status',
                 },
               }),
               repeating: true,
@@ -443,7 +443,7 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.nagprainventories_common.inventoryGroup.fullName',
-                    defaultMessage: 'Inventory status group',
+                    defaultMessage: 'Inventory documentation status group',
                   },
                   name: {
                     id: 'field.nagprainventories_common.inventoryGroup.name',
@@ -463,7 +463,7 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.nagprainventories_common.inventoryIndividual.fullName',
-                    defaultMessage: 'Inventory status individual',
+                    defaultMessage: 'Inventory documentation status individual',
                   },
                   name: {
                     id: 'field.nagprainventories_common.inventoryIndividual.name',
@@ -483,7 +483,7 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.nagprainventories_common.inventoryStatus.fullName',
-                    defaultMessage: 'Inventory status',
+                    defaultMessage: 'Inventory documentation status',
                   },
                   name: {
                     id: 'field.nagprainventories_common.inventoryStatus.name',
@@ -504,7 +504,7 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.nagprainventories_common.inventoryDate.fullName',
-                    defaultMessage: 'Inventory status date',
+                    defaultMessage: 'Inventory documentation status date',
                   },
                   name: {
                     id: 'field.nagprainventories_common.inventoryDate.name',
@@ -521,7 +521,7 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.nagprainventories_common.inventoryNote.fullName',
-                    defaultMessage: 'Inventory status note',
+                    defaultMessage: 'Inventory documentation status note',
                   },
                   name: {
                     id: 'field.nagprainventories_common.inventoryNote.name',

--- a/src/plugins/recordTypes/summarydocumentation/fields.js
+++ b/src/plugins/recordTypes/summarydocumentation/fields.js
@@ -422,7 +422,7 @@ export default (configContext) => {
               messages: defineMessages({
                 name: {
                   id: 'field.summarydocumentations_common.statusGroup.name',
-                  defaultMessage: 'Summary status',
+                  defaultMessage: 'Summary documentation status',
                 },
               }),
               repeating: true,
@@ -435,7 +435,7 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.summarydocumentations_common.statusGroupType.fullName',
-                    defaultMessage: 'Summary status group',
+                    defaultMessage: 'Summary documentation status group',
                   },
                   name: {
                     id: 'field.summarydocumentations_common.statusGroupType.name',
@@ -455,7 +455,7 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.summarydocumentations_common.statusIndividual.fullName',
-                    defaultMessage: 'Summary status individual',
+                    defaultMessage: 'Summary documentation status individual',
                   },
                   name: {
                     id: 'field.summarydocumentations_common.statusIndividual.name',
@@ -475,7 +475,7 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.summarydocumentations_common.status.fullName',
-                    defaultMessage: 'Summary status',
+                    defaultMessage: 'Summary documentation status',
                   },
                   name: {
                     id: 'field.summarydocumentations_common.status.name',
@@ -496,7 +496,7 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.summarydocumentations_common.statusDate.fullName',
-                    defaultMessage: 'Summary status date',
+                    defaultMessage: 'Summary documentation status date',
                   },
                   name: {
                     id: 'field.summarydocumentations_common.statusDate.name',
@@ -513,7 +513,7 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.summarydocumentations_common.statusNote.fullName',
-                    defaultMessage: 'Summary status note',
+                    defaultMessage: 'Summary documentation status note',
                   },
                   name: {
                     id: 'field.summarydocumentations_common.statusNote.name',


### PR DESCRIPTION
**What does this do?**
* Updates labels to include 'documentation'

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1703 + https://collectionspace.atlassian.net/browse/DRYD-1704

The labels need “Documentation to represent that they are documentation statuses vs workflow statuses.

**How should this be tested? Do these changes have associated tests?**
* Run the dev server, e.g. `npm run devserver --back-end=https://core.dev.collectionspace.org`
* In the NAGPRA Inventory form, verify that the label reads 'Inventory documentation status'
* In the NAGPRA Inventory advanced search, verify that the fields are labeled 'Inventory documentation status ...'
* In the Summary Documentation form, verify that the label reads 'Summary documentation status'
* In the Summary Documentation advanced search, verify that the fields are labeled 'Summary documentation status ...'

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested with core.dev as a backend