### PR TITLE
DRYD-2130: Accessibility > Missing form label (Criteria 3.3.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 ### Accessibility
 
 - Resolved text contrast issue in Administration and Tools sections (Criteria 1.4.3).
-- Resolved orphaned form labels issue (Criteria 3.3.2).
+- Resolved orphaned/missing form labels issue (Criteria 3.3.2).
 - Resolved very low contrast buttons issue (Criteria 1.4.3).
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@axe-core/react": "^4.11.0",
         "classnames": "^2.2.5",
         "cspace-client": "^2.0.0",
-        "cspace-input": "^2.0.4",
+        "cspace-input": "^2.2.0",
         "cspace-layout": "^2.0.4",
         "cspace-refname": "^1.0.4",
         "history": "^5.0.0",
@@ -4098,9 +4098,9 @@
       }
     },
     "node_modules/cspace-input": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/cspace-input/-/cspace-input-2.1.2.tgz",
-      "integrity": "sha512-tsYjv1JDIYG0X4PW5dNNq7CdSFob1/ebE4toX8X4XWXum4+/UrA5Y+txrGgry1YGamwpvYILajTrx0tidhMU4g==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cspace-input/-/cspace-input-2.2.0.tgz",
+      "integrity": "sha512-FcEneEfVRBttjvzWzcSDF0fJMbuYA6taeLDKWH5NuWxkoVD6MyE0WxXK7T44PIjOgRYPXB+cC8vOUN8ooHRL7Q==",
       "license": "ECL-2.0",
       "dependencies": {
         "classnames": "^2.2.6",
@@ -17217,9 +17217,9 @@
       }
     },
     "cspace-input": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/cspace-input/-/cspace-input-2.1.2.tgz",
-      "integrity": "sha512-tsYjv1JDIYG0X4PW5dNNq7CdSFob1/ebE4toX8X4XWXum4+/UrA5Y+txrGgry1YGamwpvYILajTrx0tidhMU4g==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cspace-input/-/cspace-input-2.2.0.tgz",
+      "integrity": "sha512-FcEneEfVRBttjvzWzcSDF0fJMbuYA6taeLDKWH5NuWxkoVD6MyE0WxXK7T44PIjOgRYPXB+cC8vOUN8ooHRL7Q==",
       "requires": {
         "classnames": "^2.2.6",
         "cspace-layout": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@axe-core/react": "^4.11.0",
     "classnames": "^2.2.5",
     "cspace-client": "^2.0.0",
-    "cspace-input": "^2.0.4",
+    "cspace-input": "^2.2.0",
     "cspace-layout": "^2.0.4",
     "cspace-refname": "^1.0.4",
     "history": "^5.0.0",

--- a/src/components/admin/AccountSearchBar.jsx
+++ b/src/components/admin/AccountSearchBar.jsx
@@ -68,6 +68,7 @@ export default class AccountSearchBar extends Component {
     return (
       <div className={styles.common}>
         <LineInput
+          id="accountSearchBarFilter"
           label={intl.formatMessage(messages.filter)}
           onChange={this.handleInputChange}
           value={value}

--- a/src/components/admin/AuthRoleSearchBar.jsx
+++ b/src/components/admin/AuthRoleSearchBar.jsx
@@ -68,6 +68,7 @@ export default class AuthRoleSearchBar extends Component {
     return (
       <div className={styles.common}>
         <LineInput
+          id="authRoleSearchBarFilter"
           label={intl.formatMessage(messages.filter)}
           onChange={this.handleInputChange}
           value={value}

--- a/src/components/admin/VocabularySearchBar.jsx
+++ b/src/components/admin/VocabularySearchBar.jsx
@@ -68,6 +68,7 @@ export default class VocabularySearchBar extends Component {
     return (
       <div className={styles.common}>
         <LineInput
+          id="vocabularySearchBarFilter"
           label={intl.formatMessage(messages.filter)}
           onChange={this.handleInputChange}
           value={value}

--- a/src/components/invocable/InvocableSearchBar.jsx
+++ b/src/components/invocable/InvocableSearchBar.jsx
@@ -68,6 +68,7 @@ export default class InvocableSearchBar extends Component {
     return (
       <div className={styles.common}>
         <LineInput
+          id="invocableSearchBarFilter"
           label={intl.formatMessage(messages.filter)}
           onChange={this.handleInputChange}
           value={value}

--- a/src/components/invocable/InvocationModal.jsx
+++ b/src/components/invocable/InvocationModal.jsx
@@ -244,6 +244,7 @@ export default class InvocationModal extends Component {
         <div className={formatPickerStyles.common}>
           <OptionPickerInput
             blankable={false}
+            id="invocationFormatPicker"
             label={<Label><FormattedMessage {...messages.format} /></Label>}
             source="reportMimeTypes"
             prefilter={mimeList ? prefilter : null}

--- a/src/components/invocable/ModePickerInput.jsx
+++ b/src/components/invocable/ModePickerInput.jsx
@@ -56,6 +56,7 @@ export default function ModePickerInput(props) {
   return (
     <OptionPickerInput
       blankable={false}
+      id="modePickerInput"
       label={<Label><FormattedMessage {...messages.label} /></Label>}
       options={options}
       readOnly={modes.length < 2}

--- a/src/components/media/MediaViewer.jsx
+++ b/src/components/media/MediaViewer.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import Immutable from 'immutable';
 import get from 'lodash/get';
 import ImageGallery from 'react-image-gallery';
+import { defineMessages, intlShape } from 'react-intl';
 import { baseComponents as inputComponents } from 'cspace-input';
 import ImageContainer from '../../containers/media/ImageContainer';
 import { getContentPath } from '../../helpers/contentHelpers';
@@ -20,6 +21,19 @@ import styles from '../../../styles/cspace-ui/MediaViewer.css';
 import '!style-loader!css-loader!react-image-gallery/styles/css/image-gallery.css';
 
 const { MiniButton } = inputComponents;
+
+const messages = defineMessages({
+  previous: {
+    id: 'mediaViewer.previous',
+    description: 'Label of the button to show the previous image in the media viewer.',
+    defaultMessage: 'Previous image',
+  },
+  next: {
+    id: 'mediaViewer.next',
+    description: 'Label of the button to show the next image in the media viewer.',
+    defaultMessage: 'Next image',
+  },
+});
 
 const renderItem = (item) => (
   <div className="image-gallery-image">
@@ -69,12 +83,10 @@ const sortByPriority = (items, priorityOrder) => {
   return items.sortBy((item) => indexByRefName.get(item.get('refName'), Infinity));
 };
 
-const renderLeftNav = (onClick, disabled) => (
-  <MiniButton name="mediaViewerPrev" disabled={disabled} onClick={onClick}>&lt;</MiniButton>
-);
-
-const renderRightNav = (onClick, disabled) => (
-  <MiniButton name="mediaViewerNext" disabled={disabled} onClick={onClick}>&gt;</MiniButton>
+const makeRenderNav = (name, symbol, label) => (onClick, disabled) => (
+  <MiniButton name={name} disabled={disabled} onClick={onClick} aria-label={label}>
+    {symbol}
+  </MiniButton>
 );
 
 const propTypes = {
@@ -171,6 +183,16 @@ export default class MediaViewer extends Component {
       searchResult,
     } = this.props;
 
+    const { intl } = this.context;
+
+    const renderLeftNav = makeRenderNav(
+      'mediaViewerPrev', '<', intl.formatMessage(messages.previous),
+    );
+
+    const renderRightNav = makeRenderNav(
+      'mediaViewerNext', '>', intl.formatMessage(messages.next),
+    );
+
     const images = [];
 
     if (ownFields) {
@@ -242,3 +264,6 @@ export default class MediaViewer extends Component {
 
 MediaViewer.propTypes = propTypes;
 MediaViewer.defaultProps = defaultProps;
+MediaViewer.contextTypes = {
+  intl: intlShape,
+};

--- a/src/components/pages/SearchResultPage.jsx
+++ b/src/components/pages/SearchResultPage.jsx
@@ -2,6 +2,7 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { defineMessages, intlShape } from 'react-intl';
 import get from 'lodash/get';
 import Immutable from 'immutable';
 import qs from 'qs';
@@ -38,6 +39,14 @@ import SortBy from '../search/SortBy';
 // const stopPropagation = (event) => {
 //   event.stopPropagation();
 // };
+
+const messages = defineMessages({
+  selectItem: {
+    id: 'searchResultPage.selectItem',
+    description: 'The accessible label of the checkbox to select a search result.',
+    defaultMessage: 'Select item {index}',
+  },
+});
 
 const propTypes = {
   isSidebarOpen: PropTypes.bool,
@@ -76,6 +85,7 @@ const contextTypes = {
   config: PropTypes.shape({
     recordTypes: PropTypes.object,
   }).isRequired,
+  intl: intlShape,
 };
 
 export default class SearchResultPage extends Component {
@@ -433,8 +443,11 @@ export default class SearchResultPage extends Component {
     const itemCsid = rowData.get('csid');
     const selected = selectedItems ? selectedItems.has(itemCsid) : false;
 
+    const { intl } = this.context;
+
     return (
       <CheckboxInput
+        aria-label={intl.formatMessage(messages.selectItem, { index: rowIndex + 1 })}
         embedded
         name={`${rowIndex}`}
         value={selected}

--- a/src/components/record/ErrorBadge.jsx
+++ b/src/components/record/ErrorBadge.jsx
@@ -9,7 +9,7 @@ export default function ErrorBadge(props) {
       className={styles.common}
       type="button"
     >
-      <img alt="!" src={errorIcon} />
+      <img alt="" src={errorIcon} />
     </button>
   );
 }

--- a/src/components/record/Field.jsx
+++ b/src/components/record/Field.jsx
@@ -174,7 +174,9 @@ export default function Field(props, context) {
       return;
     }
 
-    if (propName in basePropTypes) {
+    // Always forward aria-* props, since base components pass them through to rendered
+    // inputs without declaring them in propTypes.
+    if (propName.startsWith('aria-') || propName in basePropTypes) {
       // eslint-disable-next-line react/destructuring-assignment
       providedProps[propName] = props[propName];
     }
@@ -245,6 +247,17 @@ export default function Field(props, context) {
         id: `${childInputId}-label`,
         readOnly: effectiveReadOnly,
       }));
+    };
+  }
+
+  if ('renderAriaLabel' in basePropTypes) {
+    computedProps.renderAriaLabel = (childInput) => {
+      const childName = childInput.props.name;
+      const childField = field[childName];
+      const childMessages = get(childField, [configKey, 'messages']);
+      const message = childMessages && (childMessages.fullName || childMessages.name);
+
+      return (message && intl.formatMessage(message));
     };
   }
 

--- a/src/components/record/RecordBrowserNavBar.jsx
+++ b/src/components/record/RecordBrowserNavBar.jsx
@@ -31,6 +31,11 @@ const messages = defineMessages({
     id: 'recordBrowserNavBar.moreRelated',
     defaultMessage: '+ Related',
   },
+  relatedSelectorLabel: {
+    id: 'recordBrowserNavBar.relatedSelectorLabel',
+    description: 'The accessible label of the selector used to add a related record type tab.',
+    defaultMessage: 'Add a related record type',
+  },
   close: {
     id: 'recordBrowserNavBar.close',
     defaultMessage: 'close',
@@ -249,6 +254,7 @@ class RecordBrowserNavBar extends Component {
         relatedRecordTypeSelector = (
           <li className={itemStyles.selector}>
             <RecordTypeInput
+              aria-label={intl.formatMessage(messages.relatedSelectorLabel)}
               filtering={false}
               indentItems={false}
               placeholder={placeholder}

--- a/src/components/record/RecordFormSelector.jsx
+++ b/src/components/record/RecordFormSelector.jsx
@@ -1,11 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import get from 'lodash/get';
-import { injectIntl, intlShape } from 'react-intl';
+import { defineMessages, injectIntl, intlShape } from 'react-intl';
 import { baseComponents as components } from 'cspace-input';
 import styles from '../../../styles/cspace-ui/RecordFormSelector.css';
 
 const { DropdownMenuInput } = components;
+
+const messages = defineMessages({
+  label: {
+    id: 'recordFormSelector.label',
+    description: 'The accessible label of the form template selector.',
+    defaultMessage: 'Form template',
+  },
+});
 
 const formOptions = (forms, intl) => Object.keys(forms)
   .filter((formName) => !forms[formName].disabled)
@@ -77,6 +85,7 @@ function RecordFormSelector(props) {
   return (
     <div className={styles.common}>
       <DropdownMenuInput
+        aria-label={intl.formatMessage(messages.label)}
         options={options}
         value={formName}
         onCommit={onCommit}

--- a/src/components/record/RelatedRecordPanel.jsx
+++ b/src/components/record/RelatedRecordPanel.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Immutable from 'immutable';
-import { defineMessages, FormattedMessage } from 'react-intl';
+import { defineMessages, intlShape, FormattedMessage } from 'react-intl';
 import get from 'lodash/get';
 import CheckboxInput from 'cspace-input/lib/components/CheckboxInput';
 import { getRecordTypeNameByUri } from '../../helpers/configHelpers';
@@ -19,6 +19,11 @@ const messages = defineMessages({
   title: {
     id: 'relatedRecordPanel.title',
     defaultMessage: 'Related {collectionName}',
+  },
+  selectItem: {
+    id: 'relatedRecordPanel.selectItem',
+    description: 'The accessible label of the checkbox to select a related record.',
+    defaultMessage: 'Select item {index}',
   },
 });
 
@@ -268,8 +273,11 @@ export default class RelatedRecordPanel extends Component {
       const itemCsid = rowData.get('csid');
       const selected = selectedItems ? selectedItems.has(itemCsid) : false;
 
+      const { intl } = this.context;
+
       return (
         <CheckboxInput
+          aria-label={intl.formatMessage(messages.selectItem, { index: rowIndex + 1 })}
           embedded
           name={`${rowIndex}`}
           value={selected}
@@ -457,3 +465,6 @@ export default class RelatedRecordPanel extends Component {
 
 RelatedRecordPanel.propTypes = propTypes;
 RelatedRecordPanel.defaultProps = defaultProps;
+RelatedRecordPanel.contextTypes = {
+  intl: intlShape,
+};

--- a/src/components/record/SaveButton.jsx
+++ b/src/components/record/SaveButton.jsx
@@ -28,6 +28,11 @@ const messages = defineMessages({
     description: 'Text of the tooltip shown when the save button is disabled due to field validation errors.',
     defaultMessage: 'Field validation errors must be corrected before this record can be saved.',
   },
+  errorBadge: {
+    id: 'saveButton.errorBadge',
+    description: 'Accessible label of the badge that reveals field validation errors.',
+    defaultMessage: 'Show validation errors',
+  },
 });
 
 const propTypes = {
@@ -81,7 +86,12 @@ function SaveButton(props) {
   const isValidationBlocked = hasBlockingError(validationErrors);
 
   const errorBadge = isValidationBlocked
-    ? <ErrorBadge onClick={onErrorBadgeClick} />
+    ? (
+      <ErrorBadge
+        aria-label={intl.formatMessage(messages.errorBadge)}
+        onClick={onErrorBadgeClick}
+      />
+    )
     : null;
 
   const title = isValidationBlocked

--- a/src/components/search/PageSizeChooser.jsx
+++ b/src/components/search/PageSizeChooser.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { defineMessages, FormattedMessage } from 'react-intl';
+import { defineMessages, intlShape, FormattedMessage } from 'react-intl';
 import ComboBoxInputContainer from '../../containers/input/ComboBoxInputContainer';
 import styles from '../../../styles/cspace-ui/PageSizeChooser.css';
 
@@ -9,6 +9,11 @@ const messages = defineMessages({
     id: 'pageSizeChooser.pageSize',
     description: 'The current page size displayed above search results.',
     defaultMessage: '{pageSize} per page',
+  },
+  pageSizeLabel: {
+    id: 'pageSizeChooser.pageSizeLabel',
+    description: 'The accessible label of the page size chooser input.',
+    defaultMessage: 'Results per page',
   },
 });
 
@@ -69,8 +74,11 @@ export default class PageSizeChooser extends Component {
 
     const value = Number.isNaN(pageSize) ? '' : pageSize.toString();
 
+    const { intl } = this.context;
+
     const chooser = (
       <ComboBoxInputContainer
+        aria-label={intl.formatMessage(messages.pageSizeLabel)}
         embedded={embedded}
         source={pageSizeOptionListName}
         value={value}
@@ -93,3 +101,6 @@ export default class PageSizeChooser extends Component {
 
 PageSizeChooser.propTypes = propTypes;
 PageSizeChooser.defaultProps = defaultProps;
+PageSizeChooser.contextTypes = {
+  intl: intlShape,
+};

--- a/src/components/search/Pager.jsx
+++ b/src/components/search/Pager.jsx
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { defineMessages, FormattedMessage, FormattedNumber } from 'react-intl';
+import {
+  defineMessages, intlShape, FormattedMessage, FormattedNumber,
+} from 'react-intl';
 import { baseComponents as inputComponents } from 'cspace-input';
 import PageSizeChooser from './PageSizeChooser';
 import styles from '../../../styles/cspace-ui/Pager.css';
@@ -12,9 +14,19 @@ const messages = defineMessages({
     id: 'pager.previous',
     defaultMessage: '<',
   },
+  previousAriaLabel: {
+    id: 'pager.previousAriaLabel',
+    description: 'Accessible label of the button to go to the previous page of search results.',
+    defaultMessage: 'Previous page',
+  },
   nextLabel: {
     id: 'pager.next',
     defaultMessage: '>',
+  },
+  nextAriaLabel: {
+    id: 'pager.nextAriaLabel',
+    description: 'Accessible label of the button to go to the next page of search results.',
+    defaultMessage: 'Next page',
   },
   gap: {
     id: 'pager.gap',
@@ -196,6 +208,8 @@ export default class Pager extends Component {
       onPageSizeChange,
     } = this.props;
 
+    const { intl } = this.context;
+
     return (
       <div className={styles.common}>
         <PageSizeChooser
@@ -206,6 +220,7 @@ export default class Pager extends Component {
         />
         <nav>
           <MiniButton
+            aria-label={intl.formatMessage(messages.previousAriaLabel)}
             disabled={currentPage === 0}
             onClick={this.handlePrevButtonClick}
           >
@@ -213,6 +228,7 @@ export default class Pager extends Component {
           </MiniButton>
           {this.renderPages()}
           <MiniButton
+            aria-label={intl.formatMessage(messages.nextAriaLabel)}
             disabled={currentPage === lastPage}
             onClick={this.handleNextButtonClick}
           >
@@ -226,3 +242,6 @@ export default class Pager extends Component {
 
 Pager.propTypes = propTypes;
 Pager.defaultProps = defaultProps;
+Pager.contextTypes = {
+  intl: intlShape,
+};

--- a/src/components/search/QuickSearchForm.jsx
+++ b/src/components/search/QuickSearchForm.jsx
@@ -18,6 +18,21 @@ const messages = defineMessages({
     description: 'The label of the search button in the quick search input.',
     defaultMessage: 'Search',
   },
+  keywordInputLabel: {
+    id: 'quickSearchForm.keywordInputLabel',
+    description: 'The accessible label of the keyword field in the quick search input.',
+    defaultMessage: 'Search keywords',
+  },
+  recordTypeInputLabel: {
+    id: 'quickSearchForm.recordTypeInputLabel',
+    description: 'The accessible label of the record type dropdown in the quick search input.',
+    defaultMessage: 'Record type to search',
+  },
+  vocabularyInputLabel: {
+    id: 'quickSearchForm.vocabularyInputLabel',
+    description: 'The accessible label of the vocabulary dropdown in the quick search input.',
+    defaultMessage: 'Vocabulary to search',
+  },
 });
 
 const propTypes = {
@@ -52,9 +67,12 @@ export default function QuickSearchForm(props) {
         {...remainingProps}
         formatRecordTypeLabel={formatRecordTypeLabel}
         formatVocabularyLabel={formatVocabularyLabel}
+        keywordInputLabel={intl.formatMessage(messages.keywordInputLabel)}
         placeholder={intl.formatMessage(messages.placeholder)}
+        recordTypeInputLabel={intl.formatMessage(messages.recordTypeInputLabel)}
         recordTypes={getSearchableRecordTypes(getAuthorityVocabCsid, config, perms)}
         searchButtonLabel={intl.formatMessage(messages.search)}
+        vocabularyInputLabel={intl.formatMessage(messages.vocabularyInputLabel)}
       />
     </fieldset>
   );

--- a/src/components/search/RangeSearchField.jsx
+++ b/src/components/search/RangeSearchField.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { defineMessages, FormattedMessage } from 'react-intl';
+import { defineMessages, intlShape, FormattedMessage } from 'react-intl';
 import Immutable from 'immutable';
 import SearchField from './SearchField';
 import styles from '../../../styles/cspace-ui/RangeSearchField.css';
@@ -10,9 +10,20 @@ const messages = defineMessages({
     id: 'RangeSearchField.fields',
     defaultMessage: '{startField} and {endField}',
   },
+  start: {
+    id: 'RangeSearchField.start',
+    description: 'The accessible label of the start field of a range.',
+    defaultMessage: '{fieldLabel} start',
+  },
+  end: {
+    id: 'RangeSearchField.end',
+    description: 'The accessible label of the end field of a range.',
+    defaultMessage: '{fieldLabel} end',
+  },
 });
 
 const propTypes = {
+  'aria-label': PropTypes.string,
   parentPath: PropTypes.arrayOf(PropTypes.string),
   name: PropTypes.string,
   value: PropTypes.oneOfType([
@@ -68,6 +79,7 @@ export default class RangeSearchField extends Component {
 
   render() {
     const {
+      'aria-label': ariaLabel,
       inline,
       parentPath,
       name,
@@ -75,10 +87,13 @@ export default class RangeSearchField extends Component {
       readOnly,
     } = this.props;
 
+    const { intl } = this.context;
+
     const normalizedValue = Immutable.List.isList(value) ? value : Immutable.List.of(value);
 
     const startField = (
       <SearchField
+        aria-label={ariaLabel && intl.formatMessage(messages.start, { fieldLabel: ariaLabel })}
         parentPath={parentPath}
         name={name}
         value={normalizedValue.get(0)}
@@ -90,6 +105,7 @@ export default class RangeSearchField extends Component {
 
     const endField = (
       <SearchField
+        aria-label={ariaLabel && intl.formatMessage(messages.end, { fieldLabel: ariaLabel })}
         parentPath={parentPath}
         name={name}
         value={normalizedValue.get(1)}
@@ -115,3 +131,6 @@ export default class RangeSearchField extends Component {
 
 RangeSearchField.propTypes = propTypes;
 RangeSearchField.defaultProps = defaultProps;
+RangeSearchField.contextTypes = {
+  intl: intlShape,
+};

--- a/src/components/search/RemoveConditionButton.jsx
+++ b/src/components/search/RemoveConditionButton.jsx
@@ -1,12 +1,28 @@
 import React from 'react';
+import { defineMessages, intlShape } from 'react-intl';
 import { components as inputComponents } from 'cspace-input';
 import styles from '../../../styles/cspace-ui/RemoveConditionButton.css';
 
 const { MiniButton } = inputComponents;
 
-export default function RemoveConditionButton(props) {
+const messages = defineMessages({
+  remove: {
+    id: 'removeConditionButton.remove',
+    description: 'Label of the button to remove a search condition.',
+    defaultMessage: 'Remove search condition',
+  },
+});
+
+const contextTypes = {
+  intl: intlShape,
+};
+
+export default function RemoveConditionButton(props, context) {
+  const { intl } = context;
+
   return (
     <MiniButton
+      aria-label={intl.formatMessage(messages.remove)}
       className={styles.common}
       {...props}
     >
@@ -14,3 +30,5 @@ export default function RemoveConditionButton(props) {
     </MiniButton>
   );
 }
+
+RemoveConditionButton.contextTypes = contextTypes;

--- a/src/components/search/SearchField.jsx
+++ b/src/components/search/SearchField.jsx
@@ -15,6 +15,7 @@ const messages = defineMessages({
 });
 
 const propTypes = {
+  'aria-label': PropTypes.string,
   parentPath: PropTypes.arrayOf(PropTypes.string),
   name: PropTypes.string,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Immutable.List)]),
@@ -141,6 +142,7 @@ export default class SearchField extends Component {
 
   render() {
     const {
+      'aria-label': ariaLabel,
       parentPath,
       name,
       value,
@@ -161,6 +163,7 @@ export default class SearchField extends Component {
 
     return forceTextInput ? (
       <TextInput
+        aria-label={ariaLabel}
         parentPath={parentPath}
         name={name}
         asText={readOnly}
@@ -172,6 +175,7 @@ export default class SearchField extends Component {
       />
     ) : (
       <Field
+        aria-label={ariaLabel}
         label={undefined}
         parentPath={parentPath}
         name={name}

--- a/src/components/search/SearchForm.jsx
+++ b/src/components/search/SearchForm.jsx
@@ -226,8 +226,9 @@ export default class SearchForm extends Component {
 
     return (
       <div className={vocabStyles.common}>
-        <Label>{intl.formatMessage(messages.vocabulary)}</Label>
+        <Label htmlFor="searchFormVocab">{intl.formatMessage(messages.vocabulary)}</Label>
         <VocabularyInput
+          id="searchFormVocab"
           recordTypes={recordTypes}
           recordType={recordTypeValue}
           value={vocabularyValue}

--- a/src/components/search/SearchFormContent.jsx
+++ b/src/components/search/SearchFormContent.jsx
@@ -36,6 +36,7 @@ const SearchFormContent = ({
     <Panel>
       <div className={recordTypeStyles.common}>
         <RecordTypeInput
+          id="searchFormRecordType"
           label={intl.formatMessage(messages.recordType)}
           recordTypes={recordTypes}
           rootType={recordTypeInputRootType}
@@ -54,6 +55,7 @@ const SearchFormContent = ({
         recordType={recordTypeValue}
       >
         <LineInput
+          id="searchFormKeyword"
           label={intl.formatMessage(messages.keyword)}
           value={keywordValue}
           onCommit={handleKeywordInputCommit}

--- a/src/components/search/SearchFormContentNew.jsx
+++ b/src/components/search/SearchFormContentNew.jsx
@@ -68,6 +68,7 @@ const SearchFormContentNew = ({
       <Panel>
         <div className={recordTypeStyles.common}>
           <RecordTypeInput
+            id="searchFormRecordType"
             label={intl.formatMessage(messages.recordType)}
             recordTypes={recordTypes}
             rootType={recordTypeInputRootType}
@@ -84,6 +85,7 @@ const SearchFormContentNew = ({
           header={<h3>{intl.formatMessage(messages.enterSearchTerms)}</h3>}
         >
           <LineInput
+            id="searchFormKeyword"
             label={intl.formatMessage(messages.keyword)}
             value={keywordValue}
             onCommit={handleKeywordInputCommit}

--- a/src/components/search/SearchToSelectModal.jsx
+++ b/src/components/search/SearchToSelectModal.jsx
@@ -34,6 +34,11 @@ const messages = defineMessages({
     id: 'searchToSelectModal.label',
     defaultMessage: 'Select records',
   },
+  selectItem: {
+    id: 'searchToSelectModal.selectItem',
+    description: 'The accessible label of the checkbox to select a search result.',
+    defaultMessage: 'Select item {index}',
+  },
 });
 
 // FIXME: Make default page size configurable
@@ -479,8 +484,11 @@ export class BaseSearchToSelectModal extends Component {
       const itemCsid = rowData.get('csid');
       const selected = selectedItems ? selectedItems.has(itemCsid) : false;
 
+      const { intl } = this.props;
+
       return (
         <CheckboxInput
+          aria-label={intl.formatMessage(messages.selectItem, { index: rowIndex + 1 })}
           embedded
           name={`${rowIndex}`}
           value={selected}

--- a/src/components/search/SelectBar.jsx
+++ b/src/components/search/SelectBar.jsx
@@ -1,12 +1,17 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { defineMessages, FormattedMessage } from 'react-intl';
+import { defineMessages, intlShape, FormattedMessage } from 'react-intl';
 import Immutable from 'immutable';
 import CheckboxInput from 'cspace-input/lib/components/CheckboxInput';
 import styles from '../../../styles/cspace-ui/SelectBar.css';
 import buttonBarStyles from '../../../styles/cspace-ui/ButtonBar.css';
 
 const messages = defineMessages({
+  selectAll: {
+    id: 'selectBar.selectAll',
+    description: 'The accessible label of the checkbox to select all items on the page.',
+    defaultMessage: 'Select all items on this page',
+  },
   selected: {
     id: 'selectBar.selected',
     description: 'Label showing the number of selected items.',
@@ -124,11 +129,14 @@ export default class SelectBar extends Component {
       );
     }
 
+    const { intl } = this.context;
+
     const selectedItemCount = selectedItems ? selectedItems.size : 0;
 
     return (
       <div className={styles.common}>
         <CheckboxInput
+          aria-label={intl.formatMessage(messages.selectAll)}
           embedded
           readOnly={items.size === 0}
           transition={{
@@ -148,3 +156,6 @@ export default class SelectBar extends Component {
 }
 
 SelectBar.propTypes = propTypes;
+SelectBar.contextTypes = {
+  intl: intlShape,
+};

--- a/src/components/search/input/BooleanConditionInput.jsx
+++ b/src/components/search/input/BooleanConditionInput.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { defineMessages, FormattedMessage } from 'react-intl';
+import { defineMessages, intlShape, FormattedMessage } from 'react-intl';
 import Immutable from 'immutable';
 import { baseComponents as inputComponents } from 'cspace-input';
 import OptionPickerInput from '../../record/OptionPickerInput';
@@ -72,6 +72,11 @@ const messages = {
         and {must}
         or {may}
       } be satisfied:`,
+    },
+    ariaLabel: {
+      id: 'booleanConditionInput.opSelector.ariaLabel',
+      description: 'The accessible label of the any/all selector for a boolean search condition.',
+      defaultMessage: 'Match any or all conditions',
     },
   }),
   addBoolean: defineMessages({
@@ -268,10 +273,13 @@ export default class BooleanConditionInput extends Component {
       return null;
     }
 
+    const { intl } = this.context;
+
     const operator = condition.get('op');
 
     const opSelectorInput = (
       <OptionPickerInput
+        aria-label={intl.formatMessage(messages.opSelector.ariaLabel)}
         blankable={false}
         name="booleanSearchOp"
         options={[
@@ -439,3 +447,6 @@ export default class BooleanConditionInput extends Component {
 
 BooleanConditionInput.propTypes = propTypes;
 BooleanConditionInput.defaultProps = defaultProps;
+BooleanConditionInput.contextTypes = {
+  intl: intlShape,
+};

--- a/src/components/search/input/FieldConditionInput.jsx
+++ b/src/components/search/input/FieldConditionInput.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { defineMessages, FormattedMessage } from 'react-intl';
+import { defineMessages, intlShape, FormattedMessage } from 'react-intl';
 import Immutable from 'immutable';
 import get from 'lodash/get';
 import FieldInput from './FieldInput';
@@ -59,6 +59,11 @@ const messages = defineMessages({
     description: 'Message displayed in advanced search when a field is not found',
     defaultMessage: 'field not found',
   },
+  searchValue: {
+    id: 'fieldConditionInput.searchValue',
+    description: 'The accessible label of the value input in an advanced search condition.',
+    defaultMessage: 'Search value',
+  },
 });
 
 const isFieldControlled = (fieldDescriptor) => {
@@ -74,6 +79,10 @@ const isFieldControlled = (fieldDescriptor) => {
 const isOperatorMatchOrContain = (operator) => (
   [OP_MATCH, OP_NOT_MATCH, OP_CONTAIN, OP_NOT_CONTAIN].includes(operator)
 );
+
+const contextTypes = {
+  intl: intlShape,
+};
 
 export default class FieldConditionInput extends Component {
   constructor() {
@@ -367,8 +376,11 @@ export default class FieldConditionInput extends Component {
           ? RangeSearchField
           : SearchField;
 
+        const { intl } = this.context;
+
         valueSearchField = (
           <ValueSearchFieldComponent
+            aria-label={intl.formatMessage(messages.searchValue)}
             inline={inline}
             parentPath={parentPath}
             name={name}
@@ -425,3 +437,4 @@ export default class FieldConditionInput extends Component {
 }
 
 FieldConditionInput.propTypes = propTypes;
+FieldConditionInput.contextTypes = contextTypes;

--- a/src/components/search/input/FieldInput.jsx
+++ b/src/components/search/input/FieldInput.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { injectIntl, intlShape } from 'react-intl';
+import { defineMessages, injectIntl, intlShape } from 'react-intl';
 import get from 'lodash/get';
 import { DATA_TYPE_STRUCTURED_DATE } from '../../../constants/dataTypes';
 import { formatExtensionFieldName } from '../../../helpers/formatHelpers';
@@ -13,6 +13,14 @@ import {
   configKey,
   getRecordFieldOptionListName,
 } from '../../../helpers/configHelpers';
+
+const inputMessages = defineMessages({
+  ariaLabel: {
+    id: 'fieldInput.ariaLabel',
+    description: 'The accessible label of the field selector in a search condition.',
+    defaultMessage: 'Field to search',
+  },
+});
 
 const propTypes = {
   config: PropTypes.shape({
@@ -111,6 +119,7 @@ export function BaseFieldInput(props) {
 
   return (
     <OptionPickerInput
+      aria-label={intl.formatMessage(inputMessages.ariaLabel)}
       blankable={false}
       embedded={embedded}
       name={name}

--- a/src/components/search/input/GroupConditionInput.jsx
+++ b/src/components/search/input/GroupConditionInput.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { defineMessages, FormattedMessage } from 'react-intl';
+import { defineMessages, intlShape, FormattedMessage } from 'react-intl';
 import Immutable from 'immutable';
 import get from 'lodash/get';
 import RemoveConditionButton from '../RemoveConditionButton';
@@ -34,6 +34,11 @@ const propTypes = {
 
 const messages = {
   groupInput: defineMessages({
+    ariaLabel: {
+      id: 'GroupConditionInput.groupInput.ariaLabel',
+      description: 'The accessible label of the selector for the group to search within.',
+      defaultMessage: 'Group to search within',
+    },
     pendingLabel: {
       id: 'GroupConditionInput.groupInput.pendingLabel',
       defaultMessage: 'In a single {groupInput} ...',
@@ -197,8 +202,11 @@ export default class GroupConditionInput extends Component {
         return null;
       }
 
+      const { intl } = this.context;
+
       return (
         <GroupInput
+          aria-label={intl.formatMessage(messages.groupInput.ariaLabel)}
           config={config}
           inline={inline}
           name="group"
@@ -320,3 +328,6 @@ export default class GroupConditionInput extends Component {
 }
 
 GroupConditionInput.propTypes = propTypes;
+GroupConditionInput.contextTypes = {
+  intl: intlShape,
+};

--- a/src/components/search/input/GroupInput.jsx
+++ b/src/components/search/input/GroupInput.jsx
@@ -13,6 +13,7 @@ import {
 } from '../../../helpers/configHelpers';
 
 const propTypes = {
+  'aria-label': PropTypes.string,
   config: PropTypes.shape({
     locale: PropTypes.string,
   }).isRequired,
@@ -30,6 +31,7 @@ const propTypes = {
 
 export default function GroupInput(props) {
   const {
+    'aria-label': ariaLabel,
     config,
     name,
     placeholder,
@@ -86,6 +88,7 @@ export default function GroupInput(props) {
 
   return (
     <OptionPickerInput
+      aria-label={ariaLabel}
       blankable={false}
       name={name}
       placeholder={placeholder}

--- a/src/components/search/input/OperatorInput.jsx
+++ b/src/components/search/input/OperatorInput.jsx
@@ -181,6 +181,14 @@ const operatorMessages = {
   }),
 };
 
+const inputMessages = defineMessages({
+  ariaLabel: {
+    id: 'operatorInput.ariaLabel',
+    description: 'The accessible label of the operator selector in a search condition.',
+    defaultMessage: 'Comparison operator',
+  },
+});
+
 const propTypes = {
   compact: PropTypes.bool,
   intl: intlShape,
@@ -216,6 +224,7 @@ function OperatorInput(props) {
 
   return (
     <OptionPickerInput
+      aria-label={intl.formatMessage(inputMessages.ariaLabel)}
       blankable={false}
       name={name}
       options={options}

--- a/test/specs/components/admin/AccountSearchBar.spec.jsx
+++ b/test/specs/components/admin/AccountSearchBar.spec.jsx
@@ -14,8 +14,7 @@ describe('AccountSearchBar', () => {
     this.container = createTestContainer(this);
   });
 
-  // TODO: fix a11y violations
-  it.skip('should render as a div without a11y violations', async function test() {
+  it('should render as a div without a11y violations', async function test() {
     render(
       <IntlProvider locale="en">
         <AccountSearchBar />

--- a/test/specs/components/admin/AuthRoleSearchBar.spec.jsx
+++ b/test/specs/components/admin/AuthRoleSearchBar.spec.jsx
@@ -14,8 +14,7 @@ describe('AuthRoleSearchBar', () => {
     this.container = createTestContainer(this);
   });
 
-  // TODO: fix a11y violations
-  it.skip('should render as a div without a11y violations', async function test() {
+  it('should render as a div without a11y violations', async function test() {
     render(
       <IntlProvider locale="en">
         <AuthRoleSearchBar />

--- a/test/specs/components/admin/VocabularySearchBar.spec.jsx
+++ b/test/specs/components/admin/VocabularySearchBar.spec.jsx
@@ -14,8 +14,7 @@ describe('VocabularySearchBar', () => {
     this.container = createTestContainer(this);
   });
 
-  // TODO: fix a11y violations
-  it.skip('should render as a div without a11y violations', async function test() {
+  it('should render as a div without a11y violations', async function test() {
     render(
       <IntlProvider locale="en">
         <VocabularySearchBar />

--- a/test/specs/components/media/MediaViewer.spec.jsx
+++ b/test/specs/components/media/MediaViewer.spec.jsx
@@ -1,6 +1,7 @@
 /* global window */
 
 import React from 'react';
+import { IntlProvider } from 'react-intl';
 import { createRenderer } from 'react-test-renderer/shallow';
 import { findWithType } from 'react-shallow-testutils';
 import Immutable from 'immutable';
@@ -14,6 +15,8 @@ const { expect } = chai;
 chai.should();
 
 const { MiniButton } = inputComponents;
+
+const intlContext = new IntlProvider({ locale: 'en' }, {}).getChildContext();
 
 const searchDescriptor = Immutable.fromJS({
   recordType: 'media',
@@ -71,7 +74,7 @@ describe('MediaViewer', () => {
   it('should render a div', () => {
     const shallowRenderer = createRenderer();
 
-    shallowRenderer.render(<MediaViewer config={config} />);
+    shallowRenderer.render(<MediaViewer config={config} />, intlContext);
 
     const result = shallowRenderer.getRenderOutput();
 
@@ -87,6 +90,7 @@ describe('MediaViewer', () => {
         searchDescriptor={searchDescriptor}
         searchResult={searchResult}
       />,
+      intlContext,
     );
 
     const result = shallowRenderer.getRenderOutput();
@@ -114,6 +118,7 @@ describe('MediaViewer', () => {
         searchDescriptor={searchDescriptor}
         searchResult={emptySearchResult}
       />,
+      intlContext,
     );
 
     const result = shallowRenderer.getRenderOutput();
@@ -130,6 +135,7 @@ describe('MediaViewer', () => {
         searchDescriptor={searchDescriptor}
         searchResult={searchResult}
       />,
+      intlContext,
     );
 
     const result = shallowRenderer.getRenderOutput();
@@ -151,6 +157,7 @@ describe('MediaViewer', () => {
         searchDescriptor={searchDescriptor}
         searchResult={searchResult}
       />,
+      intlContext,
     );
 
     const result = shallowRenderer.getRenderOutput();
@@ -172,6 +179,7 @@ describe('MediaViewer', () => {
         searchDescriptor={searchDescriptor}
         searchResult={searchResult}
       />,
+      intlContext,
     );
 
     const result = shallowRenderer.getRenderOutput();
@@ -207,6 +215,7 @@ describe('MediaViewer', () => {
         searchDescriptor={searchDescriptor}
         searchResult={emptySearchResult}
       />,
+      intlContext,
     );
 
     const result = shallowRenderer.getRenderOutput();
@@ -236,6 +245,7 @@ describe('MediaViewer', () => {
         searchDescriptor={searchDescriptor}
         searchResult={singleSearchResult}
       />,
+      intlContext,
     );
 
     const result = shallowRenderer.getRenderOutput();
@@ -273,6 +283,7 @@ describe('MediaViewer', () => {
         searchDescriptor={searchDescriptor}
         searchResult={singleSearchResult}
       />,
+      intlContext,
     );
 
     const result = shallowRenderer.getRenderOutput();
@@ -316,6 +327,7 @@ describe('MediaViewer', () => {
         searchDescriptor={searchDescriptor}
         searchResult={searchResult}
       />,
+      intlContext,
     );
 
     const result = shallowRenderer.getRenderOutput();

--- a/test/specs/components/media/MediaViewerPanel.spec.jsx
+++ b/test/specs/components/media/MediaViewerPanel.spec.jsx
@@ -5,7 +5,7 @@ import Immutable from 'immutable';
 import configureMockStore from 'redux-mock-store';
 import { Provider as StoreProvider } from 'react-redux';
 import thunk from 'redux-thunk';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, IntlProvider } from 'react-intl';
 import createTestContainer from '../../../helpers/createTestContainer';
 import { render } from '../../../helpers/renderHelpers';
 import { ConnectedPanel as Panel } from '../../../../src/containers/layout/PanelContainer';
@@ -170,14 +170,16 @@ describe('MediaViewerPanel', () => {
     };
 
     render(
-      <StoreProvider store={store}>
-        <MediaViewerPanel
-          config={config}
-          name={searchName}
-          searchDescriptor={searchDescriptor}
-          search={search}
-        />
-      </StoreProvider>, this.container,
+      <IntlProvider locale="en">
+        <StoreProvider store={store}>
+          <MediaViewerPanel
+            config={config}
+            name={searchName}
+            searchDescriptor={searchDescriptor}
+            search={search}
+          />
+        </StoreProvider>
+      </IntlProvider>, this.container,
     );
 
     searchedConfig.should.equal(config);
@@ -202,13 +204,15 @@ describe('MediaViewerPanel', () => {
     };
 
     render(
-      <StoreProvider store={store}>
-        <MediaViewerPanel
-          config={config}
-          name={searchName}
-          searchDescriptor={searchDescriptor}
-        />
-      </StoreProvider>, this.container,
+      <IntlProvider locale="en">
+        <StoreProvider store={store}>
+          <MediaViewerPanel
+            config={config}
+            name={searchName}
+            searchDescriptor={searchDescriptor}
+          />
+        </StoreProvider>
+      </IntlProvider>, this.container,
     );
 
     const newSearchDescriptor = Immutable.fromJS({
@@ -221,14 +225,16 @@ describe('MediaViewerPanel', () => {
     });
 
     render(
-      <StoreProvider store={store}>
-        <MediaViewerPanel
-          config={config}
-          name={searchName}
-          searchDescriptor={newSearchDescriptor}
-          search={search}
-        />
-      </StoreProvider>, this.container,
+      <IntlProvider locale="en">
+        <StoreProvider store={store}>
+          <MediaViewerPanel
+            config={config}
+            name={searchName}
+            searchDescriptor={newSearchDescriptor}
+            search={search}
+          />
+        </StoreProvider>
+      </IntlProvider>, this.container,
     );
 
     searchedConfig.should.equal(config);

--- a/test/specs/components/pages/SearchResultPage.spec.jsx
+++ b/test/specs/components/pages/SearchResultPage.spec.jsx
@@ -1160,6 +1160,7 @@ describe('SearchResultPage', () => {
     const context = {
       config,
       store,
+      intl: new IntlProvider({ locale: 'en' }, {}).getChildContext().intl,
     };
 
     shallowRenderer.render(
@@ -1288,6 +1289,7 @@ describe('SearchResultPage', () => {
     const context = {
       config,
       store,
+      intl: new IntlProvider({ locale: 'en' }, {}).getChildContext().intl,
     };
 
     shallowRenderer.render(

--- a/test/specs/components/record/RelatedRecordPanel.spec.jsx
+++ b/test/specs/components/record/RelatedRecordPanel.spec.jsx
@@ -1,6 +1,7 @@
 /* global window */
 
 import React from 'react';
+import { IntlProvider } from 'react-intl';
 import { Simulate } from 'react-dom/test-utils';
 import { createRenderer } from 'react-test-renderer/shallow';
 import { findWithType, findAllWithType } from 'react-shallow-testutils';
@@ -13,6 +14,8 @@ import RelatedRecordPanel, { confirmUnrelateModalName } from '../../../../src/co
 import ConfirmRecordUnrelateModal from '../../../../src/components/record/ConfirmRecordUnrelateModal';
 import UnrelateButton from '../../../../src/components/record/UnrelateButton';
 import SelectBar from '../../../../src/components/search/SelectBar';
+
+const intlContext = new IntlProvider({ locale: 'en' }, {}).getChildContext();
 
 const { expect } = chai;
 
@@ -96,6 +99,7 @@ describe('RelatedRecordPanel', () => {
         initialSort={sort}
         serviceTag={serviceTag}
       />,
+      intlContext,
     );
 
     const result = shallowRenderer.getRenderOutput();
@@ -136,6 +140,7 @@ describe('RelatedRecordPanel', () => {
         relatedRecordType={relatedRecordType}
         recordRelationUpdatedTimestamp={recordRelationUpdatedTimestamp}
       />,
+      intlContext,
     );
 
     const result = shallowRenderer.getRenderOutput();
@@ -160,6 +165,7 @@ describe('RelatedRecordPanel', () => {
         relatedRecordType={relatedRecordType}
         showCheckboxColumn
       />,
+      intlContext,
     );
 
     const searchPanel = shallowRenderer.getRenderOutput();
@@ -184,6 +190,7 @@ describe('RelatedRecordPanel', () => {
         relatedRecordType={relatedRecordType}
         showCheckboxColumn={false}
       />,
+      intlContext,
     );
 
     const searchPanel = shallowRenderer.getRenderOutput();
@@ -210,6 +217,7 @@ describe('RelatedRecordPanel', () => {
         recordType={recordType}
         relatedRecordType="group"
       />,
+      intlContext,
     );
 
     const result = shallowRenderer.getRenderOutput();
@@ -229,6 +237,7 @@ describe('RelatedRecordPanel', () => {
         recordType={recordType}
         relatedRecordType="group"
       />,
+      intlContext,
     );
 
     const result = shallowRenderer.getRenderOutput();
@@ -255,6 +264,7 @@ describe('RelatedRecordPanel', () => {
         recordType={recordType}
         relatedRecordType="group"
       />,
+      intlContext,
     );
 
     const result = shallowRenderer.getRenderOutput();
@@ -271,6 +281,7 @@ describe('RelatedRecordPanel', () => {
         recordType={recordType}
         relatedRecordType="group"
       />,
+      intlContext,
     );
 
     const newResult = shallowRenderer.getRenderOutput();
@@ -292,6 +303,7 @@ describe('RelatedRecordPanel', () => {
         recordType={recordType}
         relatedRecordType="group"
       />,
+      intlContext,
     );
 
     const result = shallowRenderer.getRenderOutput();
@@ -315,6 +327,7 @@ describe('RelatedRecordPanel', () => {
         relatedRecordType="group"
         recordRelationUpdatedTimestamp="2017-03-27T17:56.03.000Z"
       />,
+      intlContext,
     );
 
     const newResult = shallowRenderer.getRenderOutput();
@@ -347,6 +360,7 @@ describe('RelatedRecordPanel', () => {
         selectedItems={selectedItems}
         showCheckboxColumn
       />,
+      intlContext,
     );
 
     const searchPanel = shallowRenderer.getRenderOutput();
@@ -378,6 +392,7 @@ describe('RelatedRecordPanel', () => {
         relatedRecordType={relatedRecordType}
         showCheckboxColumn
       />,
+      intlContext,
     );
 
     const searchPanel = shallowRenderer.getRenderOutput();
@@ -426,6 +441,7 @@ describe('RelatedRecordPanel', () => {
         showCheckboxColumn
         onItemSelectChange={handleItemSelectChange}
       />,
+      intlContext,
     );
 
     const searchPanel = shallowRenderer.getRenderOutput();
@@ -471,6 +487,7 @@ describe('RelatedRecordPanel', () => {
         relatedRecordType={relatedRecordType}
         showCheckboxColumn
       />,
+      intlContext,
     );
 
     const searchPanel = shallowRenderer.getRenderOutput();
@@ -542,13 +559,14 @@ describe('RelatedRecordPanel', () => {
         showCheckboxColumn
         openModal={openModal}
       />,
+      intlContext,
     );
 
     const searchPanel = shallowRenderer.getRenderOutput();
     const header = searchPanel.props.renderTableHeader({ searchResult });
 
     const selectBarRenderer = createRenderer();
-    const selectBar = selectBarRenderer.render(findWithType(header, SelectBar));
+    const selectBar = selectBarRenderer.render(findWithType(header, SelectBar), intlContext);
     const unrelateButton = findWithType(selectBar, UnrelateButton);
 
     unrelateButton.props.onClick();
@@ -631,6 +649,7 @@ describe('RelatedRecordPanel', () => {
         onUnrelated={handleUnrelated}
         closeModal={closeModal}
       />,
+      intlContext,
     );
 
     const searchPanel = shallowRenderer.getRenderOutput();
@@ -712,6 +731,7 @@ describe('RelatedRecordPanel', () => {
         showCheckboxColumn
         unrelateRecords={unrelateRecords}
       />,
+      intlContext,
     );
 
     const searchPanel = shallowRenderer.getRenderOutput();
@@ -826,6 +846,7 @@ describe('RelatedRecordPanel', () => {
         showCheckboxColumn
         unrelateRecords={unrelateRecords}
       />,
+      intlContext,
     );
 
     const searchPanel = shallowRenderer.getRenderOutput();
@@ -940,6 +961,7 @@ describe('RelatedRecordPanel', () => {
         showCheckboxColumn
         closeModal={closeModal}
       />,
+      intlContext,
     );
 
     const searchPanel = shallowRenderer.getRenderOutput();

--- a/test/specs/components/search/SelectBar.spec.jsx
+++ b/test/specs/components/search/SelectBar.spec.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { createRenderer } from 'react-test-renderer/shallow';
 import { findWithType, findAllWithType } from 'react-shallow-testutils';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, IntlProvider } from 'react-intl';
 import Immutable from 'immutable';
 import CheckboxInput from 'cspace-input/lib/components/CheckboxInput';
 import SelectBar from '../../../../src/components/search/SelectBar';
+
+const intlContext = new IntlProvider({ locale: 'en' }, {}).getChildContext();
 
 const { expect } = chai;
 
@@ -52,6 +54,7 @@ describe('SelectBar', () => {
         listType={listType}
         searchResult={searchResult}
       />,
+      intlContext,
     );
 
     const result = shallowRenderer.getRenderOutput();
@@ -68,6 +71,7 @@ describe('SelectBar', () => {
         config={config}
         listType={listType}
       />,
+      intlContext,
     );
 
     const result = shallowRenderer.getRenderOutput();
@@ -88,6 +92,7 @@ describe('SelectBar', () => {
         listType={listType}
         searchResult={emptyResult}
       />,
+      intlContext,
     );
 
     const result = shallowRenderer.getRenderOutput();
@@ -110,6 +115,7 @@ describe('SelectBar', () => {
         searchResult={searchResult}
         buttons={buttons}
       />,
+      intlContext,
     );
 
     const result = shallowRenderer.getRenderOutput();
@@ -133,6 +139,7 @@ describe('SelectBar', () => {
         searchResult={searchResult}
         selectedItems={selectedItems}
       />,
+      intlContext,
     );
 
     const result = shallowRenderer.getRenderOutput();
@@ -153,6 +160,7 @@ describe('SelectBar', () => {
         searchResult={searchResult}
         selectedItems={selectedItems}
       />,
+      intlContext,
     );
 
     const result = shallowRenderer.getRenderOutput();
@@ -175,6 +183,7 @@ describe('SelectBar', () => {
         searchResult={searchResult}
         selectedItems={selectedItems}
       />,
+      intlContext,
     );
 
     const result = shallowRenderer.getRenderOutput();
@@ -209,6 +218,7 @@ describe('SelectBar', () => {
         searchResult={singleItemSearchResult}
         selectedItems={selectedItems}
       />,
+      intlContext,
     );
 
     const result = shallowRenderer.getRenderOutput();
@@ -234,6 +244,7 @@ describe('SelectBar', () => {
         selectedItems={selectedItems}
         showCheckboxFilter={showCheckboxFilter}
       />,
+      intlContext,
     );
 
     const result = shallowRenderer.getRenderOutput();
@@ -276,6 +287,7 @@ describe('SelectBar', () => {
         setAllItemsSelected={setAllItemsSelected}
         showCheckboxFilter={showCheckboxFilter}
       />,
+      intlContext,
     );
 
     const result = shallowRenderer.getRenderOutput();


### PR DESCRIPTION
**What does this do?**
It fixes all the missing form label a11y issues. The main changes are:
* Added missing id to inputs. The `labelable` enhancer associates a label with an input when an id is supplied. In some cases the id was not supplied
* Added `aria-label` to inputs without a visible label. Most of the components had no access to `intl`, so they gained `contextTypes = { intl: intlShape }`, similar to the rest of the codebase
* Fixed forwarding `aria-*` label props
* Fixed tabular repeating fields by adding a `renderAriaLabel` check to `Field`, formatting the column field's configured message. cspace-input's `InputTableRow` applies it as `aria-label`.

**Why are we doing this? (with JIRA link)**
We need to fix the Missing form label (Criteria 3.3.2) across the application: https://collectionspace.atlassian.net/browse/DRYD-2130

**How should this be tested? Do these changes have associated tests?**
The cspace-input changes https://github.com/collectionspace/cspace-input.js/pull/27 should be built along locally. Then using the WAVE browser plugin: https://chromewebstore.google.com/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh please confirm that the "Missing form label" error is not being reported any more. The fixed spots are in the following list, but please check the whole application for any other spot where the error might persist:

Administration
* Users -> Filter by full name
* Roles and Persmissions -> Filter by name

Tools 
* Term Lists/Reports/Data Updates -> Filter by name
Quick search in header
* Keyword field, record type dropdown and vocabulary dropdown (after selecting an authority).

Search Page 
* Keyword field, record type dropdown and vocabulary dropdown (after selecting an authority).
* Field dropdown of a new condition
* Operator dropdown
* Value input of a text condition
* Date range value fields (after selecting the is-between operator)
* Pick a controlled/repeating field (f.e an annotation field), add a second value instance with "+".
* The "All/Any of the following conditions" selector at the top, and each "−" remove button.
* Group condition ("in a single … group") dropdown.

Search Results
* Pager buttons, page size
* Select all checkbox, row checkboxes

Record Editor
* Template selector
* + Related tab selector

Media Handling Record Editor
* Create New -> Media Handling -> File Information -> Upload input and value field next to it (local file/external media)
* Saved media record -> Created time / Last updated time fields
* A record with several images -> Sidebar Media Gallery arrows

Tabular Repeating Lists
* Administration -> Term Lists -> a vocabulary with several terms
* Record Editor -> Any repeating tabular group with multiple values (f.e Other number)

Invocation modal
* Tools -> Reports -> Any report -> Open invocation modal by clicking Run -> Format: dropdown

**Dependencies for merging? Releasing to production?**
https://github.com/collectionspace/cspace-input.js/pull/27

**Has the application documentation been updated for these changes?**
Changelog has been updated

**Did someone actually run this code to verify it works?**
@spirosdi ran it locally

**Have any new accessibility violations been handled?**
no new a11y violation
