### PR TITLE
DRYD-1770: Add production agent verbatim

### DIFF
--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -2630,6 +2630,27 @@ export default (configContext) => {
             },
           },
         },
+        objectProductionAgents: {
+          [config]: {
+            view: {
+              type: CompoundInput,
+            },
+          },
+          objectProductionAgent: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.collectionobjects_common.objectProductionAgent.name',
+                  defaultMessage: 'Production agent (verbatim)',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: TextInput,
+              },
+            },
+          },
+        },
         assocActivityGroupList: {
           [config]: {
             view: {

--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -397,6 +397,10 @@ const template = (configContext) => {
               </Field>
             </Field>
 
+            <Field name="objectProductionAgents">
+              <Field name="objectProductionAgent" />
+            </Field>
+
             <Field name="objectProductionNote" />
           </Col>
         </Row>

--- a/src/plugins/recordTypes/collectionobject/forms/timebased.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/timebased.jsx
@@ -401,6 +401,10 @@ const template = (configContext) => {
               </Field>
             </Field>
 
+            <Field name="objectProductionAgents">
+              <Field name="objectProductionAgent" />
+            </Field>
+
             <Field name="objectProductionNote" />
           </Col>
         </Row>


### PR DESCRIPTION
**What does this do?**
This adds a repeatable free text `Object production agent` field to the collection object record.

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1770

This is intended to complement the authority controlled field to help assist with migration work.

**How should this be tested? Do these changes have associated tests?**
* Run the devserver `npm run devserver`
* Create a CollectionObject
* In the `Object Production Information` panel, see that the new field exists

**Dependencies for merging? Releasing to production?**
There are two additional templates which have the production panel but it is still being determined if the field should be added to them.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter is in the process of testing locally