### PR TITLE
Run CI For PRs Against dev

### DIFF
--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -2,9 +2,9 @@ name: Continuous integration
 
 on:
   push:
-    branches: [ "master", "main", "v*" ]
+    branches: [ "main", "v*", "develop" ]
   pull_request:
-    branches: [ "master", "main", "v*" ]
+    branches: [ "main", "v*", "develop" ]
 
 jobs:
   check:


### PR DESCRIPTION
**What does this do?**
Updates the CI rules to add develop as a branch.

**Why are we doing this? (with JIRA link)**
No jira. This allows CI to be run when we create PRs.

**How should this be tested? Do these changes have associated tests?**
* Create a PR
* See CI is run

**Dependencies for merging? Releasing to production?**
none

**Has the application documentation been updated for these changes?**
no

**Did someone actually run this code to verify it works?**
no