### PR TITLE
DRYD-1804: Sorting for SearchResultTable 

### DIFF
--- a/src/components/pages/search/SearchResults.jsx
+++ b/src/components/pages/search/SearchResults.jsx
@@ -165,13 +165,15 @@ function normalizeQuery(props, config) {
 
     if (Object.keys(normalizedQueryParams).length > 0) {
       const newQuery = { ...query, ...normalizedQueryParams };
-      const queryString = qs.stringify(newQuery);
 
+      /*
+      const queryString = qs.stringify(newQuery);
       history.replace({
         pathname: location.pathname,
         search: `?${queryString}`,
         state: location.state,
       });
+      */
 
       return newQuery;
     }

--- a/src/components/search/table/SearchResultTableHeader.jsx
+++ b/src/components/search/table/SearchResultTableHeader.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import qs from 'qs';
+
+const propTypes = {
+  column: PropTypes.shape({
+    dataKey: PropTypes.string,
+    formatValue: PropTypes.func,
+    label: PropTypes.func,
+  }),
+  sort: PropTypes.string,
+};
+
+export default function SearchResultTableHeader({ column, sort }) {
+  const history = useHistory();
+  const location = useLocation();
+
+  function handleSortChange() {
+    let newSort;
+    if (sort === undefined || sort === 'desc') {
+      newSort = '';
+    } else {
+      newSort = ' desc';
+    }
+
+    const {
+      search,
+    } = location;
+
+    const query = qs.parse(search.substring(1));
+
+    query.sort = `${column.dataKey}${newSort}`;
+
+    const queryString = qs.stringify(query);
+    history.push({
+      pathname: location.pathname,
+      search: `?${queryString}`,
+      state: location.state,
+    });
+  }
+
+  let arrow;
+  if (sort === 'asc') {
+    arrow = (
+      <svg width={16} height={16} viewBox="0 0 24 24">
+        <path d="M 7 14 l5-5 5 5 z" />
+      </svg>
+    );
+  } else if (sort === 'desc') {
+    arrow = (
+      <svg width={16} height={16} viewBox="0 0 24 24">
+        <path d="M 7 14 l5 5 5-5 z" />
+      </svg>
+    );
+  }
+
+  return (
+    <th key={column.dataKey} style={{ textAlign: 'left' }} onClick={() => handleSortChange()}>
+      {column.label()}
+      {arrow}
+    </th>
+  );
+}
+
+SearchResultTableHeader.propTypes = propTypes;


### PR DESCRIPTION
**What does this do?**
* Adds a SearchResultTableHeader component
* Allows for table headers to be clicked, updating the sort by/order

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1804

This is additional work to bring the new SearchResultTable up to feature parity with the existing implementation.

**How should this be tested? Do these changes have associated tests?**
* Run the devserver
* Search on 'Objects'
* Click the table headers to sort

**Dependencies for merging? Releasing to production?**
When changing sort order, the table can be seen resizing. We should have that sorted out before it is released for production.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter has been testing with core.dev as a backend.