### PR TITLE
DRYD-2002: Add Password Requirements

### DIFF
--- a/src/components/pages/service/PasswordResetPage.jsx
+++ b/src/components/pages/service/PasswordResetPage.jsx
@@ -172,7 +172,7 @@ function PasswordResetPage(props) {
 
     if (!valid) {
       const errorMessages = errors.map(({ errorCode, values }) => (
-        <li>
+        <li key={errorCode}>
           <FormattedMessage {...messages[errorCode]} values={values} />
         </li>
       ));
@@ -275,10 +275,10 @@ function PasswordResetPage(props) {
     ) : undefined;
   const errorMessage = error
     ? (
-      <p className="status error">
+      <div className="status error">
         {error}
         {validationMessage}
-      </p>
+      </div>
     )
     : undefined;
 

--- a/src/components/pages/service/PasswordResetPage.jsx
+++ b/src/components/pages/service/PasswordResetPage.jsx
@@ -52,7 +52,32 @@ const messages = defineMessages({
   errorInvalidPassword: {
     id: 'passwordResetPage.errorInvalidPassword',
     description: 'Message to display when the password is invalid on the password reset page.',
-    defaultMessage: 'The password must be between 8 and 24 characters.',
+    defaultMessage: 'The password is missing the following requirements:',
+  },
+  errorInvalidLength: {
+    id: 'passwordResetPage.errorInvalidLength',
+    description: 'Message to display when the password does not meet length requirements.',
+    defaultMessage: 'The password must be at least {minLength} characters',
+  },
+  errorMissingLower: {
+    id: 'passwordResetPage.errorMissingLower',
+    description: 'Message to display when the password is missing lowercase letters.',
+    defaultMessage: 'Missing at least one lowercase letter',
+  },
+  errorMissingUpper: {
+    id: 'passwordResetPage.errorMissingUpper',
+    description: 'Message to display when the password is missing uppercase letters.',
+    defaultMessage: 'Missing at least one uppercase letter',
+  },
+  errorMissingDigit: {
+    id: 'passwordResetPage.errorMissingDigit',
+    description: 'Message to display when the password is missing digits.',
+    defaultMessage: 'Missing at least one digit',
+  },
+  errorMissingSpecial: {
+    id: 'passwordResetPage.errorMissingSpecial',
+    description: 'Message to display when the password is missing special characters.',
+    defaultMessage: 'Missing at least one symbol',
   },
   success: {
     id: 'passwordResetPage.success',
@@ -88,6 +113,7 @@ const messages = defineMessages({
 
 const propTypes = {
   csrf: PropTypes.object,
+  passwordRequirements: PropTypes.object,
   intl: intlShape.isRequired,
   tenantId: PropTypes.string,
   tenantLoginUrl: PropTypes.string,
@@ -96,6 +122,7 @@ const propTypes = {
 
 const defaultProps = {
   csrf: null,
+  passwordRequirements: null,
   tenantId: null,
   // If we don't receive a tenant-specific login URL, default to the services login page.
   tenantLoginUrl: '/cspace-services/login',
@@ -108,9 +135,11 @@ function PasswordResetPage(props) {
     tenantId,
     tenantLoginUrl,
     token,
+    passwordRequirements,
   } = props;
 
   const [error, setError] = useState();
+  const [validationErrors, setValidationErrors] = useState();
   const [isPending, setPending] = useState();
   const [success, setSuccess] = useState();
 
@@ -128,14 +157,27 @@ function PasswordResetPage(props) {
     const password = formData.get('password');
     const confirmPassword = formData.get('confirmPassword');
 
+    // clear old validation messages
+    setValidationErrors(null);
     if (!password) {
       setError(<FormattedMessage {...messages.errorMissingPassword} />);
 
       return;
     }
 
-    if (!isValidPassword(password)) {
+    const {
+      valid,
+      errors,
+    } = isValidPassword(password, passwordRequirements);
+
+    if (!valid) {
+      const errorMessages = errors.map(({ errorCode, values }) => (
+        <li>
+          <FormattedMessage {...messages[errorCode]} values={values} />
+        </li>
+      ));
       setError(<FormattedMessage {...messages.errorInvalidPassword} />);
+      setValidationErrors(errorMessages);
 
       return;
     }
@@ -225,8 +267,19 @@ function PasswordResetPage(props) {
       });
   };
 
+  const validationMessage = validationErrors
+    ? (
+      <ul className="validation">
+        {validationErrors}
+      </ul>
+    ) : undefined;
   const errorMessage = error
-    ? <p className="status error">{error}</p>
+    ? (
+      <p className="status error">
+        {error}
+        {validationMessage}
+      </p>
+    )
     : undefined;
 
   return (

--- a/src/components/pages/service/PasswordResetPage.jsx
+++ b/src/components/pages/service/PasswordResetPage.jsx
@@ -54,8 +54,13 @@ const messages = defineMessages({
     description: 'Message to display when the password is invalid on the password reset page.',
     defaultMessage: 'The password is missing the following requirements:',
   },
-  errorInvalidLength: {
-    id: 'passwordResetPage.errorInvalidLength',
+  errorTooLong: {
+    id: 'passwordResetPage.errorTooLong',
+    description: 'Message to display when the password exceeds length requirements.',
+    defaultMessage: 'The password must be at most {maxLength} characters',
+  },
+  errorTooShort: {
+    id: 'passwordResetPage.errorTooShort',
     description: 'Message to display when the password does not meet length requirements.',
     defaultMessage: 'The password must be at least {minLength} characters',
   },

--- a/src/helpers/passwordHelpers.js
+++ b/src/helpers/passwordHelpers.js
@@ -5,9 +5,16 @@ export const isValidPassword = (password, passwordRequirements) => {
   const special = /[!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~]/;
   const errors = [];
 
+  // max length check for bcrypt which only accepts up to 72 bytes
+  const maxLength = 72;
+  const encoder = new TextEncoder();
+  if (encoder.encode(password).length > maxLength) {
+    errors.push({ errorCode: 'errorTooLong', values: { maxLength } });
+  }
+
   if (passwordRequirements) {
     if (passwordRequirements.minLength && password.length < passwordRequirements.minLength) {
-      errors.push({ errorCode: 'errorInvalidLength', values: { minLength: passwordRequirements.minLength } });
+      errors.push({ errorCode: 'errorTooShort', values: { minLength: passwordRequirements.minLength } });
     }
     if (passwordRequirements.requireLowerCase && !lower.test(password)) {
       errors.push({ errorCode: 'errorMissingLower' });

--- a/src/helpers/passwordHelpers.js
+++ b/src/helpers/passwordHelpers.js
@@ -1,7 +1,32 @@
-export const isValidPassword = (password) => (
-  password
-  && password.length >= 8
-  && password.length <= 24
-);
+export const isValidPassword = (password, passwordRequirements) => {
+  const lower = /[a-z]/; // can do \p{Ll}/v as well
+  const upper = /[A-Z]/;
+  const digit = /[\d]/;
+  const special = /[!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~]/;
+  const errors = [];
+
+  if (passwordRequirements) {
+    if (passwordRequirements.minLength && password.length < passwordRequirements.minLength) {
+      errors.push({ errorCode: 'errorInvalidLength', values: { minLength: passwordRequirements.minLength } });
+    }
+    if (passwordRequirements.requireLowerCase && !lower.test(password)) {
+      errors.push({ errorCode: 'errorMissingLower' });
+    }
+    if (passwordRequirements.requireUpperCase && !upper.test(password)) {
+      errors.push({ errorCode: 'errorMissingUpper' });
+    }
+    if (passwordRequirements.requireDigit && !digit.test(password)) {
+      errors.push({ errorCode: 'errorMissingDigit' });
+    }
+    if (passwordRequirements.requireSpecial && !special.test(password)) {
+      errors.push({ errorCode: 'errorMissingSpecial' });
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+};
 
 export default {};

--- a/src/plugins/recordTypes/account/fields.js
+++ b/src/plugins/recordTypes/account/fields.js
@@ -1,12 +1,10 @@
 import { defineMessages } from 'react-intl';
 import Immutable from 'immutable';
 import { isExistingRecord, isNewRecord } from '../../../helpers/recordDataHelpers';
-import { isValidPassword } from '../../../helpers/passwordHelpers';
 import { isValidEmail } from '../../../helpers/validationHelpers';
 
 import {
   ERR_INVALID_EMAIL,
-  ERR_INVALID_PW,
   ERR_PW_NOT_CONFIRMED,
 } from '../../../constants/errorCodes';
 
@@ -170,11 +168,6 @@ export default (configContext) => {
         [config]: {
           cloneable: false,
           messages: defineMessages({
-            errorInvalidPassword: {
-              id: 'field.accounts_common.password.errorInvalidPassword',
-              description: 'Message to display when the password is invalid on the user account form.',
-              defaultMessage: 'Password must be between 8 and 24 characters.',
-            },
             name: {
               id: 'field.accounts_common.password.name',
               defaultMessage: 'Password',
@@ -184,16 +177,6 @@ export default (configContext) => {
             isNewRecord(recordData)
             && recordData.getIn(['ns2:accounts_common', 'requireSSO']) === false
           ),
-          validate: ({ data, fieldDescriptor }) => {
-            if (data && !isValidPassword(data)) {
-              return {
-                code: ERR_INVALID_PW,
-                message: fieldDescriptor[config].messages.errorInvalidPassword,
-              };
-            }
-
-            return undefined;
-          },
           view: {
             type: PasswordInput,
             props: {

--- a/src/service.jsx
+++ b/src/service.jsx
@@ -44,6 +44,7 @@ export default (uiConfig) => {
     tenantId,
     tenantLoginUrl,
     token,
+    passwordRequirements,
   } = config;
 
   const mountNode = document.querySelector(container);
@@ -120,6 +121,7 @@ export default (uiConfig) => {
                     tenantId={tenantId}
                     tenantLoginUrl={tenantLoginUrl}
                     token={token}
+                    passwordRequirements={passwordRequirements}
                   />
                 )}
               />

--- a/styles/cspace-ui/ServicePage.css
+++ b/styles/cspace-ui/ServicePage.css
@@ -127,7 +127,7 @@ body {
   color: rgb(220, 0, 0);
 }
 
-.common ul {
+.common :global(.validation) {
   text-align: left;
   list-style: none;
 }

--- a/styles/cspace-ui/ServicePage.css
+++ b/styles/cspace-ui/ServicePage.css
@@ -126,3 +126,8 @@ body {
   border-color: #e6b3b3;
   color: rgb(220, 0, 0);
 }
+
+.common ul {
+  text-align: left;
+  list-style: none;
+}


### PR DESCRIPTION
**What does this do?**
* Update password validate logic to include requirements from the backend

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-2002

This is for better HECVAT compatibility

**How should this be tested? Do these changes have associated tests?**
Setup your tenant to have password complexity requirements per the instructions in https://github.com/collectionspace/application/pull/355

There are multiple scenarios which we will need to check:
* Creating a normal account
  * Navigate to Administration > Create New
  * Set a password which does not meet the requirements and see that the notification displays which requirements are missing (note: these are the enums from the backend. I didn't add messages for them).
  * Set a password which does meet the requirements and see the account is created.
* Create an account with SSO enabled
  * Navigate to Administration > Create New
  * Check the 'Require single sign-on' option
  * Press 'Save' and see that it succeeds
* Update a user account
  * Navigate to Administration > Users > User
  * Verify that passwords must meet complexity requirements similar to the Create form
* Creating a Password Reset Request
  * First prepare the backend to use the correct version of the services-ui js
    * In `cspace-ui.js` run `npm build`
    * In `cspace-ui.js`, copy `dist/cspaceUI-service.*` to `$CSPACE_JEESERVER_HOME/webapps/cspace-ui/`
    * Modify `$CSPACE_JEESERVER_HOME/cspace/config/services/resources/service-ui.ftlh` so that the script for the service ui is the newly built bundle, e.g. `src=/cspace-ui/cspaceUI-service.min.js`
  * Start the request password flow
    * Sign out of your CollectionSpace instance
    * Sign in and select 'Forgot password'
    * Enter your email
      * This will return an SMTP error which is ok. We don't need to rely on it.
    * Query the token created for the password reset request, e.g. `psql -U postgres -h localhost cspace_default -c "select id from tokens;"` 
    * Using the token, navigate to the process password request form, e.g. `http://localhost:8180/cspace-services/accounts/processpasswordreset?token=b6d287b5-f432-47de-bf62-cb3262be2456`
    * Test the form logic for password requirements

**Dependencies for merging? Releasing to production?**
There used to be a check for max length. We could add it back, I was kind of mixed on it.

The unicode regexs were also not cooperating initially. It should be noted that although the backend is using `\p{Punct}` it appears to only be ASCII punctuation anyway. As this is not a feature specifically being requested by any clients I didn't look at better unicode support.

**Has the application documentation been updated for these changes?**
No, it will need to be.

**Did someone actually run this code to verify it works?**
@mikejritter tested locally

**Have any new accessibility violations been handled?**
n/a
