### PR TITLE
DRYD-2108: Updates to Search Result Table Links

### DIFF
--- a/src/components/search/table/SearchResultTableRow.jsx
+++ b/src/components/search/table/SearchResultTableRow.jsx
@@ -84,13 +84,17 @@ function SearchResultTableRow({
         />
       </td>
       {columns.map((column) => {
-        const data = item.get(column.dataKey);
-        const formatted = data ? column.formatValue(data) : null;
-        const key = `${csid}-${column.dataKey}`;
+        const {
+          dataKey,
+          linkable,
+          formatValue,
+        } = column;
+        const data = item.get(dataKey);
+        const formatted = data ? formatValue(data) : null;
+        const key = `${csid}-${dataKey}`;
 
         // Wrap the value in a link if it's in a linkable column and the location is available.
-        const linkableColumns = ['objectNumber'];
-        if (linkableColumns.includes(column.dataKey) && location) {
+        if (linkable && location) {
           return (
             <td key={key}>
               <Link to={{ pathname: location, state }}>

--- a/src/components/search/table/SearchTable.jsx
+++ b/src/components/search/table/SearchTable.jsx
@@ -107,6 +107,7 @@ function SearchResultTable({ searchDescriptor, intl }) {
           }
           return data;
         },
+        linkable: column.linkable,
         label: () => {
           const message = get(column, ['messages', 'label']);
           return message ? intl.formatMessage(message) : '';

--- a/src/plugins/recordTypes/collectionobject/columns.js
+++ b/src/plugins/recordTypes/collectionobject/columns.js
@@ -17,6 +17,7 @@ export default (configContext) => {
         order: 10,
         sortBy: 'collectionobjects_common:objectNumber',
         width: 200,
+        linkable: true,
       },
       title: {
         messages: defineMessages({

--- a/styles/cspace-ui/SearchTable.css
+++ b/styles/cspace-ui/SearchTable.css
@@ -45,15 +45,6 @@
   padding-right: 0px;
 }
 
-.results > table > tbody > tr:hover {
-  background-color: #ACC9EB;
-  cursor: pointer;
-}
-
-.results > table > tbody > tr:focus {
-  outline: 1px dotted black;
-}
-
 .results > table > tbody > tr > a {
   width: 100%;
   display: inline-block;


### PR DESCRIPTION
**What does this do?**
* Moves `linkableColumns` into the column config
* Remove interactivity cues for Search Tables

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-2108

These are some small changes on top of #350 to remove some of the hard coding of columns to be linked and user cues for what is interactive in the table. As the table is intended to be used for more than just CollectionObjects, this allows it to be expanded to other procedures without updating an array of arbitrary field names.

**How should this be tested? Do these changes have associated tests?**
* Run the devserver
* See that the table view for Objects works the same as before
* Then verify that the config can be updated:
  * In the index.html add
```
      recordTypes: {
        collectionobject: {
          columns: {
            default: {
              title: {
                linkable: true,
              },
            },
          },
        },
```
  * Navigate to the search result table view again and see that the title field now has links as well

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally

**Have any new accessibility violations been handled?**
No new accessibility violations were added
