### PR TITLE
DRYD-2135: Update Object Name Formatting for Grid and Detail List

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   - Pinned queries feature is introduced. Users are able to pin advanced search query parameters with a name and description, re-run them later, and delete them, all from the Advanced Search page. Queries are stored locally, so they are available only from the same device + browser combination.
 - On the password reset form, password requirements can now be passed from the services backend
   - Initial validators exist for maximum length (with a default of 72 characters), minimum length (with a default of 8 characters), lowercase, uppercase, digit, and special character requirements
+- On the Object Search Results, separate Object Names and Controlled Object Names using a forward slash
 
 ### New Fields
 

--- a/src/plugins/recordTypes/collectionobject/detailList.jsx
+++ b/src/plugins/recordTypes/collectionobject/detailList.jsx
@@ -95,7 +95,7 @@ export default (configContext) => {
         const objectName = [
           formatRefNameWithDefault(data.get('objectNameControlled')),
           formatRefNameWithDefault(data.get('objectName')),
-        ].filter((name) => !!name).join(', ');
+        ].filter((name) => !!name).join(' / ');
 
         const taxon = formatRefNameWithDefault(data.get('taxon'));
         const form = formatRefNameWithDefault(data.get('form'));

--- a/src/plugins/recordTypes/collectionobject/grid.jsx
+++ b/src/plugins/recordTypes/collectionobject/grid.jsx
@@ -8,7 +8,7 @@ export default (configContext) => {
     formatRefNameWithDefault,
   } = configContext.formatHelpers;
 
-  const formatObjectName = (objectNames) => objectNames.filter((name) => !!name).join(', ');
+  const formatObjectName = (objectNames) => objectNames.filter((name) => !!name).join(' / ');
 
   const formatTaxon = (taxon, form) => {
     if (taxon && form) {

--- a/styles/cspace-ui/Image.css
+++ b/styles/cspace-ui/Image.css
@@ -28,4 +28,5 @@
   justify-content: center;
   font-size: inherit;
   font-weight: 600;
+  text-align: center;
 }


### PR DESCRIPTION
**What does this do?**
Separates uncontrolled and controlled object names with a `/`
Also snuck in a change for text alignment when no media is present

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-2135

This is to help with differentiate object names which use punctuation.

For the text alignment, I noticed when using a lower resolution (my screen split vertically) that the alignment was incorrect. The change is small enough I included it here.

**How should this be tested? Do these changes have associated tests?**
* Search with the following constraints:
  * Objects > objectName is not blank
  * Objects > objectNameControlled is not blank
* In the grid and detail list views see that the names display as `objectName / objectNameControlled`

**Dependencies for merging? Releasing to production?**
I did a quick check of the profiles and it didn't look like any required updates, but it would be good to double check.

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@mikejritter tested against core.

**Have any new accessibility violations been handled?**
No new violations were added.
