### PR TITLE
DRYD-1382: Add Support For New Search API

### DIFF
--- a/src/plugins/listTypes/index.js
+++ b/src/plugins/listTypes/index.js
@@ -4,6 +4,7 @@ import authRef from './authRef';
 import common from './common';
 import refDoc from './refDoc';
 import role from './role';
+import search from './search';
 
 export default [
   account,
@@ -12,4 +13,5 @@ export default [
   common,
   refDoc,
   role,
+  search,
 ];

--- a/src/plugins/listTypes/search.js
+++ b/src/plugins/listTypes/search.js
@@ -1,0 +1,25 @@
+import { defineMessages } from 'react-intl';
+
+export default () => ({
+  listTypes: {
+    search: {
+      listNodeName: 'ns3:advancedsearch-common-list',
+      itemNodeName: 'advancedsearch-list-item',
+      messages: defineMessages({
+        resultCount: {
+          id: 'list.search.resultCount',
+          defaultMessage: `{totalItems, plural,
+            =0 {No records}
+            one {1 record}
+            other {{startNum, number}–{endNum, number} of {totalItems, number} records}
+          } found`,
+        },
+        searching: {
+          id: 'list.search.searching',
+          defaultMessage: 'Finding records...',
+        },
+      }),
+      getItemLocationPath: (item) => item.get('uri'),
+    },
+  },
+});

--- a/src/plugins/recordTypes/collectionobject/serviceConfig.js
+++ b/src/plugins/recordTypes/collectionobject/serviceConfig.js
@@ -6,7 +6,9 @@ export default {
   objectName: 'CollectionObject',
   documentName: 'collectionobjects',
 
-  useUpdatedSearch: true,
+  features: {
+    updatedSearch: true,
+  },
 
   quickAddData: (values) => ({
     document: {

--- a/src/plugins/recordTypes/collectionobject/serviceConfig.js
+++ b/src/plugins/recordTypes/collectionobject/serviceConfig.js
@@ -6,6 +6,8 @@ export default {
   objectName: 'CollectionObject',
   documentName: 'collectionobjects',
 
+  useUpdatedSearch: true,
+
   quickAddData: (values) => ({
     document: {
       'ns2:collectionobjects_common': {


### PR DESCRIPTION
**What does this do?**
* Adds a feature flag to the CollectionObject service config for use with the new search api
* Adds a new list type to match the new api response
* Update search redux action to work with the new search api

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1832

This is preliminary work which is being done to allow components to make use of the new API and make use of updated views.

**How should this be tested? Do these changes have associated tests?**
Testing will be ongoing while the new search interface is being developed.

**Dependencies for merging? Releasing to production?**
This still needs tests but there's a desire to do testing of the new search prototype on dev so they may be skipped for now.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter has been testing with new components