### PR TITLE
DRYD-1804: Search Table Pagination

### DIFF
--- a/src/components/pages/search/SearchResults.jsx
+++ b/src/components/pages/search/SearchResults.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import Immutable from 'immutable';
@@ -188,10 +188,11 @@ export default function SearchResults(props) {
   const dispatch = useDispatch();
 
   const normalizedQuery = normalizeQuery(props, config);
-  setPreferredPageSize(props, dispatch);
-
   const searchDescriptor = getSearchDescriptor(normalizedQuery, props);
-  dispatch(search(config, SEARCH_RESULT_PAGE_SEARCH_NAME, searchDescriptor, 'common')); // , 'common', true));
+  useEffect(() => {
+    setPreferredPageSize(props, dispatch);
+    dispatch(search(config, SEARCH_RESULT_PAGE_SEARCH_NAME, searchDescriptor, 'common')); // , 'common', true));
+  }, [normalizedQuery, searchDescriptor]);
 
   // todo: should these be called in each component? they're at the top level for now
   // as to not make too many changes at once

--- a/src/components/search/SearchResultFooter.jsx
+++ b/src/components/search/SearchResultFooter.jsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
+import { useHistory, useLocation } from 'react-router-dom';
+import qs from 'qs';
 import Pager from './Pager';
 import { useConfig } from '../config/ConfigProvider';
 import { getListType } from '../../helpers/searchHelpers';
 import { SEARCH_RESULT_PAGE_SEARCH_NAME } from '../../constants/searchNames';
 import { getSearchResult } from '../../reducers';
+import { setSearchResultPagePageSize } from '../../actions/prefs';
 
 const propTypes = {
   searchDescriptor: PropTypes.object,
@@ -20,11 +23,53 @@ export default function SearchResultFooter({ searchDescriptor }) {
     SEARCH_RESULT_PAGE_SEARCH_NAME,
     searchDescriptor));
   const config = useConfig();
+  const dispatch = useDispatch();
+  const history = useHistory();
+  const location = useLocation();
 
   if (!results) {
     return (
       <footer />
     );
+  }
+
+  function onPageChange(page) {
+    const {
+      search,
+    } = location;
+
+    const query = qs.parse(search.substring(1));
+
+    query.p = (page + 1).toString();
+
+    const queryString = qs.stringify(query);
+
+    history.push({
+      pathname: location.pathname,
+      search: `?${queryString}`,
+      state: location.state,
+    });
+  }
+
+  function onPageSizeChange(pageSize) {
+    const {
+      search,
+    } = location;
+
+    dispatch(() => setSearchResultPagePageSize(pageSize));
+
+    const query = qs.parse(search.substring(1));
+
+    query.p = '1';
+    query.size = pageSize.toString();
+
+    const queryString = qs.stringify(query);
+
+    history.push({
+      pathname: location.pathname,
+      search: `?${queryString}`,
+      state: location.state,
+    });
   }
 
   const listType = getListType(searchDescriptor);
@@ -49,8 +94,10 @@ export default function SearchResultFooter({ searchDescriptor }) {
         currentPage={pageNum}
         lastPage={lastPage}
         pageSize={pageSize}
-        // onPageChange={handlePageChange}
-        // onPageSizeChange={handlePageSizeChange}
+        // eslint-disable-next-line react/jsx-no-bind
+        onPageChange={onPageChange}
+        // eslint-disable-next-line react/jsx-no-bind
+        onPageSizeChange={onPageSizeChange}
       />
     </footer>
   );

--- a/src/components/search/table/SearchResultTableHeader.jsx
+++ b/src/components/search/table/SearchResultTableHeader.jsx
@@ -56,7 +56,7 @@ export default function SearchResultTableHeader({ column, sort }) {
   }
 
   return (
-    <th key={column.dataKey} style={{ textAlign: 'left' }} onClick={() => handleSortChange()}>
+    <th style={{ textAlign: 'left' }} onClick={() => handleSortChange()}>
       {column.label()}
       {arrow}
     </th>

--- a/src/components/search/table/SearchTable.jsx
+++ b/src/components/search/table/SearchTable.jsx
@@ -49,7 +49,7 @@ function renderRow(item, index, renderContext) {
 
   const selected = selectedItems ? selectedItems.has(csid) : false;
   return (
-    <tr key={item.csid} className={index % 2 === 0 ? styles.even : styles.odd}>
+    <tr key={`${item.csid}-${index}`} className={index % 2 === 0 ? styles.even : styles.odd}>
       <td>
         <CheckboxInput
           embedded
@@ -181,8 +181,8 @@ function SearchResultTable({ searchDescriptor, listType = 'common', intl }) {
             {/* eslint-disable-next-line jsx-a11y/control-has-associated-label */}
             <th className={styles.checkbox} />
             {columns.map((column) => (sortColumnName === column.dataKey
-              ? <SearchResultTableHeader column={column} sort={sortDir} />
-              : <SearchResultTableHeader column={column} />
+              ? <SearchResultTableHeader key={column.dataKey} column={column} sort={sortDir} />
+              : <SearchResultTableHeader key={column.dataKey} column={column} />
             ))}
           </tr>
         </thead>


### PR DESCRIPTION
**What does this do?**
* Adds pagination handlers to SearchResultFooter
* Move dispatched actions into useEffect
* Add key to tr

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1804

These are more updates to support existing functionality. This time it's just for the pagination controls at the bottom of the form. The page control in the header seems redundant and I'm not sure if we will continue to need it, so I've left it out of this PR.

**How should this be tested? Do these changes have associated tests?**
* Run the devserver against core.dev
* Search against 'Objects'
* Use the page controls underneath the table to control page size/page number

**Dependencies for merging? Releasing to production?**
The same issues apply to this as do the other PRs. Eventually tests should be added for all the new components.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter has been testing against core.dev