### PR TITLE
DRYD-2108: Search > SearchResults > Link Functionality in New Search Result Table

### DIFF
--- a/src/components/search/table/SearchResultTableRow.jsx
+++ b/src/components/search/table/SearchResultTableRow.jsx
@@ -89,7 +89,7 @@ function SearchResultTableRow({
         const key = `${csid}-${column.dataKey}`;
 
         // Wrap the value in a link if it's in a linkable column and the location is available.
-        const linkableColumns = ['title', 'objectNumber'];
+        const linkableColumns = ['objectNumber'];
         if (linkableColumns.includes(column.dataKey) && location) {
           return (
             <td key={key}>

--- a/src/components/search/table/SearchResultTableRow.jsx
+++ b/src/components/search/table/SearchResultTableRow.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { defineMessages, injectIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import Immutable from 'immutable';
-import { useHistory } from 'react-router-dom/cjs/react-router-dom.min';
+import { Link } from 'react-router-dom';
 import { useConfig } from '../../config/ConfigProvider';
 import { SEARCH_RESULT_PAGE_SEARCH_NAME } from '../../../constants/searchNames';
 import styles from '../../../../styles/cspace-ui/SearchTable.css';
@@ -29,13 +29,6 @@ const messages = defineMessages({
   },
 });
 
-function renderColumn(column, item) {
-  const data = item.get(column.dataKey);
-  const formatted = data ? column.formatValue(data) : null;
-  const key = `${item.get('csid')}-${column.dataKey}`;
-  return <td key={key}>{formatted}</td>;
-}
-
 function createRowLabel(column, item, index, total, intl) {
   const data = item.get(column.dataKey);
   return data
@@ -48,7 +41,6 @@ function SearchResultTableRow({
   item, index, totalItems, renderContext, intl,
 }) {
   const config = useConfig();
-  const history = useHistory();
 
   const {
     listType,
@@ -62,38 +54,26 @@ function SearchResultTableRow({
   const listTypeConfig = config.listTypes[listType];
   const { getItemLocationPath } = listTypeConfig;
   let location;
+  let state;
   if (getItemLocationPath) {
     location = getItemLocationPath(item, { config, searchDescriptor });
+    state = {
+      searchDescriptor: searchDescriptor.toJS(),
+      // The search traverser on records will always link to the search result page, so use
+      // its search name.
+      searchName: SEARCH_RESULT_PAGE_SEARCH_NAME,
+      listType,
+    };
   }
 
   const selected = selectedItems ? selectedItems.has(csid) : false;
 
   const rowAriaLabel = createRowLabel(columns[0], item, index, totalItems, intl);
 
-  function handleRowClick() {
-    // from SearchResultTable:
-    // Create a location with the item location path, along with enough state to reproduce this
-    // search. The search descriptor is converted to an object in order to reliably store it in
-    // location state. Also merge in any object that was passed in via the linkState prop.
-    const state = {
-      searchDescriptor: searchDescriptor.toJS(),
-      // The search traverser on records will always link to the search result page, so use
-      // its search name.
-      searchName: SEARCH_RESULT_PAGE_SEARCH_NAME,
-      listType,
-      // ...linkState,
-    };
-
-    history.push(location, state);
-  }
-
   return (
     <tr
       aria-label={rowAriaLabel}
-      role="link"
-      tabIndex={0}
       className={index % 2 === 0 ? styles.even : styles.odd}
-      onClick={handleRowClick}
     >
       <td>
         <SearchResultCheckbox
@@ -103,7 +83,25 @@ function SearchResultTableRow({
           selected={selected}
         />
       </td>
-      {columns.map((column) => renderColumn(column, item, location))}
+      {columns.map((column) => {
+        const data = item.get(column.dataKey);
+        const formatted = data ? column.formatValue(data) : null;
+        const key = `${csid}-${column.dataKey}`;
+
+        // Wrap the value in a link if it's in a linkable column and the location is available.
+        const linkableColumns = ['title', 'objectNumber'];
+        if (linkableColumns.includes(column.dataKey) && location) {
+          return (
+            <td key={key}>
+              <Link to={{ pathname: location, state }}>
+                {formatted}
+              </Link>
+            </td>
+          );
+        }
+
+        return <td key={key}>{formatted}</td>;
+      })}
     </tr>
   );
 }


### PR DESCRIPTION
This is pretty rushed, was just curious what it would look like. It uses `main` as the base so that if you want to do a patch release from it, future changes for v11 are not included.

**What does this do?**
Makes table rows in search results into `Link`s so that users can interact with them in expected ways.

**Why are we doing this? (with JIRA link)**
Per Mike: "IMO we should consider the right click -> new tab as a regression for the table view and put in a bug report for it."

**How should this be tested? Do these changes have associated tests?**
By checking in a browser if search results in table view behave as expected.

**Dependencies for merging? Releasing to production?**
No new dependencies.

**Has the application documentation been updated for these changes?**
No.

**Did someone actually run this code to verify it works?**
No.

**Have any new accessibility violations been handled?**
No.
