### PR TITLE
DRYD-1797: Add note to 8.1 procedures

### DIFF
--- a/src/plugins/recordTypes/exit/fields.js
+++ b/src/plugins/recordTypes/exit/fields.js
@@ -452,6 +452,22 @@ export default (configContext) => {
             },
           },
         },
+        note: {
+          [config]: {
+            messages: defineMessages({
+              name: {
+                id: 'field.exits_common.note.name',
+                defaultMessage: 'Note',
+              },
+            }),
+            view: {
+              type: TextInput,
+              props: {
+                multiline: true,
+              },
+            },
+          },
+        },
       },
     },
   };

--- a/src/plugins/recordTypes/exit/forms/default.jsx
+++ b/src/plugins/recordTypes/exit/forms/default.jsx
@@ -38,10 +38,11 @@ const template = (configContext) => {
                 <Field name="role" />
               </Field>
             </Field>
-            <Field name="exitCountNote" />
           </Col>
         </Cols>
 
+        <Field name="exitCountNote" />
+        <Field name="note" />
         <Field name="approvalStatusGroupList">
           <Field name="approvalStatusGroup">
             <Panel>

--- a/src/plugins/recordTypes/heldintrust/fields.js
+++ b/src/plugins/recordTypes/heldintrust/fields.js
@@ -619,6 +619,22 @@ export default (configContext) => {
             },
           },
         },
+        note: {
+          [config]: {
+            messages: defineMessages({
+              name: {
+                id: 'field.heldintrusts_common.note.name',
+                defaultMessage: 'Note',
+              },
+            }),
+            view: {
+              type: TextInput,
+              props: {
+                multiline: true,
+              },
+            },
+          },
+        },
       },
     },
   };

--- a/src/plugins/recordTypes/heldintrust/forms/default.jsx
+++ b/src/plugins/recordTypes/heldintrust/forms/default.jsx
@@ -43,6 +43,7 @@ const template = (configContext) => {
           </Col>
         </Cols>
 
+        <Field name="note" />
         <Field name="agreementApprovalGroupList">
           <Field name="agreementApprovalGroup">
             <Panel>

--- a/src/plugins/recordTypes/nagprainventory/fields.js
+++ b/src/plugins/recordTypes/nagprainventory/fields.js
@@ -783,6 +783,22 @@ export default (configContext) => {
             },
           },
         },
+        note: {
+          [config]: {
+            messages: defineMessages({
+              name: {
+                id: 'field.nagprainventories_common.note.name',
+                defaultMessage: 'Note',
+              },
+            }),
+            view: {
+              type: TextInput,
+              props: {
+                multiline: true,
+              },
+            },
+          },
+        },
       },
     },
   };

--- a/src/plugins/recordTypes/nagprainventory/forms/default.jsx
+++ b/src/plugins/recordTypes/nagprainventory/forms/default.jsx
@@ -40,6 +40,7 @@ const template = (configContext) => {
           </Col>
         </Cols>
 
+        <Field name="note" />
         <Field name="partiesInvolvedGroupList">
           <Field name="partiesInvolvedGroup">
             <Field name="involvedParty" />

--- a/src/plugins/recordTypes/summarydocumentation/fields.js
+++ b/src/plugins/recordTypes/summarydocumentation/fields.js
@@ -774,6 +774,22 @@ export default (configContext) => {
             },
           },
         },
+        note: {
+          [config]: {
+            messages: defineMessages({
+              name: {
+                id: 'field.summarydocumentations_common.note.name',
+                defaultMessage: 'Note',
+              },
+            }),
+            view: {
+              type: TextInput,
+              props: {
+                multiline: true,
+              },
+            },
+          },
+        },
       },
     },
   };

--- a/src/plugins/recordTypes/summarydocumentation/forms/default.jsx
+++ b/src/plugins/recordTypes/summarydocumentation/forms/default.jsx
@@ -40,6 +40,7 @@ const template = (configContext) => {
           </Col>
         </Cols>
 
+        <Field name="note" />
         <Field name="partiesInvolvedGroupList">
           <Field name="partiesInvolvedGroup">
             <Field name="involvedParty" />


### PR DESCRIPTION
**What does this do?**
* Adds a `note` field to the following procedures
  * Object Exit
  * Held-in-Trust
  * NAGPRA Inventory
  * Summary Documentation

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1797

These procedures were added in CollectionSpace 8.1 and needed a general purpose note field to help facilitate data migrations.

**How should this be tested? Do these changes have associated tests?**
* Run the devserver, e.g. `npm run devserver --back-end=https://core.dev.collectionspace.org`
* For each record, verify that the `Note` field exists for each template and can be saved

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No. The messages will need to be updated on release.

**Did someone actually run this code to verify it works?**
@mikejritter tested locally