### PR TITLE
DRYD-1732: Filter Vocabulary Used on TermPickerInput

### DIFF
--- a/src/components/admin/VocabularyUsedByPanel.jsx
+++ b/src/components/admin/VocabularyUsedByPanel.jsx
@@ -7,6 +7,10 @@ import { formatExtensionFieldName } from '../../helpers/formatHelpers';
 import { ConnectedPanel as Panel } from '../../containers/layout/PanelContainer';
 import styles from '../../../styles/cspace-ui/VocabularyUsedByPanel.css';
 
+import {
+  TermPickerInput,
+} from '../../helpers/configContextInputs';
+
 const messages = defineMessages({
   title: {
     id: 'vocabularyUsedByPanel.title',
@@ -91,7 +95,7 @@ export default function VocabularyUsedByPanel(props, context) {
   }
 
   const shortId = data.getIn(['document', 'ns2:vocabularies_common', 'shortIdentifier']);
-  const uses = findVocabularyUses(config, shortId);
+  const uses = findVocabularyUses(config, shortId, TermPickerInput);
   const title = <h3><FormattedMessage {...messages.title} /></h3>;
 
   return (

--- a/src/helpers/configHelpers.js
+++ b/src/helpers/configHelpers.js
@@ -831,7 +831,7 @@ const findFieldsWithSource = (fieldDescriptor, shortId, viewType) => {
   if (source === shortId) {
     const fieldViewType = get(fieldConfig, ['view', 'type']);
     // allow undefined viewType to accept all
-    if (!viewType || (viewType === fieldViewType)) {
+    if (!viewType || viewType === fieldViewType) {
       fieldsWithSource.push(fieldConfig);
     }
   }

--- a/src/helpers/configHelpers.js
+++ b/src/helpers/configHelpers.js
@@ -826,10 +826,11 @@ const findFieldsWithSource = (fieldDescriptor, shortId, viewType) => {
     (childFieldName) => findFieldsWithSource(fieldDescriptor[childFieldName], shortId, viewType));
 
   const fieldConfig = fieldDescriptor[configKey];
-  const fieldViewType = get(fieldConfig, ['view', 'type']);
   const source = get(fieldConfig, ['view', 'props', 'source']);
 
   if (source === shortId) {
+    const fieldViewType = get(fieldConfig, ['view', 'type']);
+    // allow undefined viewType to accept all
     if (!viewType || (viewType === fieldViewType)) {
       fieldsWithSource.push(fieldConfig);
     }

--- a/src/helpers/configHelpers.js
+++ b/src/helpers/configHelpers.js
@@ -821,21 +821,24 @@ export const findFieldConfigInPart = (recordTypeConfig, partName, fieldName) => 
   return (fieldDescriptor ? fieldDescriptor[configKey] : null);
 };
 
-const findFieldsWithSource = (fieldDescriptor, shortId) => {
+const findFieldsWithSource = (fieldDescriptor, shortId, viewType) => {
   const fieldsWithSource = flatMap(Object.keys(fieldDescriptor).filter((key) => key !== configKey),
-    (childFieldName) => findFieldsWithSource(fieldDescriptor[childFieldName], shortId));
+    (childFieldName) => findFieldsWithSource(fieldDescriptor[childFieldName], shortId, viewType));
 
   const fieldConfig = fieldDescriptor[configKey];
+  const fieldViewType = get(fieldConfig, ['view', 'type']);
   const source = get(fieldConfig, ['view', 'props', 'source']);
 
   if (source === shortId) {
-    fieldsWithSource.push(fieldConfig);
+    if (!viewType || (viewType === fieldViewType)) {
+      fieldsWithSource.push(fieldConfig);
+    }
   }
 
   return fieldsWithSource;
 };
 
-export const findVocabularyUses = (config, shortId) => {
+export const findVocabularyUses = (config, shortId, vocabularyType) => {
   if (!shortId) {
     return null;
   }
@@ -846,7 +849,7 @@ export const findVocabularyUses = (config, shortId) => {
     const fieldDescriptor = recordTypeConfig.fields;
 
     if (fieldDescriptor) {
-      const fields = findFieldsWithSource(recordTypeConfig.fields, shortId);
+      const fields = findFieldsWithSource(recordTypeConfig.fields, shortId, vocabularyType);
 
       if (fields.length > 0) {
         uses[recordTypeConfig.name] = fields;

--- a/test/specs/components/admin/VocabularyUsedByPanel.spec.jsx
+++ b/test/specs/components/admin/VocabularyUsedByPanel.spec.jsx
@@ -7,6 +7,7 @@ import createTestContainer from '../../../helpers/createTestContainer';
 import { render } from '../../../helpers/renderHelpers';
 import VocabularyUsedByPanel from '../../../../src/components/admin/VocabularyUsedByPanel';
 import { configKey } from '../../../../src/helpers/configHelpers';
+import { OptionPickerInput, TermPickerInput } from '../../../../src/helpers/configContextInputs';
 
 const { expect } = chai;
 
@@ -51,6 +52,23 @@ describe('VocabularyUsedByPanel', () => {
                 },
               },
               view: {
+                type: TermPickerInput,
+                props: {
+                  source: shortId,
+                },
+              },
+            },
+          },
+          field2: {
+            [configKey]: {
+              messages: {
+                name: {
+                  id: 'field2.name',
+                  defaultMessage: 'Field 2 - Wrong View Type',
+                },
+              },
+              view: {
+                type: OptionPickerInput,
                 props: {
                   source: shortId,
                 },
@@ -100,7 +118,9 @@ describe('VocabularyUsedByPanel', () => {
     list.should.not.equal(null);
 
     list.querySelector('li > div').textContent.should.equal('Group');
-    list.querySelector('li > ul > li').textContent.should.equal('Field 1');
+    const fields = list.querySelectorAll('li > ul > li');
+    fields.length.should.equal(1);
+    fields[0].textContent.should.equal('Field 1');
   });
 
   it('should render a not used message if no uses are found', function test() {


### PR DESCRIPTION
**What does this do?**
This updates the `findVocabularyUses` to accept a vocabulary type in order to search on specific views.

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1732

When looking at terms, the used by panel will search for uses based on the id of the term list being used. In this case, both the term list and id generator share `nagprainventory`, which is causing the ID Generator to show up in the used by panel for the term list. This update changes this to use `TermPickerInput` as the view type when in the `VocabularyUsedBy` component. 

**How should this be tested? Do these changes have associated tests?**
* Run the devserver, e.g. `npm run devserver --back-end=https://core.dev.collectionspace.org`
* Navigate to the Tools > Term Lists
* Search for `NAGPRA Inventory` 
* See that the id generator no longer shows up in the used by panel

**Dependencies for merging? Releasing to production?**
Though it shouldn't be possible, if a view config hasn't been set this will no longer show a field under the used by panel.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested using core.dev as a backend