### PR TITLE
DRYD-2125: Procedure > Acquisition > Price Information Block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - The order drives:
     - The order of images in the media snapshot gallery in cspace-ui (prioritized media first, un-prioritized media appended in the default sort order)
     - The search-result thumbnail and detail-view image gallery in the public browser
+- On the record editor for Acquisitions, the Price Information fields are now displayed in a collapsible panel, collapsed by default.
 - New Advanced Search form
   - Pinned queries feature is introduced. Users are able to pin advanced search query parameters with a name and description, re-run them later, and delete them, all from the Advanced Search page. Queries are stored locally, so they are available only from the same device + browser combination.
 

--- a/src/plugins/recordTypes/acquisition/forms/default.jsx
+++ b/src/plugins/recordTypes/acquisition/forms/default.jsx
@@ -48,7 +48,7 @@ const template = (configContext) => {
           </Col>
 
           <Col>
-            <Panel name="priceInformation">
+            <Panel name="priceInformation" collapsible collapsed>
               <InputTable name="groupPurchasePrice">
                 <Field name="groupPurchasePriceCurrency" />
                 <Field name="groupPurchasePriceValue" />


### PR DESCRIPTION
**What does this do?**
On the record editor for Acquisitions, the Price Information fields are now displayed in a collapsible panel, collapsed by default.

**Why are we doing this? (with JIRA link)**
To align UI with how other fields exist within the broader application: https://collectionspace.atlassian.net/browse/DRYD-2125

**How should this be tested? Do these changes have associated tests?**
1. Open the edit record of Procedures > Acquisitions
2. Confirm that the Price Information block is a collapsible panel, collapsed by default
3. Confirm that the open/closed state is persisted per user on reload/relogin

**Dependencies for merging? Releasing to production?**
No dependencies

**Has the application documentation been updated for these changes?**
Changelog has been updated

**Did someone actually run this code to verify it works?**
@spirosdi ran it locally

**Have any new accessibility violations been handled?**
 no new a11y violations