### PR TITLE
DRYD-2116: Search Result View > All Profiles > Deurn Responsible Department

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## v10.2.1
+
+### Bug Fixes
+
+- Fix urned Responsible Department value shown in the full detail view of search results.
+
 ## v10.2.0
 
 ### Breaking Changes

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -13,7 +13,7 @@ const getTestFiles = (config) => {
 
 module.exports = function karma(config) {
   const localBrowsers = ['Chrome'];
-  const githubBrowsers = ['Chrome'];
+  const githubBrowsers = ['ChromeHeadlessNoSandbox'];
 
   let browsers;
 
@@ -35,6 +35,12 @@ module.exports = function karma(config) {
 
   config.set({
     browsers,
+    customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox', '--disable-setuid-sandbox'],
+      },
+    },
     concurrency: 1,
 
     files: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cspace-ui",
-  "version": "10.2.0",
+  "version": "10.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cspace-ui",
-      "version": "10.2.0",
+      "version": "10.2.1",
       "license": "ECL-2.0",
       "dependencies": {
         "@axe-core/react": "^4.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cspace-ui",
-  "version": "10.2.0",
+  "version": "10.2.1",
   "description": "CollectionSpace user interface for browsers",
   "author": "Ray Lee <ray.lee@lyrasis.org>",
   "license": "ECL-2.0",

--- a/src/plugins/recordTypes/collectionobject/detailList.jsx
+++ b/src/plugins/recordTypes/collectionobject/detailList.jsx
@@ -189,7 +189,7 @@ export default (configContext) => {
         });
 
         const locationData = formatRefNameWithDefault(data.get('computedCurrentLocation'));
-        const responsibleDepartmentData = data.get('responsibleDepartment');
+        const responsibleDepartmentData = formatRefNameWithDefault(data.get('responsibleDepartment'));
 
         const location = locationData ? (
           <div>


### PR DESCRIPTION
**What does this do?**
It adds calling `formatRefNameWithDefault` when populating `responsibleDepartmentData` instead of assigning the value raw.

**Why are we doing this? (with JIRA link)**
There is an issue of displaying the `responsibleDepartmentData` as an urned value when the field is `AutocompleteInput` instead of `OptionPickerInput`: https://collectionspace.atlassian.net/browse/DRYD-2116 

**How should this be tested? Do these changes have associated tests?**
You can change the type of the `responsibleDepartment` field in the `src/plugins/recordTypes/collectionobject/fields.js` to `AutocompleteInput`, and set the source to an authority. Like this:
```
responsibleDepartment: {
            [config]: {
              messages: defineMessages({
                name: {
                  id: 'field.collectionobjects_common.responsibleDepartment.name',
                  defaultMessage: 'Responsible department',
                },
              }),
              repeating: true,
              view: {
                type: AutocompleteInput,
                props: {
                  source: 'person/local,person/shared,person/ulan',
                },
              },
            },
          },
```
Or you can also check it by running the public art profile locally. In that case the `responsibleDepartment` is a `TermPickerInput` one.

Then after creating a collection object with a responsible department set, please do an empty search and switch to the detail list view. The Responsible Department field in the aside section should be shown de-urned. 

**Dependencies for merging? Releasing to production?**
No dependencies. After merging to main, let us publish to npmjs as a patch release. We will also need to merge `main` to `develop` after merging so that they are synced.

**Has the application documentation been updated for these changes?**
Changelog has been updated

**Did someone actually run this code to verify it works?**
@spirosdi ran it locally

**Have any new accessibility violations been handled?**
no new a11y violations
