### PR TITLE
DRYD-1804: Traversal of Search Results and Store Search Ops

### DIFF
--- a/src/components/search/SearchResultSummary.jsx
+++ b/src/components/search/SearchResultSummary.jsx
@@ -4,9 +4,12 @@ import Immutable from 'immutable';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { Link } from 'react-router-dom';
 import get from 'lodash/get';
+import { batch, useDispatch } from 'react-redux';
 import PageSizeChooser from './PageSizeChooser';
 import { ERR_API, ERR_NOT_ALLOWED } from '../../constants/errorCodes';
 import styles from '../../../styles/cspace-ui/SearchResultSummary.css';
+import { setSearchPageRecordType, setSearchPageVocabulary } from '../../actions/prefs';
+import { setSearchPageAdvanced, setSearchPageKeyword } from '../../actions/searchPage';
 
 const messages = defineMessages({
   error: {
@@ -38,6 +41,7 @@ const propTypes = {
 
 const defaultProps = {
   renderEditLink: (searchDescriptor, onEditSearchLinkClick) => {
+    const dispatch = useDispatch();
     const recordType = searchDescriptor.get('recordType');
     const vocabulary = searchDescriptor.get('vocabulary');
     const subresource = searchDescriptor.get('subresource');
@@ -54,8 +58,28 @@ const defaultProps = {
     const vocabularyPath = vocabulary ? `/${vocabulary}` : '';
     const path = `/search/${recordType}${vocabularyPath}`;
 
+    function defaultOnClick() {
+      batch(() => {
+        if (setSearchPageRecordType) {
+          dispatch(setSearchPageRecordType(searchDescriptor.get('recordType')));
+        }
+
+        if (setSearchPageVocabulary) {
+          dispatch(setSearchPageVocabulary(searchDescriptor.get('vocabulary')));
+        }
+
+        if (setSearchPageKeyword) {
+          dispatch(setSearchPageKeyword(searchQuery.get('kw')));
+        }
+
+        if (setSearchPageAdvanced) {
+          dispatch(setSearchPageAdvanced(searchQuery.get('as')));
+        }
+      });
+    }
+
     return (
-      <Link to={path} onClick={onEditSearchLinkClick}>
+      <Link to={path} onClick={onEditSearchLinkClick || defaultOnClick}>
         <FormattedMessage {...messages.editSearch} />
       </Link>
     );

--- a/src/components/search/table/SearchResultTableRow.jsx
+++ b/src/components/search/table/SearchResultTableRow.jsx
@@ -79,13 +79,29 @@ function SearchResultTableRow({
   const rowAriaLabel = createRowLabel(columns[0], item, index, totalItems, intl);
   const checkboxAriaLabel = intl.formatMessage(messages.checkboxLabelSelect, { index: index + 1 });
 
+  function handleRowClick() {
+    // from SearchResultTable:
+    // Create a location with the item location path, along with enough state to reproduce this
+    // search. The search descriptor is converted to an object in order to reliably store it in
+    // location state. Also merge in any object that was passed in via the linkState prop.
+    const state = {
+      searchDescriptor: searchDescriptor.toJS(),
+      // The search traverser on records will always link to the search result page, so use
+      // its search name.
+      searchName: SEARCH_RESULT_PAGE_SEARCH_NAME,
+      // ...linkState,
+    };
+
+    history.push(location, state);
+  }
+
   return (
     <tr
       aria-label={rowAriaLabel}
       role="link"
       tabIndex={0}
       className={index % 2 === 0 ? styles.even : styles.odd}
-      onClick={() => history.push(location)}
+      onClick={handleRowClick}
     >
       <td>
         <CheckboxInput


### PR DESCRIPTION
**What does this do?**
* Updates the SearchTable to store the search descriptor for use by the SearchResultTraverser
* Adds a default on click handler for the SearchResultSummary

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1804

This is more work to bring the new search table up to parity with the existing implementation. This allows traversal of the search results when navigating from the table by passing the search descriptor along. It also adds a default on click function in the event one is not passed to the SearchResultSummary, which allows the search page to be populated with the existing query.

**How should this be tested? Do these changes have associated tests?**
* Run the dev server
* Search for objects with some condition set
* Navigate to an object and see the search result traverser
* Navigate back to the search
* Revise your search and see the condition still exists

**Dependencies for merging? Releasing to production?**
Tests are in the process of being written, though are not ready yet. We'll want them up before a production release to have more confidence that there aren't edge cases we need to handle.

Also I omitted the 'linkState' which previously was being used. I need to dig a little to see how/why that was added.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter has been testing with core.dev as a backend.