### PR TITLE
DRYD-2127: Procedure > Acquisition > Add Alternate Identifier/Note combination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 - On the record editor for Objects
   - The Home Location repeating group of fields `homeLocationGroupList/homeLocationGroup` has been added
   - The Media Priority repeating field `mediaPriorityList/mediaPriority` has been added
+- On the record editor for Acquisitions
+  - The Alternative Identifier repeating group of fields `alternativeIdentifierGroupList/alternativeIdentifierGroup` has been added
 
 ### Accessibility
 

--- a/src/plugins/recordTypes/acquisition/fields.js
+++ b/src/plugins/recordTypes/acquisition/fields.js
@@ -77,6 +77,64 @@ export default (configContext) => {
             },
           },
         },
+        alternativeIdentifierGroupList: {
+          [config]: {
+            view: {
+              type: CompoundInput,
+            },
+          },
+          alternativeIdentifierGroup: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.acquisitions_common.alternativeIdentifierGroup.name',
+                  defaultMessage: 'Alternative identifier',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: CompoundInput,
+                props: {
+                  tabular: true,
+                },
+              },
+            },
+            alternativeIdentifier: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.acquisitions_common.alternativeIdentifier.fullName',
+                    defaultMessage: 'Alternative identifier',
+                  },
+                  name: {
+                    id: 'field.acquisitions_common.alternativeIdentifier.name',
+                    defaultMessage: 'Identifier',
+                  },
+                }),
+                view: {
+                  type: TextInput,
+                },
+              },
+            },
+            alternativeIdentifierNote: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.acquisitions_common.alternativeIdentifierNote.fullName',
+                    defaultMessage: 'Alternative identifier note',
+                  },
+                  name: {
+                    id: 'field.acquisitions_common.alternativeIdentifierNote.name',
+                    defaultMessage: 'Note',
+                  },
+                }),
+                view: {
+                  type: TextInput,
+                },
+              },
+            },
+          },
+        },
         accessionDateGroup: {
           [config]: {
             dataType: DATA_TYPE_STRUCTURED_DATE,

--- a/src/plugins/recordTypes/acquisition/forms/default.jsx
+++ b/src/plugins/recordTypes/acquisition/forms/default.jsx
@@ -23,6 +23,14 @@ const template = (configContext) => {
         <Cols>
           <Col>
             <Field name="acquisitionReferenceNumber" />
+
+            <Field name="alternativeIdentifierGroupList">
+              <Field name="alternativeIdentifierGroup">
+                <Field name="alternativeIdentifier" />
+                <Field name="alternativeIdentifierNote" />
+              </Field>
+            </Field>
+
             <Field name="accessionDateGroup" />
 
             <InputTable name="acquisitionAuthorizer">


### PR DESCRIPTION
**What does this do?**
Adds a repeating Alternative Identifier group of fields (alternativeIdentifier and alternativeIdentifierNote) to the Acquisition record editor, rendered directly under the Reference number field. The field group mirrors the identically-named group that already exists on the Repatriation Request procedure, using the same labels ("Alternative identifier" / Identifier / Note).

**Why are we doing this? (with JIRA link)**
Kansas needs to record alternate accession numbers (with notes) on acquisition records to support their data migration. https://collectionspace.atlassian.net/browse/DRYD-2127

**How should this be tested? Do these changes have associated tests?**
You will need to build the backend with this application PR: https://github.com/collectionspace/application/pull/359
1. Open an Acquisition record
2. Verify the Alternative Identifier group appears under Reference number
3. Add multiple identifier/note rows, save, and reload to confirm values persist
4. Confirm searching and exporting of the new fields work as expected

Changes need to be tested in anthro, fcart, lhmc, materials, and publicart profiles. 

**Dependencies for merging? Releasing to production?**
https://github.com/collectionspace/application/pull/359
Profile PRs:
https://github.com/collectionspace/cspace-ui-plugin-profile-fcart.js/pull/34
https://github.com/collectionspace/cspace-ui-plugin-profile-lhmc.js/pull/35
https://github.com/collectionspace/cspace-ui-plugin-profile-materials.js/pull/23
https://github.com/collectionspace/cspace-ui-plugin-profile-publicart.js/pull/36

anthro (no acquisition overrides, it inherits the core form)

**Has the application documentation been updated for these changes?**
Changelog has been updated

**Did someone actually run this code to verify it works?**
@spirosdi ran it locally

**Have any new accessibility violations been handled?**
no new a11y violations