### PR TITLE
NOJIRA: enabled hot module replacement

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -131,5 +131,11 @@ export default (uiConfig) => {
     Modal.setAppElement(mountNode);
 
     render(<AppContainer {...props} />, mountNode);
+
+    if (module.hot) {
+      module.hot.accept('./containers/AppContainer', () => {
+        render(<AppContainer {...props} />, mountNode);
+      });
+    }
   }
 };

--- a/webpackDevServerConfig.js
+++ b/webpackDevServerConfig.js
@@ -123,9 +123,6 @@ module.exports = async ({
     console.info();
 
     return {
-      static: {
-        directory: __dirname,
-      },
       historyApiFallback: true,
     };
   }
@@ -313,10 +310,7 @@ module.exports = async ({
   });
 
   return {
-    static: {
-      directory: __dirname,
-      publicPath,
-    },
+    hot: 'only',
     setupMiddlewares: (middlewares) => {
       middlewares.push({
         name: 'cspace-proxy',


### PR DESCRIPTION
**What does this do?**
Enables webpack dev server's [HMR (Hot Module Replacement)](https://webpack.js.org/concepts/hot-module-replacement/) for faster development by retaining application state and only updating what's changed on source file changes, instead of full page reload. A full page reload takes ~30 seconds, when being logged in, while HMR takes <1 second.

**Why are we doing this? (with JIRA link)**
Currently, when developers save changes to the source code during development, a full app reload is triggered, requiring approximately 30 seconds to view the results in the browser—especially when logged in. This delay occurs because the app must be compiled, loaded, reauthenticate, and all API resources must be retrieved. Additionally, this process results in the loss of the application state, significantly hindering the development workflow. Immediate feedback on changes and the ability to preserve application state during source modifications are crucial for an efficient development experience.

The full reload is initiated because the webpack dev server’s `static` configuration is set to the root path, treating every file in the project as a static asset. Consequently, modifying a static file causes a complete reload of the application.

In the current pull request, I removed the `static` property from the webpack configuration since the app does not utilize any static files that require dedicated URL serving. Furthermore, I enabled Hot Module Replacement (HMR), allowing changes to the source files to trigger module updates instead of a full refresh. This improvement greatly accelerates the development process by maintaining the application state and only updating the modules that have changed, without full page reload.

**How should this be tested? Do these changes have associated tests?**
* Run the devserver, e.g. npm run devserver --back-end=https://core.dev.collectionspace.org
* Edit a source file (js, jsx, css, html), e.g. `./src/components/pages/SearchPage.jsx`
* Check the change in the browser, the change should appear without full page reload. The console log should look like:

```
[webpack-dev-server] App updated. Recompiling...
index.js:484 [webpack-dev-server] App hot update...
log.js:39 [HMR] Checking for updates on the server...
log.js:39 [HMR] Updated modules:
log.js:39 [HMR]  - ./src/components/pages/SearchPage.jsx
log.js:39 [HMR]  - ./src/containers/pages/SearchPageContainer.js
log.js:39 [HMR]  - ./src/components/pages/RootPage.jsx
log.js:39 [HMR]  - ./src/components/App.jsx
log.js:39 [HMR]  - ./src/containers/AppContainer.js
log.js:39 [HMR] App is up to date.

```


**Dependencies for merging? Releasing to production?**
None


**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@spirosdi using herbarium.collectionspace.org as backend.
