### PR TITLE
DRYD-2070: Accessibility > Fix Text Contrast on Administration and Tools Pages (Criteria 1.4.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Accessibility
 
+- Resolved text contrast issue in Administration and Tools sections (Criteria 1.4.3).
 - Resolved orphaned form labels issue (Criteria 3.3.2).
 
 ## v10.2.0

--- a/styles/cspace-ui/AdminNavItem.css
+++ b/styles/cspace-ui/AdminNavItem.css
@@ -1,3 +1,5 @@
+@value textDark from '../colors.css';
+
 .common {
   display: inline-block;
   height: 31px;
@@ -6,7 +8,7 @@
   border-top-right-radius: 3px;
   padding: 6px 10px 3px 10px;
   text-decoration: none;
-  color: #73AA4F;
+  color: textDark;
   cursor: default;
 }
 

--- a/styles/cspace-ui/AdminPage.css
+++ b/styles/cspace-ui/AdminPage.css
@@ -1,7 +1,7 @@
 @value textDark from '../colors.css';
 
 .common {
-  background-color: #EEF4D7;
+  background-color: #F0F5FB;
 }
 
 .common > :global(.cspace-ui-TitleBar--common) {

--- a/styles/cspace-ui/AdminPage.css
+++ b/styles/cspace-ui/AdminPage.css
@@ -1,7 +1,9 @@
+@value textDark from '../colors.css';
+
 .common {
   background-color: #EEF4D7;
 }
 
 .common > :global(.cspace-ui-TitleBar--common) {
-  color: #73AA4F;
+  color: textDark;
 }


### PR DESCRIPTION
**What does this do?**
Replace low-contrast green header and tab text with `textDark` on the Administration and Tools pages.

**Why are we doing this? (with JIRA link)**
To meet WCAG 1.4.3 contrast requirements: https://collectionspace.atlassian.net/browse/DRYD-2070

**How should this be tested? Do these changes have associated tests?**
Please check the Administration, Tools pages and confirm that the Headers and the Tabs use the `textDark` color `rgb(70, 70, 70)`

**Dependencies for merging? Releasing to production?**
No dependencies

**Has the application documentation been updated for these changes?**
Changelog has been updated

**Did someone actually run this code to verify it works?**
@spirosdi ran this locally

**Have any new accessibility violations been handled?**
no new a11y violations
