### PR TITLE
DRYD-2144 Authority Fields > Predictive Search Result Messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   - Pinned queries feature is introduced. Users are able to pin advanced search query parameters with a name and description, re-run them later, and delete them, all from the Advanced Search page. Queries are stored locally, so they are available only from the same device + browser combination.
 - On the password reset form, password requirements can now be passed from the services backend
   - Initial validators exist for maximum length (with a default of 72 characters), minimum length (with a default of 8 characters), lowercase, uppercase, digit, and special character requirements
+- In autocomplete fields, the dropdown now shows "Continue typing to narrow results" instead of a match count when more terms match than the server returns.
 
 ### New Fields
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4098,9 +4098,9 @@
       }
     },
     "node_modules/cspace-input": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cspace-input/-/cspace-input-2.2.0.tgz",
-      "integrity": "sha512-FcEneEfVRBttjvzWzcSDF0fJMbuYA6taeLDKWH5NuWxkoVD6MyE0WxXK7T44PIjOgRYPXB+cC8vOUN8ooHRL7Q==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cspace-input/-/cspace-input-2.3.0.tgz",
+      "integrity": "sha512-WFChYBLD0swwvKop4S4MoSO7q2ei8NzKY2znbiXikLwyT8HOu+Dzia/WcprOy2AQCv3pqMMxB2wpCq58zuoIMA==",
       "license": "ECL-2.0",
       "dependencies": {
         "classnames": "^2.2.6",
@@ -17217,9 +17217,9 @@
       }
     },
     "cspace-input": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cspace-input/-/cspace-input-2.2.0.tgz",
-      "integrity": "sha512-FcEneEfVRBttjvzWzcSDF0fJMbuYA6taeLDKWH5NuWxkoVD6MyE0WxXK7T44PIjOgRYPXB+cC8vOUN8ooHRL7Q==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cspace-input/-/cspace-input-2.3.0.tgz",
+      "integrity": "sha512-WFChYBLD0swwvKop4S4MoSO7q2ei8NzKY2znbiXikLwyT8HOu+Dzia/WcprOy2AQCv3pqMMxB2wpCq58zuoIMA==",
       "requires": {
         "classnames": "^2.2.6",
         "cspace-layout": "^2.0.2",

--- a/src/containers/input/AutocompleteInputContainer.js
+++ b/src/containers/input/AutocompleteInputContainer.js
@@ -42,6 +42,11 @@ const messages = defineMessages({
     description: 'Message displayed in the autocomplete input dropdown when more characters must be typed in order to begin matching.',
     defaultMessage: 'Continue typing to find matching terms',
   },
+  narrowResults: {
+    id: 'autocompleteInputContainer.narrowResults',
+    description: 'Message displayed in the autocomplete input dropdown when there are more matching terms than can be shown.',
+    defaultMessage: 'Continue typing to narrow results',
+  },
   addPrompt: {
     id: 'autocompleteInputContainer.addPrompt',
     description: 'Message displayed in the autocomplete input dropdown to prompt a user to add a new term.',
@@ -118,6 +123,7 @@ const mapStateToProps = (state, ownProps) => {
     formatCloneOptionLabel: () => intl.formatMessage(messages.cloneOptionLabel),
     formatCreateNewOptionLabel: () => intl.formatMessage(messages.createNewOptionLabel),
     formatMoreCharsRequiredMessage: () => intl.formatMessage(messages.moreCharsRequired),
+    formatNarrowResultsMessage: () => intl.formatMessage(messages.narrowResults),
     formatSearchResultMessage: (count) => intl.formatMessage(messages.count, { count }),
     formatSourceName: (recordTypeConfig, vocabulary) => intl.formatMessage(
       vocabulary

--- a/src/reducers/partialTermSearch.js
+++ b/src/reducers/partialTermSearch.js
@@ -13,6 +13,8 @@ import {
 export default (state = Immutable.Map(), action) => {
   let count;
   let items;
+  let pageSize;
+  let totalItems;
 
   switch (action.type) {
     case ADD_TERM_STARTED:
@@ -49,6 +51,8 @@ export default (state = Immutable.Map(), action) => {
       }));
     case PARTIAL_TERM_SEARCH_FULFILLED:
       count = parseInt(action.payload.data['ns2:abstract-common-list'].itemsInPage, 10);
+      pageSize = parseInt(action.payload.data['ns2:abstract-common-list'].pageSize, 10);
+      totalItems = parseInt(action.payload.data['ns2:abstract-common-list'].totalItems, 10);
 
       if (Number.isNaN(count) || count === 0) {
         items = [];
@@ -66,6 +70,8 @@ export default (state = Immutable.Map(), action) => {
         action.meta.vocabulary,
       ], Immutable.Map({
         items,
+        pageSize: Number.isNaN(pageSize) ? undefined : pageSize,
+        totalItems: Number.isNaN(totalItems) ? undefined : totalItems,
       }));
     case PARTIAL_TERM_SEARCH_REJECTED:
       return state.setIn([

--- a/test/specs/containers/input/AutocompleteInputContainer.spec.jsx
+++ b/test/specs/containers/input/AutocompleteInputContainer.spec.jsx
@@ -72,6 +72,7 @@ describe('AutocompleteInputContainer', () => {
     input.props.should.have.property('formatCloneOptionLabel').that.is.a('function');
     input.props.should.have.property('formatCreateNewOptionLabel').that.is.a('function');
     input.props.should.have.property('formatMoreCharsRequiredMessage').that.is.a('function');
+    input.props.should.have.property('formatNarrowResultsMessage').that.is.a('function');
     input.props.should.have.property('formatSearchResultMessage').that.is.a('function');
     input.props.should.have.property('formatSourceName').that.is.a('function');
     input.props.should.have.property('addTerm').that.is.a('function');
@@ -131,6 +132,7 @@ describe('AutocompleteInputContainer', () => {
     input.props.should.have.property('formatCloneOptionLabel').that.is.a('function');
     input.props.should.have.property('formatCreateNewOptionLabel').that.is.a('function');
     input.props.should.have.property('formatMoreCharsRequiredMessage').that.is.a('function');
+    input.props.should.have.property('formatNarrowResultsMessage').that.is.a('function');
     input.props.should.have.property('formatSearchResultMessage').that.is.a('function');
     input.props.should.have.property('formatSourceName').that.is.a('function');
     input.props.should.have.property('addTerm').that.is.a('function');
@@ -366,7 +368,7 @@ describe('AutocompleteInputContainer', () => {
     store.getActions()[2].should.have.property('type', CLEAR_PARTIAL_TERM_SEARCH_RESULTS);
   });
 
-  it('should connect formatAddPrompt, formatCloneOptionLabel, formatCreateNewOptionLabel, formatMoreCharsRequiredMessage, formatSearchResultMessage, and formatSourceName to intl.formatMessage', () => {
+  it('should connect formatAddPrompt, formatCloneOptionLabel, formatCreateNewOptionLabel, formatMoreCharsRequiredMessage, formatNarrowResultsMessage, formatSearchResultMessage, and formatSourceName to intl.formatMessage', () => {
     const matches = Immutable.Map({});
 
     let formatMessageCalledCount = 0;
@@ -445,12 +447,16 @@ describe('AutocompleteInputContainer', () => {
 
     formatMessageCalledCount.should.equal(4);
 
-    input.props.formatSearchResultMessage(1);
+    input.props.formatNarrowResultsMessage();
 
     formatMessageCalledCount.should.equal(5);
 
-    input.props.formatSourceName({ messages: {} });
+    input.props.formatSearchResultMessage(1);
 
     formatMessageCalledCount.should.equal(6);
+
+    input.props.formatSourceName({ messages: {} });
+
+    formatMessageCalledCount.should.equal(7);
   });
 });

--- a/test/specs/reducers/partialTermSearch.spec.js
+++ b/test/specs/reducers/partialTermSearch.spec.js
@@ -126,6 +126,8 @@ describe('partialTermSearch reducer', () => {
     const searchData = {
       'ns2:abstract-common-list': {
         itemsInPage: '2',
+        pageSize: '40',
+        totalItems: '2',
         'list-item': items,
       },
     };
@@ -145,6 +147,8 @@ describe('partialTermSearch reducer', () => {
     });
 
     newState.getIn([partialTerm, recordType, vocabulary, 'items']).should.deep.equal(items);
+    newState.getIn([partialTerm, recordType, vocabulary, 'pageSize']).should.equal(40);
+    newState.getIn([partialTerm, recordType, vocabulary, 'totalItems']).should.equal(2);
 
     getMatches(newState).should.equal(newState);
   });


### PR DESCRIPTION
**What does this do?**
It stores the `pageSize` and `totalItems` in redux for each partial term search response. It also adds a `formatNarrowResultsMessage` passing it to `AutocompleteInput`, so it can show "Continue typing to narrow results" instead of a misleading count when the server truncates the result list.

**Why are we doing this? (with JIRA link)**
https://collectionspace.atlassian.net/browse/DRYD-2144

**How should this be tested? Do these changes have associated tests?**
Tests have been extended. 

For manual testing:
After building cspace-ui.js with cspace-input.js changes https://github.com/collectionspace/cspace-input.js/pull/28 (I do it by changing package.json entry to use a symlink to the local cspace-input: `"cspace-input": "file:../cspace-input.js",`) start the devserver using anthro.collectionspace.org as backend.

Big single-vocabulary sources showing "Continue typing to narrow results":
* Object record -> Field collection place (actually multi-source but only the local place has 33,791 terms). Type san, cal, or riv.
* Object record -> Content -> Place (controlled) single-source place/local, same prefixes.
* Organization fields (any org-sourced field) 612 terms. Type uni.

Multi-vocabulary sources showing "Continue typing to narrow results":
* Acquisition record -> Acquisition source. Type tri. person/local responds with 3 total items, organization/local responds with 40. The drop down shows  "Continue typing to narrow results". When you continue typing tribal then the 14 matching terms found appears that is a sum of both endpoint results.

**Dependencies for merging? Releasing to production?**
After merging the cspace-input PR https://github.com/collectionspace/cspace-input.js/pull/28 and publishing it to npmjs, we need to update the cspace-ui package-lock.json before merging this PR.

**Has the application documentation been updated for these changes?**
Changelog has been updated

**Did someone actually run this code to verify it works?**
@spirosdi ran it locally with anthro.collectionspace.org as backend

**Have any new accessibility violations been handled?**
No new a11y violations
