### PR TITLE
DRYD-2073: Object Record > All Profiles > Add Home Location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## v11.0.0
 
+### New Fields
+
+- On the record editor for Objects
+  - The Home Location repeating group of fields `homeLocationGroupList/homeLocationGroup` has been added
+
 ### Accessibility
 
 - Resolved orphaned form labels issue (Criteria 3.3.2).

--- a/docs/configuration/messages.js
+++ b/docs/configuration/messages.js
@@ -580,10 +580,10 @@ export default {
   "deprecateButton.label": "Deactivate",
 
   // The prefix for current location in the search detail view
-  "detailList.aside.collectionobject.currentLocation": "Current Storage Location:",
+  "detailList.aside.collectionobject.currentLocation": "Current Location:",
 
   // The text when the computedCurrentLocation is null or empty
-  "detailList.aside.collectionobject.locationNotFound": "Storage Location not assigned",
+  "detailList.aside.collectionobject.locationNotFound": "Current Location not assigned",
 
   // The prefix for responsible department in the search detail view
   "detailList.aside.collectionobject.responsibleDepartment": "Responsible Department:",

--- a/src/plugins/recordTypes/collectionobject/detailList.jsx
+++ b/src/plugins/recordTypes/collectionobject/detailList.jsx
@@ -174,12 +174,17 @@ export default (configContext) => {
           computedLocation: {
             id: 'detailList.aside.collectionobject.currentLocation',
             description: 'The prefix for current location in the search detail view',
-            defaultMessage: 'Current Storage Location:',
+            defaultMessage: 'Current Location:',
           },
           locationNotFound: {
             id: 'detailList.aside.collectionobject.locationNotFound',
             description: 'The text when the computedCurrentLocation is null or empty',
-            defaultMessage: 'Storage Location not assigned',
+            defaultMessage: 'Current Location not assigned',
+          },
+          homeLocation: {
+            id: 'detailList.aside.collectionobject.homeLocation',
+            description: 'The prefix for home location in the search detail view',
+            defaultMessage: 'Home Location:',
           },
           responsibleDepartment: {
             id: 'detailList.aside.collectionobject.responsibleDepartment',
@@ -202,6 +207,25 @@ export default (configContext) => {
           </div>
         );
 
+        const homeLocations = data.get('homeLocations');
+        let homeLocationValues = homeLocations
+          ? homeLocations.get('homeLocation')
+          : undefined;
+        if (homeLocationValues && !Immutable.List.isList(homeLocationValues)) {
+          homeLocationValues = Immutable.List([homeLocationValues]);
+        }
+
+        const homeLocationItems = (homeLocationValues || Immutable.List())
+          .map((value) => formatRefNameWithDefault(value))
+          .filter((value) => !!value);
+
+        const homeLocation = homeLocationItems.size > 0 ? (
+          <div>
+            <span>{intl.formatMessage(messages.homeLocation)}</span>
+            <p>{homeLocationItems.join('; ')}</p>
+          </div>
+        ) : null;
+
         const responsibleDepartment = responsibleDepartmentData ? (
           <div>
             <span>{intl.formatMessage(messages.responsibleDepartment)}</span>
@@ -212,6 +236,7 @@ export default (configContext) => {
         return (
           <>
             {location}
+            {homeLocation}
             {responsibleDepartment}
           </>
         );

--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -513,24 +513,63 @@ export default (configContext) => {
             },
           },
         },
-        homeStorageLocation: {
+        homeLocationGroupList: {
           [config]: {
-            messages: defineMessages({
-              name: {
-                id: 'field.collectionobjects_common.homeStorageLocation.name',
-                defaultMessage: 'Home storage location',
-              },
-            }),
-            searchView: {
-              type: AutocompleteInput,
-              props: {
-                source: 'location/local,location/offsite,organization/local,organization/shared',
+            view: {
+              type: CompoundInput,
+            },
+          },
+          homeLocationGroup: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.collectionobjects_common.homeLocationGroup.name',
+                  defaultMessage: 'Home location',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: CompoundInput,
+                props: {
+                  tabular: true,
+                },
               },
             },
-            view: {
-              type: AutocompleteInput,
-              props: {
-                source: 'location/local,location/offsite,organization/local,organization/shared',
+            homeLocation: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.collectionobjects_common.homeLocation.fullName',
+                    defaultMessage: 'Home location',
+                  },
+                  name: {
+                    id: 'field.collectionobjects_common.homeLocation.name',
+                    defaultMessage: 'Location',
+                  },
+                }),
+                view: {
+                  type: AutocompleteInput,
+                  props: {
+                    source: 'location/local,location/offsite,organization/local,organization/shared',
+                  },
+                },
+              },
+            },
+            homeLocationNote: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.collectionobjects_common.homeLocationNote.fullName',
+                    defaultMessage: 'Home location note',
+                  },
+                  name: {
+                    id: 'field.collectionobjects_common.homeLocationNote.name',
+                    defaultMessage: 'Note',
+                  },
+                }),
+                view: {
+                  type: TextInput,
+                },
               },
             },
           },

--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -513,6 +513,28 @@ export default (configContext) => {
             },
           },
         },
+        homeStorageLocation: {
+          [config]: {
+            messages: defineMessages({
+              name: {
+                id: 'field.collectionobjects_common.homeStorageLocation.name',
+                defaultMessage: 'Home storage location',
+              },
+            }),
+            searchView: {
+              type: AutocompleteInput,
+              props: {
+                source: 'location/local,location/offsite,organization/local,organization/shared',
+              },
+            },
+            view: {
+              type: AutocompleteInput,
+              props: {
+                source: 'location/local,location/offsite,organization/local,organization/shared',
+              },
+            },
+          },
+        },
         titleGroupList: {
           [config]: {
             view: {

--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -73,6 +73,7 @@ const template = (configContext) => {
             </Field>
 
             <Field name="computedCurrentLocation" />
+            <Field name="homeStorageLocation" />
           </Col>
         </Row>
 

--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -73,7 +73,13 @@ const template = (configContext) => {
             </Field>
 
             <Field name="computedCurrentLocation" />
-            <Field name="homeStorageLocation" />
+
+            <Field name="homeLocationGroupList">
+              <Field name="homeLocationGroup">
+                <Field name="homeLocation" />
+                <Field name="homeLocationNote" />
+              </Field>
+            </Field>
           </Col>
         </Row>
 

--- a/src/plugins/recordTypes/collectionobject/forms/timebased.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/timebased.jsx
@@ -56,6 +56,7 @@ const template = (configContext) => {
             </Field>
 
             <Field name="computedCurrentLocation" />
+            <Field name="homeStorageLocation" />
           </Col>
         </Row>
 

--- a/src/plugins/recordTypes/collectionobject/forms/timebased.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/timebased.jsx
@@ -56,7 +56,13 @@ const template = (configContext) => {
             </Field>
 
             <Field name="computedCurrentLocation" />
-            <Field name="homeStorageLocation" />
+
+            <Field name="homeLocationGroupList">
+              <Field name="homeLocationGroup">
+                <Field name="homeLocation" />
+                <Field name="homeLocationNote" />
+              </Field>
+            </Field>
           </Col>
         </Row>
 

--- a/styles/cspace-ui/SearchList.css
+++ b/styles/cspace-ui/SearchList.css
@@ -64,6 +64,7 @@
   background-color: aliceblue;
   height: 200px;
   margin-bottom: 1em;
+  padding: 5px;
   display: flex;
   flex-direction: column;
   justify-content: space-evenly;

--- a/test/specs/plugins/recordTypes/collectionobject/detailList.spec.jsx
+++ b/test/specs/plugins/recordTypes/collectionobject/detailList.spec.jsx
@@ -410,8 +410,8 @@ describe('collectionobject detail list layout', () => {
       departmentDiv.should.contain(responsibleDepartment);
     });
 
-    it('should display \'Storage Location not found\' when no location data is present', function test() {
-      const noLocationText = 'Storage Location not assigned';
+    it('should display \'Current Location not assigned\' when no location data is present', function test() {
+      const noLocationText = 'Current Location not assigned';
       const formatted = formatter(Immutable.fromJS({
         objectNumber,
       }), { intl });


### PR DESCRIPTION
**What does this do?**
It adds the `homeLocationGroupList` fields to the templates where `computedCurrentLocation` already exists. Also relabels "Current Storage Location" to "Current Location"

**Why are we doing this? (with JIRA link)**
We need to show the new `homeLocationGroupList` fields beneath the already existing `computedCurrentLocation` field: https://collectionspace.atlassian.net/browse/DRYD-2073

**How should this be tested? Do these changes have associated tests?**
Please checkout locally the https://github.com/collectionspace/application/pull/352 and the https://github.com/collectionspace/services/pull/541. Build and redeploy backend. Then start the cspace-ui.js:
1. Create a new Collection Object
2. Assign multiple Home location values and notes
3. Confirm that saved values persist and fields are searchable
4. Confirm that in the "detail list view" of search results, the values are shown as a semi-colon separated list. Notes don't need to be displayed.

**Dependencies for merging? Releasing to production?**
The following PRs should be released along: 
https://github.com/collectionspace/application/pull/352
https://github.com/collectionspace/services/pull/541
https://github.com/collectionspace/cspace-ui-plugin-profile-anthro.js/pull/44
https://github.com/collectionspace/cspace-ui-plugin-profile-fcart.js/pull/33
https://github.com/collectionspace/cspace-ui-plugin-profile-lhmc.js/pull/34
https://github.com/collectionspace/cspace-ui-plugin-profile-materials.js/pull/22
https://github.com/collectionspace/cspace-ui-plugin-profile-publicart.js/pull/35

**Has the application documentation been updated for these changes?**
Changelog has been updated

**Did someone actually run this code to verify it works?**
@spirosdi ran it locally