### PR TITLE
nojira: default value for minimum password length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - On the record editor for Acquisitions, the Price Information fields are now displayed in a collapsible panel, collapsed by default.
 - New Advanced Search form
   - Pinned queries feature is introduced. Users are able to pin advanced search query parameters with a name and description, re-run them later, and delete them, all from the Advanced Search page. Queries are stored locally, so they are available only from the same device + browser combination.
+- On the password reset form, password requirements can now be passed from the services backend
+  - Initial validators exist for maximum length (with a default of 72 characters), minimum length (with a default of 8 characters), lowercase, uppercase, digit, and special character requirements
 
 ### New Fields
 

--- a/src/helpers/passwordHelpers.js
+++ b/src/helpers/passwordHelpers.js
@@ -12,10 +12,12 @@ export const isValidPassword = (password, passwordRequirements) => {
     errors.push({ errorCode: 'errorTooLong', values: { maxLength } });
   }
 
+  const minLength = passwordRequirements?.minLength || 8;
+  if (password.length < minLength) {
+    errors.push({ errorCode: 'errorTooShort', values: { minLength } });
+  }
+
   if (passwordRequirements) {
-    if (passwordRequirements.minLength && password.length < passwordRequirements.minLength) {
-      errors.push({ errorCode: 'errorTooShort', values: { minLength: passwordRequirements.minLength } });
-    }
     if (passwordRequirements.requireLowerCase && !lower.test(password)) {
       errors.push({ errorCode: 'errorMissingLower' });
     }


### PR DESCRIPTION
**What does this do?**
Adds a default value for minimum password length

**Why are we doing this? (with JIRA link)**
No jira. This is a follow up from https://github.com/collectionspace/services/pull/554, as it seemed to make sense to have parity between the frontend and backend for what they check. I'm not sure if we needed this but it's simple enough I figured I'd get the changes done.

**How should this be tested? Do these changes have associated tests?**
* Create a password reset with no password complexity settings defined for your tenant
* In the password reset form, enter a password with less than 8 characters and see the form validation fails
* Validation can also be done by changing the password complexity settings to include a minimum length and seeing that the minimum length is equal to what is defined in the settings

**Dependencies for merging? Releasing to production?**
No dependencies. I can add tests as I just realized there aren't any.

**Has the application documentation been updated for these changes?**
A ticket exists for updating documentation.

**Did someone actually run this code to verify it works?**
@mikejritter tested locally

**Have any new accessibility violations been handled?**
no accessibility changes have occurred.
