### PR TITLE
DRYD-1802: Search Result List Prototype

### DIFF
--- a/src/components/pages/search/SearchResults.jsx
+++ b/src/components/pages/search/SearchResults.jsx
@@ -247,8 +247,9 @@ export default function SearchResults(props) {
           <header>
             <SearchResultSummary
               listType="common"
-              searchResults={searchResults}
-              searchErrors={searchErrors}
+              config={config}
+              searchResult={searchResults}
+              searchError={searchErrors}
               searchDescriptor={searchDescriptor}
             />
             <SimpleSelectBar toggleBar={displayToggles} />

--- a/src/components/pages/search/SearchResults.jsx
+++ b/src/components/pages/search/SearchResults.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import Immutable from 'immutable';
@@ -10,6 +10,7 @@ import SearchResultFooter from '../../search/SearchResultFooter';
 import ExportButton from '../../search/ExportButton';
 import RelateButton from '../../record/RelateButton';
 import SearchResultTable from '../../search/table/SearchTable';
+import SearchDetailList from '../../search/list/SearchList';
 import SearchResultSummary from '../../search/SearchResultSummary';
 import { ToggleButton, ToggleButtonContainer } from '../../search/header/ToggleButtons';
 import { useConfig } from '../../config/ConfigProvider';
@@ -179,7 +180,7 @@ function normalizeQuery(props, config) {
 }
 
 export default function SearchResults(props) {
-  // const [display, setDisplay] = useState('table');
+  const [display, setDisplay] = useState('table');
   const config = useConfig();
   const dispatch = useDispatch();
 
@@ -201,7 +202,7 @@ export default function SearchResults(props) {
   const toggles = [
     { key: 'table', label: 'table' },
     // { key: 'grid', label: 'grid' },
-    // { key: 'list', label: 'list' },
+    { key: 'list', label: 'list' },
   ];
 
   const displayToggles = (
@@ -214,13 +215,19 @@ export default function SearchResults(props) {
           name={item.key}
           label={item.label}
           style={styles[item.key]}
-          // onClick={() => setDisplay(item.key)}
+          onClick={() => setDisplay(item.key)}
         />
       )}
     />
   );
 
-  const searchDisplay = <SearchResultTable searchDescriptor={searchDescriptor} listType="common" />;
+  let searchDisplay;
+  if (display === 'table') {
+    searchDisplay = <SearchResultTable searchDescriptor={searchDescriptor} listType="common" />;
+  } else {
+    searchDisplay = <SearchDetailList searchDescriptor={searchDescriptor} />;
+  }
+
   // todo: these are needed in the Title/Footer/Pager
   // const pageSize = parseInt(list.get('pageSize'), 10);
   // const totalItems = parseInt(list.get('totalItems'), 10);

--- a/src/components/search/list/SearchList.css
+++ b/src/components/search/list/SearchList.css
@@ -10,12 +10,6 @@
   margin: 2px;
 }
 
-.innerdetail > ol {
-  list-style: none;
-  padding-left: 0;
-  margin-top: 0;
-}
-
 .detailimg {
   width: 128px;
   height: 128px;
@@ -25,4 +19,10 @@
 
 .detail-checkbox {
   margin-right: 5px;
+}
+
+.detail-list {
+  list-style: none;
+  padding-left: 0;
+  margin-top: 0;
 }

--- a/src/components/search/list/SearchList.css
+++ b/src/components/search/list/SearchList.css
@@ -7,6 +7,13 @@
 .innerdetail {
   display: flex;
   flex-direction: row;
+  margin: 2px;
+}
+
+.innerdetail > ol {
+  list-style: none;
+  padding-left: 0;
+  margin-top: 0;
 }
 
 .detailimg {
@@ -14,4 +21,8 @@
   height: 128px;
   margin-right: 5px;
   background:rgb(220, 220, 220);
+}
+
+.detail-checkbox {
+  margin-right: 5px;
 }

--- a/src/components/search/list/SearchList.css
+++ b/src/components/search/list/SearchList.css
@@ -1,0 +1,17 @@
+.detail {
+  display: flex;
+  flex-direction: column;
+  padding: 5px;
+}
+
+.innerdetail {
+  display: flex;
+  flex-direction: row;
+}
+
+.detailimg {
+  width: 128px;
+  height: 128px;
+  margin-right: 5px;
+  background:rgb(220, 220, 220);
+}

--- a/src/components/search/list/SearchList.css
+++ b/src/components/search/list/SearchList.css
@@ -4,24 +4,24 @@
   padding: 5px;
 }
 
-.innerdetail {
+.innerDetail {
   display: flex;
   flex-direction: row;
   margin: 2px;
 }
 
-.detailimg {
+.detailImg {
   width: 128px;
   height: 128px;
   margin-right: 5px;
   background:rgb(220, 220, 220);
 }
 
-.detail-checkbox {
+.detailCheckbox {
   margin-right: 5px;
 }
 
-.detail-list {
+.detailList {
   list-style: none;
   padding-left: 0;
   margin-top: 0;

--- a/src/components/search/list/SearchList.jsx
+++ b/src/components/search/list/SearchList.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import styles from './SearchList.css';
+import deactivate from '../../../../images/deactivate.svg';
+
+export function DetailItem() {
+  // todo: read fields from record config
+
+  return (
+    <div className={styles.innerdetail}>
+      <img src={deactivate} className={styles.detailimg} />
+      <input style={{ alignSelf: 'flex-start' }} type="checkbox" />
+      <ol>
+        <li>ID: 2025.1.2</li>
+        <li>Title: Published Item Title Test</li>
+        <li>Responsible Department: Departmentalized</li>
+        <li>Current Location: Storage Site A</li>
+        <li>Brief Description: Some information about this item...</li>
+      </ol>
+    </div>
+  );
+}
+
+export default function SearchDetailList() {
+  return (
+    <div className={styles.detail}>
+      <DetailItem />
+    </div>
+  );
+}

--- a/src/components/search/list/SearchList.jsx
+++ b/src/components/search/list/SearchList.jsx
@@ -1,23 +1,31 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
+import get from 'lodash/get';
 import styles from './SearchList.css';
 import deactivate from '../../../../images/deactivate.svg';
+import { getColumnConfig, readListItems } from '../searchResultHelpers';
 import { getSearchResult } from '../../../reducers';
-import { NEW_SEARCH_RESULT_PAGE_SEARCH_NAME } from '../../../constants/searchNames';
+import { SEARCH_RESULT_PAGE_SEARCH_NAME } from '../../../constants/searchNames';
+import { useConfig } from '../../config/ConfigProvider';
 
-export function DetailItem({ result }) {
+const DETAIL_COLUMN_SET = 'list';
+
+export function DetailItem({ item, listItems }) {
   // todo: read fields from record config
 
+  console.log(`${JSON.stringify(item)}`);
   return (
     <div className={styles.innerdetail}>
       <img src={deactivate} className={styles.detailimg} />
       <input style={{ alignSelf: 'flex-start' }} type="checkbox" />
       <ol>
-        <li>{`ID: ${result.objectNumber}`}</li>
-        <li>{`Title: ${result.title}`}</li>
-        <li>{`Responsible Department: ${result.responsibleDepartment}`}</li>
-        <li>{`Current Location: ${result.computedCurrentLocation}`}</li>
-        <li>{`Brief Description: ${result.briefDescription}`}</li>
+        {listItems.map((listItem) => (
+          <li key={item.csid}>
+            {listItem.dataKey}
+            :
+            {item.get(listItem.dataKey)}
+          </li>
+        ))}
       </ol>
     </div>
   );
@@ -25,12 +33,57 @@ export function DetailItem({ result }) {
 
 export default function SearchDetailList({ searchDescriptor }) {
   const results = useSelector((state) => getSearchResult(state,
-    NEW_SEARCH_RESULT_PAGE_SEARCH_NAME,
+    SEARCH_RESULT_PAGE_SEARCH_NAME,
     searchDescriptor));
+  const config = useConfig();
+
+  if (!results) {
+    return null;
+  }
+
+  // Note: The items returned is an Immutable.Map, so we need to use get
+  // in order to retrieve the data
+  // todo: read into the search results based on the list type
+  // todo: why do we need to do !results AND !items?
+  const items = readListItems(config, 'common', results);
+  if (!items) {
+    return null;
+  }
+
+  // read headers
+  const listConfig = getColumnConfig(config, searchDescriptor, DETAIL_COLUMN_SET);
+  const listItems = Object.keys(listConfig)
+    .filter((name) => !listConfig[name].disabled)
+    .sort((nameA, nameB) => {
+      const orderA = listConfig[nameA].order;
+      const orderB = listConfig[nameB].order;
+
+      return orderA - orderB;
+    }).map((name) => {
+      const column = listConfig[name];
+      return {
+        dataKey: column.dataKey || name,
+        cellDataGetter: ({ dataKey, rowData }) => rowData,
+        label: () => {
+          const message = get(column, ['messages', 'label']);
+          return message; // ? intl.formatMessage(message) : '';
+        },
+        // I kind of like this - a render prop which can be used to render arbitrary rows
+        // the one thing is, it would be nice to have a formatter provided alongside so it
+        // could be like format(label, data) or something. Maybe that could be variadic to support
+        // the grid too? Probably not worth tho.
+        renderRow: ({ dataKey, rowData }) => {
+          const label = get(column, ['message', 'label']);
+          const data = rowData.get(dataKey);
+          const formatted = `${label}: ${data}`;
+          return <li>{formatted}</li>;
+        },
+      };
+    });
 
   return (
     <div className={styles.detail}>
-      {results.map((result) => <DetailItem result={result} />)}
+      {items.map((item) => <DetailItem item={item} listItems={listItems} />)}
     </div>
   );
 }

--- a/src/components/search/list/SearchList.jsx
+++ b/src/components/search/list/SearchList.jsx
@@ -111,15 +111,11 @@ function SearchDetailList({ searchDescriptor, intl, listType = 'common' }) {
       const column = listConfig[name];
       return {
         dataKey: column.dataKey || name,
-        cellDataGetter: ({ dataKey, rowData }) => rowData,
         label: () => {
           const message = get(column, ['messages', 'label']);
           return message ? intl.formatMessage(message) : '';
         },
-        // I kind of like this - a render prop which can be used to render arbitrary rows
-        // the one thing is, it would be nice to have a formatter provided alongside so it
-        // could be like format(label, data) or something. Maybe that could be variadic to support
-        // the grid too? Probably not worth tho.
+        // Just an idea - a render 'prop' passed along with the listItems
         renderRow: ({ dataKey, rowData }) => {
           const label = get(column, ['message', 'label']);
           const data = rowData.get(dataKey);

--- a/src/components/search/list/SearchList.jsx
+++ b/src/components/search/list/SearchList.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import Immutable from 'immutable';
 import { useSelector } from 'react-redux';
 import get from 'lodash/get';
 import { injectIntl } from 'react-intl';
@@ -11,10 +13,13 @@ import { useConfig } from '../../config/ConfigProvider';
 
 const DETAIL_COLUMN_SET = 'list';
 
-export function DetailItem({ item, listItems }) {
-  // todo: read fields from record config
+const itemPropTypes = {
+  item: PropTypes.instanceOf(Immutable.Map),
+  // exact shape tbd
+  listItems: PropTypes.array,
+};
 
-  console.log(`${JSON.stringify(item)}`);
+export function DetailItem({ item, listItems }) {
   return (
     <div className={styles.innerdetail}>
       <img src={deactivate} className={styles.detailimg} />
@@ -32,6 +37,12 @@ export function DetailItem({ item, listItems }) {
   );
 }
 
+DetailItem.propTypes = itemPropTypes;
+
+const propTypes = {
+  searchDescriptor: PropTypes.instanceOf(Immutable.Map),
+};
+
 function SearchDetailList({ searchDescriptor }) {
   const results = useSelector((state) => getSearchResult(state,
     SEARCH_RESULT_PAGE_SEARCH_NAME,
@@ -44,9 +55,10 @@ function SearchDetailList({ searchDescriptor }) {
 
   // Note: The items returned is an Immutable.Map, so we need to use get
   // in order to retrieve the data
+  // Note x2: This is only available for 'new' searches, so we don't need a list type prop
   // todo: read into the search results based on the list type
   // todo: why do we need to do !results AND !items?
-  const items = readListItems(config, 'common', results);
+  const items = readListItems(config, 'search', results);
   if (!items) {
     return null;
   }
@@ -88,5 +100,7 @@ function SearchDetailList({ searchDescriptor }) {
     </div>
   );
 }
+
+SearchDetailList.propTypes = propTypes;
 
 export default injectIntl(SearchDetailList);

--- a/src/components/search/list/SearchList.jsx
+++ b/src/components/search/list/SearchList.jsx
@@ -41,9 +41,10 @@ DetailItem.propTypes = itemPropTypes;
 
 const propTypes = {
   searchDescriptor: PropTypes.instanceOf(Immutable.Map),
+  listType: PropTypes.string,
 };
 
-function SearchDetailList({ searchDescriptor }) {
+function SearchDetailList({ searchDescriptor, listType = 'common' }) {
   const results = useSelector((state) => getSearchResult(state,
     SEARCH_RESULT_PAGE_SEARCH_NAME,
     searchDescriptor));
@@ -58,7 +59,7 @@ function SearchDetailList({ searchDescriptor }) {
   // Note x2: This is only available for 'new' searches, so we don't need a list type prop
   // todo: read into the search results based on the list type
   // todo: why do we need to do !results AND !items?
-  const items = readListItems(config, 'search', results);
+  const items = readListItems(config, listType, results);
   if (!items) {
     return null;
   }

--- a/src/components/search/list/SearchList.jsx
+++ b/src/components/search/list/SearchList.jsx
@@ -43,6 +43,7 @@ export function DetailItem({
       <img src={deactivate} className={styles.detailimg} />
       <CheckboxInput
         embedded
+        className={styles['detail-checkbox']}
         name={`${index}`}
         value={selected}
         onCommit={(path, value) => dispatch(setResultItemSelected(config,

--- a/src/components/search/list/SearchList.jsx
+++ b/src/components/search/list/SearchList.jsx
@@ -56,7 +56,7 @@ export function DetailItem({
       />
       <ol>
         {listItems.map((listItem) => (
-          <li key={item.csid}>
+          <li key={`${csid}-${listItem.dataKey}`}>
             {listItem.label()}
             {': '}
             {item.get(listItem.dataKey)}

--- a/src/components/search/list/SearchList.jsx
+++ b/src/components/search/list/SearchList.jsx
@@ -47,7 +47,7 @@ export function DetailItem({
   const list = location
     ? (
       <Link to={location}>
-        <ol className={styles['detail-list']}>
+        <ol className={styles.detailList}>
           {listItems.map((listItem) => (
             <li key={`${csid}-${listItem.dataKey}`}>
               {listItem.label()}
@@ -60,7 +60,7 @@ export function DetailItem({
       </Link>
     )
     : (
-      <ol className={styles['detail-list']}>
+      <ol className={styles.detailList}>
         {listItems.map((listItem) => (
           <li key={`${csid}-${listItem.dataKey}`}>
             {listItem.label()}
@@ -73,12 +73,12 @@ export function DetailItem({
 
   // omit fields when no data is returned?
   return (
-    <div className={styles.innerdetail}>
+    <div className={styles.innerDetail}>
       {/* eslint-disable-next-line jsx-a11y/alt-text */}
-      <img src={deactivate} className={styles.detailimg} />
+      <img src={deactivate} className={styles.detailImg} />
       <CheckboxInput
         embedded
-        className={styles['detail-checkbox']}
+        className={styles.detailCheckbox}
         name={`${index}`}
         value={selected}
         onCommit={(path, value) => dispatch(setResultItemSelected(config,

--- a/src/components/search/list/SearchList.jsx
+++ b/src/components/search/list/SearchList.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import get from 'lodash/get';
+import { injectIntl } from 'react-intl';
 import styles from './SearchList.css';
 import deactivate from '../../../../images/deactivate.svg';
 import { getColumnConfig, readListItems } from '../searchResultHelpers';
@@ -31,7 +32,7 @@ export function DetailItem({ item, listItems }) {
   );
 }
 
-export default function SearchDetailList({ searchDescriptor }) {
+function SearchDetailList({ searchDescriptor }) {
   const results = useSelector((state) => getSearchResult(state,
     SEARCH_RESULT_PAGE_SEARCH_NAME,
     searchDescriptor));
@@ -87,3 +88,5 @@ export default function SearchDetailList({ searchDescriptor }) {
     </div>
   );
 }
+
+export default injectIntl(SearchDetailList);

--- a/src/components/search/list/SearchList.jsx
+++ b/src/components/search/list/SearchList.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 import styles from './SearchList.css';
 import deactivate from '../../../../images/deactivate.svg';
+import { getSearchResult } from '../../../reducers';
+import { NEW_SEARCH_RESULT_PAGE_SEARCH_NAME } from '../../../constants/searchNames';
 
-export function DetailItem() {
+export function DetailItem({ result }) {
   // todo: read fields from record config
 
   return (
@@ -10,20 +13,24 @@ export function DetailItem() {
       <img src={deactivate} className={styles.detailimg} />
       <input style={{ alignSelf: 'flex-start' }} type="checkbox" />
       <ol>
-        <li>ID: 2025.1.2</li>
-        <li>Title: Published Item Title Test</li>
-        <li>Responsible Department: Departmentalized</li>
-        <li>Current Location: Storage Site A</li>
-        <li>Brief Description: Some information about this item...</li>
+        <li>{`ID: ${result.objectNumber}`}</li>
+        <li>{`Title: ${result.title}`}</li>
+        <li>{`Responsible Department: ${result.responsibleDepartment}`}</li>
+        <li>{`Current Location: ${result.computedCurrentLocation}`}</li>
+        <li>{`Brief Description: ${result.briefDescription}`}</li>
       </ol>
     </div>
   );
 }
 
-export default function SearchDetailList() {
+export default function SearchDetailList({ searchDescriptor }) {
+  const results = useSelector((state) => getSearchResult(state,
+    NEW_SEARCH_RESULT_PAGE_SEARCH_NAME,
+    searchDescriptor));
+
   return (
     <div className={styles.detail}>
-      <DetailItem />
+      {results.map((result) => <DetailItem result={result} />)}
     </div>
   );
 }

--- a/src/components/search/list/SearchList.jsx
+++ b/src/components/search/list/SearchList.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import Immutable from 'immutable';
 import { useDispatch, useSelector } from 'react-redux';
@@ -36,6 +37,40 @@ export function DetailItem({
   const csid = item.get('csid');
   const selected = selectedItems ? selectedItems.has(csid) : false;
 
+  const listTypeConfig = config.listTypes[listType];
+  const { getItemLocationPath } = listTypeConfig;
+  let location;
+  if (getItemLocationPath) {
+    location = getItemLocationPath(item, { config, searchDescriptor });
+  }
+
+  const list = location
+    ? (
+      <Link to={location}>
+        <ol className={styles['detail-list']}>
+          {listItems.map((listItem) => (
+            <li key={`${csid}-${listItem.dataKey}`}>
+              {listItem.label()}
+              {': '}
+              {item.get(listItem.dataKey)}
+            </li>
+          ))}
+        </ol>
+
+      </Link>
+    )
+    : (
+      <ol className={styles['detail-list']}>
+        {listItems.map((listItem) => (
+          <li key={`${csid}-${listItem.dataKey}`}>
+            {listItem.label()}
+            {': '}
+            {item.get(listItem.dataKey)}
+          </li>
+        ))}
+      </ol>
+    );
+
   // omit fields when no data is returned?
   return (
     <div className={styles.innerdetail}>
@@ -54,15 +89,7 @@ export function DetailItem({
           value))}
         onClick={(event) => event.stopPropagation()}
       />
-      <ol>
-        {listItems.map((listItem) => (
-          <li key={`${csid}-${listItem.dataKey}`}>
-            {listItem.label()}
-            {': '}
-            {item.get(listItem.dataKey)}
-          </li>
-        ))}
-      </ol>
+      {list}
     </div>
   );
 }

--- a/src/plugins/recordTypes/collectionobject/columns.js
+++ b/src/plugins/recordTypes/collectionobject/columns.js
@@ -2,6 +2,7 @@ import { defineMessages } from 'react-intl';
 
 export default (configContext) => {
   const {
+    formatRefName,
     formatTimestamp,
   } = configContext.formatHelpers;
 
@@ -75,6 +76,55 @@ export default (configContext) => {
         order: 30,
         sortBy: 'collectionspace_core:updatedAt',
         width: 150,
+      },
+    },
+    list: {
+      objectNumber: {
+        messages: defineMessages({
+          label: {
+            id: 'column.collectionobject.list.objectNumber',
+            defaultMessage: 'Object ID',
+          },
+        }),
+        order: 10,
+      },
+      title: {
+        messages: defineMessages({
+          label: {
+            id: 'column.collectionobject.list.title',
+            defaultMessage: 'Object Title',
+          },
+        }),
+        order: 20,
+      },
+      responsibleDepartment: {
+        messages: defineMessages({
+          label: {
+            id: 'column.collectionobject.list.responsibleDepartment',
+            defaultMessage: 'Responsible Department',
+          },
+        }),
+        order: 30,
+      },
+      computedCurrentLocation: {
+        formatValue: formatRefName,
+        messages: defineMessages({
+          label: {
+            id: 'column.collectionobject.list.computedCurrentLocation',
+            defaultMessage: 'Current Location',
+          },
+        }),
+        order: 40,
+      },
+      briefDescription: {
+        messages: defineMessages({
+          label: {
+            id: 'column.collectionobject.list.briefDescription',
+            defaultMessage: 'Brief Description',
+          },
+        }),
+        order: 50,
+        sortBy: 'collectionobjects_common:briefDescriptions/0',
       },
     },
   };


### PR DESCRIPTION
**What does this do?**
* Adds a detailed list view to the search result page
* Adds a toggle for the list view
* Add column configuration to the list view for collection objects

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1802

This is an additional view for search results being prototyped.

**How should this be tested? Do these changes have associated tests?**
* Run the dev server with core.dev as a backend
* Perform a search on CollectionObjects
* Be able to toggle between the table and list views

**Dependencies for merging? Releasing to production?**
There's still a fair amount of work and speccing to be done before this is production ready. As the views are tested we'll be making more changes to the views.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter has been testing with core.dev as a backend