### PR TITLE
Add context to ConfigProvider

### DIFF
--- a/src/components/config/ConfigProvider.jsx
+++ b/src/components/config/ConfigProvider.jsx
@@ -1,4 +1,4 @@
-import { Component, Children } from 'react';
+import React, { Component, Children, useContext } from 'react';
 import PropTypes from 'prop-types';
 
 const propTypes = {
@@ -11,6 +11,8 @@ const childContextTypes = {
   // eslint-disable-next-line react/forbid-prop-types
   config: PropTypes.object,
 };
+
+export const ConfigContext = React.createContext(null);
 
 export default class ConfigProvider extends Component {
   getChildContext() {
@@ -25,11 +27,20 @@ export default class ConfigProvider extends Component {
 
   render() {
     const {
+      config,
       children,
     } = this.props;
 
-    return Children.only(children);
+    return (
+      <ConfigContext.Provider value={config}>
+        {Children.only(children)}
+      </ConfigContext.Provider>
+    );
   }
+}
+
+export function useConfig() {
+  return useContext(ConfigContext);
 }
 
 ConfigProvider.propTypes = propTypes;


### PR DESCRIPTION
**What does this do?**
This adds a context for the ConfigProvider. It also adds a function, useConfig, which allows for easy use of the config in functional components.

**Why are we doing this? (with JIRA link)**
No jira. As I've been prototyping the new search this is something that has been needed. It's also a bit of a stop gap because of how many components use the contextTypes to get the config.

**How should this be tested? Do these changes have associated tests?**
* run `npm run test` and ensure all test pass

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@mikejritter tested using core.dev as a backend.