### PR TITLE
DRYD-2115 Search > Search Results > Removing Sorting Options for CMIS Queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 - Resolved orphaned form labels issue (Criteria 3.3.2).
 - Resolved very low contrast buttons issue (Criteria 1.4.3).
 
+### Bug Fixes
+
+- When viewing related records, sorting on complex fields is now disabled. These searches use CMIS, which can only sort on simple fields, and would otherwise return an error.
+
 ## v10.2.1
 
 ### Bug Fixes

--- a/src/components/pages/SearchResultPage.jsx
+++ b/src/components/pages/SearchResultPage.jsx
@@ -514,6 +514,7 @@ export default class SearchResultPage extends Component {
         onSortDirChange={sortDirChangeHandler}
         sort={query?.sort}
         recordType={searchDescriptor.get('recordType')}
+        searchDescriptor={searchDescriptor}
       />
     );
 

--- a/src/components/pages/search/SearchResults.jsx
+++ b/src/components/pages/search/SearchResults.jsx
@@ -329,6 +329,7 @@ function SearchResults(props) {
       onSortDirChange={handleSortDirChange}
       sort={normalizedQuery?.sort}
       recordType={searchDescriptor.get('recordType')}
+      searchDescriptor={searchDescriptor}
     />
   );
 

--- a/src/components/search/SearchResultTable.jsx
+++ b/src/components/search/SearchResultTable.jsx
@@ -9,6 +9,7 @@ import dimensions from '../../../styles/dimensions.css';
 import styles from '../../../styles/cspace-ui/SearchResultTable.css';
 import emptyResultStyles from '../../../styles/cspace-ui/SearchResultEmpty.css';
 import { getListTypeFromResult } from '../../helpers/searchHelpers';
+import { isSortable } from './searchResultHelpers';
 
 const rowHeight = parseInt(dimensions.inputHeight, 10);
 
@@ -23,19 +24,6 @@ const messages = defineMessages({
     defaultMessage: '{primary} selected row {index} of {total}',
   },
 });
-
-/**
- * Determines if a column is sortable for a given search. A column is sortable if sortBy is truthy,
- * and the search is not constrained by a related record, or if it is, the field to sort by is not
- * complex. This is here to deal with CSPACE-5366 (searches with related record constraints are
- * done using CMIS, which can't see into complex fields). If that bug is ever fixed, then it will
- * suffice just to check sortBy.
- */
-const isSortable = (column, searchDescriptor) => {
-  const { sortBy } = column;
-
-  return (sortBy && (!searchDescriptor.getIn(['searchQuery', 'rel']) || sortBy.indexOf('/0/') === -1));
-};
 
 const rowRenderer = (params, location, ariaLabel) => {
   // This is a fork of react-virtualized's default row renderer:

--- a/src/components/search/SortBy.jsx
+++ b/src/components/search/SortBy.jsx
@@ -9,6 +9,7 @@ import { get } from 'lodash';
 import classNames from 'classnames';
 import styles from '../../../styles/cspace-ui/SortBy.css';
 import { useConfig } from '../config/ConfigProvider';
+import { isSortable } from './searchResultHelpers';
 
 const { DropdownMenuInput, Button } = components;
 
@@ -32,6 +33,7 @@ function SortBy({
   onSortChange,
   onSortDirChange,
   recordType,
+  searchDescriptor,
   sort,
 }) {
   const config = useConfig();
@@ -48,7 +50,9 @@ function SortBy({
   } = sortConfig;
 
   const options = Object.keys(sortConfig)
-    .filter((key) => sortConfig[key].sortBy !== undefined)
+    .filter((key) => (searchDescriptor
+      ? isSortable(sortConfig[key], searchDescriptor)
+      : sortConfig[key].sortBy !== undefined))
     .map((key) => {
       const option = sortConfig[key];
       const label = intl.formatMessage(option.messages.label) ?? key;
@@ -103,6 +107,7 @@ SortBy.propTypes = {
   onSortChange: PropTypes.func,
   onSortDirChange: PropTypes.func,
   recordType: PropTypes.string,
+  searchDescriptor: PropTypes.object,
   sort: PropTypes.string,
 };
 

--- a/src/components/search/searchResultHelpers.js
+++ b/src/components/search/searchResultHelpers.js
@@ -81,7 +81,7 @@ const complexFieldPattern = /\/\d+(\/|$)/;
 /**
  * Determines if a column is sortable for a given search. A column is sortable if sortBy is truthy,
  * and the search is not constrained by a related record, or if it is, the field to sort by is not
- * complex. This is here to deal with CSPACE-5366 (searches with related record constraints are
+ * complex. This is here to deal with DRYD-2136 (searches with related record constraints are
  * done using CMIS, which can't see into complex fields). If that bug is ever fixed, then it will
  * suffice just to check sortBy.
  *

--- a/src/components/search/searchResultHelpers.js
+++ b/src/components/search/searchResultHelpers.js
@@ -71,3 +71,27 @@ export function readListItems(config, listType, searchResult) {
     items,
   };
 }
+
+/**
+ * Matches a sortBy field path that indexes into a repeating field, e.g. a subfield of a repeating
+ * group (".../titleGroupList/0/title") or an element of a repeating scalar (".../owners/0").
+ */
+const complexFieldPattern = /\/\d+(\/|$)/;
+
+/**
+ * Determines if a column is sortable for a given search. A column is sortable if sortBy is truthy,
+ * and the search is not constrained by a related record, or if it is, the field to sort by is not
+ * complex. This is here to deal with CSPACE-5366 (searches with related record constraints are
+ * done using CMIS, which can't see into complex fields). If that bug is ever fixed, then it will
+ * suffice just to check sortBy.
+ *
+ * @param {object} column           A column configuration, expected to have a sortBy property
+ * @param {object} searchDescriptor The search descriptor for the current search
+ * @returns {boolean} true if the column may be sorted for this search
+ */
+export function isSortable(column, searchDescriptor) {
+  const { sortBy } = column;
+
+  return !!(sortBy
+    && (!searchDescriptor.getIn(['searchQuery', 'rel']) || !complexFieldPattern.test(sortBy)));
+}

--- a/src/components/search/table/SearchResultTableHeader.jsx
+++ b/src/components/search/table/SearchResultTableHeader.jsx
@@ -22,7 +22,7 @@ export default function SearchResultTableHeader({ column, sortable, sort }) {
   const history = useHistory();
   const location = useLocation();
 
-  // CSPACE-5366: related-record searches use CMIS, which can't sort on complex fields.
+  // DRYD-2136: related-record searches use CMIS, which can't sort on complex fields.
   if (!sortable) {
     return (
       <th style={{ textAlign: 'left' }}>

--- a/src/components/search/table/SearchResultTableHeader.jsx
+++ b/src/components/search/table/SearchResultTableHeader.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import qs from 'qs';
+import styles from '../../../../styles/cspace-ui/SearchTable.css';
 
 const propTypes = {
   column: PropTypes.shape({
@@ -9,12 +10,26 @@ const propTypes = {
     formatValue: PropTypes.func,
     label: PropTypes.func,
   }),
+  sortable: PropTypes.bool,
   sort: PropTypes.string,
 };
 
-export default function SearchResultTableHeader({ column, sort }) {
+const defaultProps = {
+  sortable: true,
+};
+
+export default function SearchResultTableHeader({ column, sortable, sort }) {
   const history = useHistory();
   const location = useLocation();
+
+  // CSPACE-5366: related-record searches use CMIS, which can't sort on complex fields.
+  if (!sortable) {
+    return (
+      <th style={{ textAlign: 'left' }}>
+        {column.label()}
+      </th>
+    );
+  }
 
   function handleSortChange() {
     let newSort;
@@ -56,7 +71,12 @@ export default function SearchResultTableHeader({ column, sort }) {
   }
 
   return (
-    <th style={{ textAlign: 'left' }} onClick={() => handleSortChange()} tabIndex={0}>
+    <th
+      className={styles.sortable}
+      style={{ textAlign: 'left' }}
+      onClick={() => handleSortChange()}
+      tabIndex={0}
+    >
       {column.label()}
       {arrow}
     </th>
@@ -64,3 +84,4 @@ export default function SearchResultTableHeader({ column, sort }) {
 }
 
 SearchResultTableHeader.propTypes = propTypes;
+SearchResultTableHeader.defaultProps = defaultProps;

--- a/src/components/search/table/SearchTable.jsx
+++ b/src/components/search/table/SearchTable.jsx
@@ -5,7 +5,7 @@ import { useSelector } from 'react-redux';
 import get from 'lodash/get';
 import Immutable from 'immutable';
 import SearchResultTableHeader from './SearchResultTableHeader';
-import { getColumnConfig, readListItems } from '../searchResultHelpers';
+import { getColumnConfig, isSortable, readListItems } from '../searchResultHelpers';
 import { getSearchResult, getSearchSelectedItems } from '../../../reducers';
 import { SEARCH_RESULT_PAGE_SEARCH_NAME } from '../../../constants/searchNames';
 import { useConfig } from '../../config/ConfigProvider';
@@ -95,6 +95,7 @@ function SearchResultTable({ searchDescriptor, intl }) {
       const column = columnConfig[name];
       return {
         dataKey: column.dataKey || name,
+        sortable: isSortable(column, searchDescriptor),
         formatValue: (data) => {
           if (column.formatValue) {
             const formatterContext = {
@@ -133,8 +134,21 @@ function SearchResultTable({ searchDescriptor, intl }) {
             {/* eslint-disable-next-line jsx-a11y/control-has-associated-label */}
             <th className={styles.checkbox} aria-label={selectLabel} />
             {columns.map((column) => (sortColumnName === column.dataKey
-              ? <SearchResultTableHeader key={column.dataKey} column={column} sort={sortDir} />
-              : <SearchResultTableHeader key={column.dataKey} column={column} />
+              ? (
+                <SearchResultTableHeader
+                  key={column.dataKey}
+                  column={column}
+                  sortable={column.sortable}
+                  sort={sortDir}
+                />
+              )
+              : (
+                <SearchResultTableHeader
+                  key={column.dataKey}
+                  column={column}
+                  sortable={column.sortable}
+                />
+              )
             ))}
           </tr>
         </thead>

--- a/styles/cspace-ui/SearchTable.css
+++ b/styles/cspace-ui/SearchTable.css
@@ -25,9 +25,12 @@
 }
 
 .results > table > thead > tr > th {
-  cursor: pointer;
   font-size: 12px;
   font-weight: inherit;
+}
+
+.results > table > thead > tr > th.sortable {
+  cursor: pointer;
   text-decoration: underline;
 }
 


### PR DESCRIPTION
**What does this do?**
The changes include:
* moved `isSortable` from SearchResultTable to the shared searchResultHelpers. 
* added using it in SortBy and SearchResultTableHeader.
* extended the `isSortable` repeating field pattern to also match elements of repeating scalars.

**Why are we doing this? (with JIRA link)**
https://collectionspace.atlassian.net/browse/DRYD-2115

**How should this be tested? Do these changes have associated tests?**
Check that the normal object search still works as previously:
1. Go to /list/collectionobject (empty find keyword search of objects)
2. Verify that every column header with a sortable field (Identification number, Title, Update) is still sortable.
3. Open the Sort by dropdown and verify that all sort options are present (including Title, Object name). 

Check the related object search:
1. Open the related-objects view. By clicking the "open" button in a related Objects tab.
2. Verify that complex fields (title) are not sortable, while the simple ones (identification number) are.
3. Open the Sort by dropdown and verify that complex fields are absent.

Check the related record -> sort by repeating field
1. Open a related Acquisitions panel (old table)
2.  Verify that repeating fields (like Acquisition source) is not sortable

**Dependencies for merging? Releasing to production?**
No dependencies

**Has the application documentation been updated for these changes?**
Changelog has been updated

**Did someone actually run this code to verify it works?**
@spirosdi ran it locally

**Have any new accessibility violations been handled?**
no new a11y violations