### PR TITLE
DRYD-1776: Form validation for role description/role name

### DIFF
--- a/src/helpers/validationHelpers.js
+++ b/src/helpers/validationHelpers.js
@@ -12,6 +12,12 @@ const isBlocking = (validationError) => {
   return (typeof nonblocking === 'undefined') ? true : !nonblocking;
 };
 
+export const isValidLength = (value, length) => {
+  // use the TextEncoder in case any utf8 characters are present
+  const encoder = new TextEncoder();
+  return encoder.encode(value).length <= length;
+};
+
 export const hasBlockingError = (validationErrors) => {
   if (!validationErrors) {
     return false;

--- a/src/plugins/recordTypes/authrole/fields.js
+++ b/src/plugins/recordTypes/authrole/fields.js
@@ -1,4 +1,9 @@
 import { defineMessages } from 'react-intl';
+import { isValidLength } from '../../../helpers/validationHelpers';
+
+import {
+  ERR_VALIDATION,
+} from '../../../constants/errorCodes';
 
 export default (configContext) => {
   const {
@@ -58,8 +63,25 @@ export default (configContext) => {
               id: 'field.authrole.displayName.name',
               defaultMessage: 'Name',
             },
+            errorInvalidDisplayName: {
+              id: 'field.accounts_common.errorInvalidDisplayName',
+              description: 'Message to display when the description is too large',
+              defaultMessage: 'Name must be under {maxLength} characters',
+            },
           }),
           required: true,
+          validate: ({ data, fieldDescriptor }) => {
+            const maxLength = 200;
+            if (!isValidLength(data, maxLength)) {
+              return {
+                code: ERR_VALIDATION,
+                message: fieldDescriptor[config].messages.errorInvalidDisplayName,
+                maxLength,
+              };
+            }
+
+            return undefined;
+          },
           view: {
             type: TextInput,
           },
@@ -72,7 +94,24 @@ export default (configContext) => {
               id: 'field.authrole.description.name',
               defaultMessage: 'Description',
             },
+            errorInvalidDescription: {
+              id: 'field.accounts_common.errorInvalidDescription',
+              description: 'Message to display when the description is too large',
+              defaultMessage: 'Description must be under {maxLength} characters',
+            },
           }),
+          validate: ({ data, fieldDescriptor }) => {
+            const maxLength = 255;
+            if (!isValidLength(data, maxLength)) {
+              return {
+                code: ERR_VALIDATION,
+                message: fieldDescriptor[config].messages.errorInvalidDescription,
+                maxLength,
+              };
+            }
+
+            return undefined;
+          },
           view: {
             type: TextInput,
             props: {


### PR DESCRIPTION
**What does this do?**
* Adds validation for input length for role description
* Adds validation for input length for role display name

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1776

Previously there were no validation errors that would show up, and the response from the api was not readable. This prevents the form from being submitted before all fields are valid, and if there are any errors they are displayed similar to other form errors.

**How should this be tested? Do these changes have associated tests?**
* Run the devserver, e.g. npm run devserver --back-end=https://core.dev.collectionspace.org
* Navigate to Administration > Roles and Permissions
* Try to create a new role with a name which is too long and a description which is too long
  * This should also work to utf8 encoded characters which appear to only take up one character but take up multiple
* See the error message

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against core.dev