### PR TITLE
DRYD-1804: ARIA/WCAG updates for search table

### DIFF
--- a/src/components/search/searchResultHelpers.js
+++ b/src/components/search/searchResultHelpers.js
@@ -36,6 +36,37 @@ export function getColumnConfig(config, searchDescriptor, columnSetName) {
   return columnConfig;
 }
 
+export function readSearchResultList(config, listType, searchResult) {
+  if (!searchResult) {
+    return null;
+  }
+
+  const listTypeConfig = config.listTypes[listType];
+  const { listNodeName } = listTypeConfig;
+  return searchResult.get(listNodeName);
+}
+
+export function readSearchResultListItems(config, listType, list) {
+  if (!list) {
+    return null;
+  }
+
+  const listTypeConfig = config.listTypes[listType];
+  const { itemNodeName } = listTypeConfig;
+
+  let items = list.get(itemNodeName);
+  if (!items) {
+    items = Immutable.List();
+  }
+
+  if (!Immutable.List.isList(items)) {
+    // If there's only one result, it won't be returned as a list.
+    items = Immutable.List.of(items);
+  }
+
+  return items;
+}
+
 /**
  * Extract the search result list items from a given search result.
  *
@@ -45,7 +76,6 @@ export function getColumnConfig(config, searchDescriptor, columnSetName) {
  * @returns An Immutable.List containing the items for a search
  */
 export function readListItems(config, listType, searchResult) {
-  // console.log(`searchResult == ${JSON.stringify(searchResult)}`);
   const listTypeConfig = config.listTypes[listType];
   const { listNodeName, itemNodeName } = listTypeConfig;
 

--- a/src/components/search/table/SearchResultTableHeader.jsx
+++ b/src/components/search/table/SearchResultTableHeader.jsx
@@ -56,7 +56,7 @@ export default function SearchResultTableHeader({ column, sort }) {
   }
 
   return (
-    <th style={{ textAlign: 'left' }} onClick={() => handleSortChange()}>
+    <th style={{ textAlign: 'left' }} onClick={() => handleSortChange()} tabIndex={0}>
       {column.label()}
       {arrow}
     </th>

--- a/src/components/search/table/SearchResultTableRow.jsx
+++ b/src/components/search/table/SearchResultTableRow.jsx
@@ -13,6 +13,8 @@ import styles from '../../../../styles/cspace-ui/SearchTable.css';
 const propTypes = {
   item: PropTypes.instanceOf(Immutable.Map),
   index: PropTypes.number,
+  totalItems: PropTypes.number,
+  intl: PropTypes.object,
   renderContext: PropTypes.shape({
     listType: PropTypes.string,
     searchDescriptor: PropTypes.object,
@@ -22,15 +24,15 @@ const propTypes = {
 };
 
 const messages = defineMessages({
-  checkboxLabel: {
-    id: 'searchResultTableRow.checkboxLabel',
+  checkboxLabelSelect: {
+    id: 'searchResultTableRow.checkboxLabelSelect',
     description: 'The aria-label for a checkbox input',
-    defaultMessage: 'Selected row {index}',
+    defaultMessage: 'Select row {index}',
   },
   rowAriaLabel: {
     id: 'searchResultTableRow.rowAriaLabel',
     description: 'The aria-label for a row',
-    defaultMessage: '{primary} selected row {index} of {total}',
+    defaultMessage: 'Row {index} of {total} - {primary}',
   },
 });
 
@@ -41,7 +43,17 @@ function renderColumn(column, item) {
   return <td key={key}>{formatted}</td>;
 }
 
-function SearchResultTableRow({ item, index, renderContext }) {
+function createRowLabel(column, item, index, total, intl) {
+  const data = item.get(column.dataKey);
+  return data
+    ? intl.formatMessage(messages.rowAriaLabel,
+      { primary: data, index: index + 1, total })
+    : 'row';
+}
+
+function SearchResultTableRow({
+  item, index, totalItems, renderContext, intl,
+}) {
   const config = useConfig();
   const dispatch = useDispatch();
   const history = useHistory();
@@ -62,19 +74,21 @@ function SearchResultTableRow({ item, index, renderContext }) {
     location = getItemLocationPath(item, { config, searchDescriptor });
   }
 
-  const a11yProps = {};
-  a11yProps['aria-label'] = `Select row ${index}`;
-
   const selected = selectedItems ? selectedItems.has(csid) : false;
+
+  const rowAriaLabel = createRowLabel(columns[0], item, index, totalItems, intl);
+  const checkboxAriaLabel = intl.formatMessage(messages.checkboxLabelSelect, { index: index + 1 });
+
   return (
     <tr
+      aria-label={rowAriaLabel}
       tabIndex={0}
       className={index % 2 === 0 ? styles.even : styles.odd}
       onClick={() => history.push(location)}
     >
       <td>
         <CheckboxInput
-          {...a11yProps}
+          aria-label={checkboxAriaLabel}
           embedded
           name={`${index}`}
           value={selected}

--- a/src/components/search/table/SearchResultTableRow.jsx
+++ b/src/components/search/table/SearchResultTableRow.jsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { defineMessages, injectIntl } from 'react-intl';
+import PropTypes from 'prop-types';
+import Immutable from 'immutable';
+import { useDispatch } from 'react-redux';
+import { useHistory } from 'react-router-dom/cjs/react-router-dom.min';
+import CheckboxInput from 'cspace-input/lib/components/CheckboxInput';
+import { useConfig } from '../../config/ConfigProvider';
+import { setResultItemSelected } from '../../../actions/search';
+import { SEARCH_RESULT_PAGE_SEARCH_NAME } from '../../../constants/searchNames';
+import styles from '../../../../styles/cspace-ui/SearchTable.css';
+
+const propTypes = {
+  item: PropTypes.instanceOf(Immutable.Map),
+  index: PropTypes.number,
+  renderContext: PropTypes.shape({
+    listType: PropTypes.string,
+    searchDescriptor: PropTypes.object,
+    columns: PropTypes.array,
+    selectedItems: PropTypes.object,
+  }),
+};
+
+const messages = defineMessages({
+  checkboxLabel: {
+    id: 'searchResultTableRow.checkboxLabel',
+    description: 'The aria-label for a checkbox input',
+    defaultMessage: 'Selected row {index}',
+  },
+  rowAriaLabel: {
+    id: 'searchResultTableRow.rowAriaLabel',
+    description: 'The aria-label for a row',
+    defaultMessage: '{primary} selected row {index} of {total}',
+  },
+});
+
+function renderColumn(column, item) {
+  const data = item.get(column.dataKey);
+  const formatted = data ? column.formatValue(data) : null;
+  const key = `${item.get('csid')}-${column.dataKey}`;
+  return <td key={key}>{formatted}</td>;
+}
+
+function SearchResultTableRow({ item, index, renderContext }) {
+  const config = useConfig();
+  const dispatch = useDispatch();
+  const history = useHistory();
+
+  const {
+    listType,
+    searchDescriptor,
+    columns,
+    selectedItems,
+  } = renderContext;
+
+  const csid = item.get('csid');
+
+  const listTypeConfig = config.listTypes[listType];
+  const { getItemLocationPath } = listTypeConfig;
+  let location;
+  if (getItemLocationPath) {
+    location = getItemLocationPath(item, { config, searchDescriptor });
+  }
+
+  const a11yProps = {};
+  a11yProps['aria-label'] = `Select row ${index}`;
+
+  const selected = selectedItems ? selectedItems.has(csid) : false;
+  return (
+    <tr
+      tabIndex={0}
+      className={index % 2 === 0 ? styles.even : styles.odd}
+      onClick={() => history.push(location)}
+    >
+      <td>
+        <CheckboxInput
+          {...a11yProps}
+          embedded
+          name={`${index}`}
+          value={selected}
+          onCommit={(path, value) => dispatch(setResultItemSelected(config,
+            SEARCH_RESULT_PAGE_SEARCH_NAME,
+            searchDescriptor,
+            listType,
+            parseInt(path[0], 10),
+            value))}
+          onClick={(event) => event.stopPropagation()}
+        />
+      </td>
+      {columns.map((column) => renderColumn(column, item, location))}
+    </tr>
+  );
+}
+
+SearchResultTableRow.propTypes = propTypes;
+
+export default injectIntl(SearchResultTableRow);

--- a/src/components/search/table/SearchResultTableRow.jsx
+++ b/src/components/search/table/SearchResultTableRow.jsx
@@ -82,6 +82,7 @@ function SearchResultTableRow({
   return (
     <tr
       aria-label={rowAriaLabel}
+      role="link"
       tabIndex={0}
       className={index % 2 === 0 ? styles.even : styles.odd}
       onClick={() => history.push(location)}

--- a/src/components/search/table/SearchTable.jsx
+++ b/src/components/search/table/SearchTable.jsx
@@ -117,7 +117,8 @@ function SearchResultTable({ searchDescriptor, listType = 'common', intl }) {
     columns,
   };
 
-  // todo: showCheckbox
+  const totalItems = parseInt(list.get('totalItems'), 10);
+  // todo: showCheckbox prop
   return (
     <div className={styles.results}>
       <table>
@@ -137,6 +138,7 @@ function SearchResultTable({ searchDescriptor, listType = 'common', intl }) {
               key={item.get('csid')}
               item={item}
               index={index}
+              totalItems={totalItems}
               renderContext={renderContext}
             />
           ))}

--- a/src/components/search/table/SearchTable.jsx
+++ b/src/components/search/table/SearchTable.jsx
@@ -78,11 +78,15 @@ function renderRow(item, index, renderContext) {
     location = getItemLocationPath(item, { config, searchDescriptor });
   }
 
+  const a11yProps = {};
+  a11yProps['aria-label'] = `Select row ${index}`;
+
   const selected = selectedItems ? selectedItems.has(csid) : false;
   return (
     <tr key={`${item.csid}-${index}`} className={index % 2 === 0 ? styles.even : styles.odd}>
       <td>
         <CheckboxInput
+          {...a11yProps}
           embedded
           name={`${index}`}
           value={selected}
@@ -206,7 +210,7 @@ function SearchResultTable({ searchDescriptor, listType = 'common', intl }) {
         <thead>
           <tr>
             {/* eslint-disable-next-line jsx-a11y/control-has-associated-label */}
-            <th className={styles.checkbox} />
+            <th className={styles.checkbox} aria-label="Select" />
             {columns.map((column) => (sortColumnName === column.dataKey
               ? <SearchResultTableHeader key={column.dataKey} column={column} sort={sortDir} />
               : <SearchResultTableHeader key={column.dataKey} column={column} />

--- a/src/components/search/table/SearchTable.jsx
+++ b/src/components/search/table/SearchTable.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { injectIntl } from 'react-intl';
+import { defineMessages, injectIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
 import get from 'lodash/get';
 import Immutable from 'immutable';
@@ -17,6 +17,14 @@ const propTypes = {
   listType: PropTypes.string,
   intl: PropTypes.object,
 };
+
+const messages = defineMessages({
+  selectHeader: {
+    id: 'searchTable.selectHeaderAll',
+    description: 'Label for select table header',
+    defaultMessage: 'Selected',
+  },
+});
 
 function getSortDir(searchDescriptor) {
   const searchQuery = searchDescriptor.get('searchQuery');
@@ -111,14 +119,17 @@ function SearchResultTable({ searchDescriptor, listType = 'common', intl }) {
   };
 
   const totalItems = parseInt(list.get('totalItems'), 10);
+  const selectLabel = intl.formatMessage(messages.selectHeader);
+
   // todo: showCheckbox prop
   return (
     <div className={styles.results}>
       <table>
         <thead>
           <tr>
+            {/* todo: I think it probably make this visible if it exists */}
             {/* eslint-disable-next-line jsx-a11y/control-has-associated-label */}
-            <th className={styles.checkbox} aria-label="Select" />
+            <th className={styles.checkbox} aria-label={selectLabel} />
             {columns.map((column) => (sortColumnName === column.dataKey
               ? <SearchResultTableHeader key={column.dataKey} column={column} sort={sortDir} />
               : <SearchResultTableHeader key={column.dataKey} column={column} />

--- a/src/components/search/table/SearchTable.jsx
+++ b/src/components/search/table/SearchTable.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { defineMessages, injectIntl } from 'react-intl';
+import { injectIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
 import get from 'lodash/get';
 import Immutable from 'immutable';
@@ -17,13 +17,6 @@ const propTypes = {
   listType: PropTypes.string,
   intl: PropTypes.object,
 };
-
-const messages = defineMessages({
-  searchPending: {
-    id: 'searchResultTable.searchPending',
-    defaultMessage: '⋯',
-  },
-});
 
 function getSortDir(searchDescriptor) {
   const searchQuery = searchDescriptor.get('searchQuery');

--- a/styles/cspace-ui/SearchTable.css
+++ b/styles/cspace-ui/SearchTable.css
@@ -50,6 +50,10 @@
   cursor: pointer;
 }
 
+.results > table > tbody > tr:focus {
+  outline: 1px dotted black;
+}
+
 .results > table > tbody > tr > a {
   width: 100%;
   display: inline-block;

--- a/styles/cspace-ui/SearchTable.css
+++ b/styles/cspace-ui/SearchTable.css
@@ -31,6 +31,10 @@
   text-decoration: underline;
 }
 
+.results > table > thead > tr > th:focus {
+  outline: 1px dotted black;
+}
+
 /* todo: flex col sizing */
 .results > table > tbody > td {
   height: 23px;


### PR DESCRIPTION
**What does this do?**
* Add aria-label to checkbox inputs which have no display area for labels
* Add aria-label and role to table row for interactive semantics
* Add focus styling for table headers and rows
* Add functions for getting search result list/items to simplify null handling

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1804

This adds back some of the functionality (link on a row) and missing WCAG requirements to the search result table.

**How should this be tested? Do these changes have associated tests?**
You know maybe I'll write tests for this one.

**Dependencies for merging? Releasing to production?**
We'll likely want to double check these with a screen reader at some point to make sure navigation of the result pages makes sense. There are also still some more changes we'll need to make, e.g. in the SearchResultSummary the checkbox is missing a label (I think). Also the other views will need updates but we still need some changes to the API and wireframes in order for them be a bit more representative of how they will look.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter has been testing against core.dev