### PR TITLE
DRYD-2081: Authority > Disable alt terms

### DIFF
--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -144,7 +144,7 @@ The default page size for search results presented in a panel, for example, in a
 
 ### disableAltTerms
 ```
-disableAltTerms: boolean = false
+disableAltTerms: boolean = true
 ```
 If true, alternate terms (aka non-preferred terms) are disabled (but remain visible) in autocompletion inputs when they match the partial term that the user has entered. The user may only select the preferred term. This setting can be overridden on a per-vocabulary basis in the [vocabulary configuration](./VocabularyConfiguration.md#disableAltTerms).
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -43,7 +43,7 @@ const defaultConfig = mergeConfig({
       },
     },
   },
-  disableAltTerms: false,
+  disableAltTerms: true,
   index: '/search',
   locale: 'en-US',
   logo: logoUrl,


### PR DESCRIPTION
**What does this do?**
It changes the default value of the `disableAltTerms` config to `true`.

**Why are we doing this? (with JIRA link)**
In Lyrasis hosted sites configurations, `disableAltTerms` is set to `true`. In order to make the cspace sites (dev, qa, demo) consistent, we change the default value to `true`.

**How should this be tested? Do these changes have associated tests?**
1. Create an authority (f.e Person) with an additional "Term" block and "Display name" value. 
2. Move to the create new object (collection object) view and in an authority autocomplete field (f.e Author) type the "Display name" of the additional/alternate "Term" block's "Display name".
3. The matching term should be displayed but the alternate term should be disabled. Only the Primary term should be selectable:
<img width="473" height="201" alt="image" src="https://github.com/user-attachments/assets/c466b726-405c-4b72-aca6-95a04b8222e1" />

**Dependencies for merging? Releasing to production?**
No dependencies

**Has the application documentation been updated for these changes?**
Readme has been updated

**Did someone actually run this code to verify it works?**
@spirosdi ran it locally

**Have any new accessibility violations been handled?**
no new a11y violations introduced