### PR TITLE
DRYD-2160 Objects > "Leave Record?" prompt always appears for records with media

### DIFF
--- a/src/actions/record.js
+++ b/src/actions/record.js
@@ -1020,13 +1020,16 @@ export const moveFieldValue = (recordTypeConfig, csid, path, newPosition) => (di
     .then(() => dispatch(validateRecordData(recordTypeConfig, csid)));
 };
 
-export const setFieldValue = (recordTypeConfig, csid, path, value) => (dispatch) => {
+export const setFieldValue = (
+  recordTypeConfig, csid, path, value, updateBaseline = false,
+) => (dispatch) => {
   dispatch({
     type: SET_FIELD_VALUE,
     payload: value,
     meta: {
       csid,
       path,
+      updateBaseline,
     },
   });
 

--- a/src/components/record/MediaPriorityOrderPanel.jsx
+++ b/src/components/record/MediaPriorityOrderPanel.jsx
@@ -139,7 +139,7 @@ export default function MediaPriorityOrderPanel(props) {
 
   useEffect(() => {
     if (mergedValue && !mergedValue.equals(Immutable.List(toRefNameArray(storedValue)))) {
-      onCommit(mediaPriorityPath, mergedValue);
+      dispatch(setFieldValue(recordTypeConfig, csid, mediaPriorityPath, mergedValue, true));
     }
   }, [mergedValue]);
 

--- a/src/reducers/record.js
+++ b/src/reducers/record.js
@@ -307,6 +307,7 @@ const setFieldValue = (state, action) => {
   const {
     csid,
     path,
+    updateBaseline,
   } = action.meta;
 
   const data = getCurrentData(state, csid);
@@ -317,7 +318,25 @@ const setFieldValue = (state, action) => {
 
   const newValue = action.payload;
   const updatedData = deepSet(data, path, newValue);
-  const nextState = setCurrentData(state, csid, updatedData);
+
+  let nextState = setCurrentData(state, csid, updatedData);
+
+  if (updateBaseline) {
+    // Apply the change to the baseline data as well as the current data, so that it does not
+    // cause the record to be considered modified. When the record is unmodified, the baseline
+    // and current data must remain referentially equal, since modification checks use reference
+    // equality.
+
+    const baselineData = getBaselineData(state, csid);
+
+    if (baselineData) {
+      nextState = setBaselineData(
+        nextState,
+        csid,
+        (baselineData === data) ? updatedData : deepSet(baselineData, path, newValue),
+      );
+    }
+  }
 
   return nextState;
 };

--- a/test/specs/actions/record.spec.js
+++ b/test/specs/actions/record.spec.js
@@ -3039,6 +3039,7 @@ describe('record action creator', () => {
             meta: {
               csid,
               path,
+              updateBaseline: false,
             },
           });
 

--- a/test/specs/reducers/record.spec.js
+++ b/test/specs/reducers/record.spec.js
@@ -816,6 +816,89 @@ describe('record reducer', () => {
     isModified(state, csid).should.equal(true);
   });
 
+  it('should update the baseline data when SET_FIELD_VALUE has updateBaseline set', () => {
+    const csid = '1234';
+
+    let data;
+    let state;
+
+    // Setting a value on an unmodified record leaves it unmodified
+
+    data = Immutable.fromJS({
+      foo: {
+        bar: 'a',
+      },
+    });
+
+    state = reducer(Immutable.fromJS({
+      [csid]: {
+        data: {
+          baseline: data,
+          current: data,
+        },
+      },
+    }), {
+      type: SET_FIELD_VALUE,
+      payload: 'b',
+      meta: {
+        csid,
+        path: ['foo', 'bar'],
+        updateBaseline: true,
+      },
+    });
+
+    getData(state, csid).should.equal(Immutable.fromJS({
+      foo: {
+        bar: 'b',
+      },
+    }));
+
+    isModified(state, csid).should.equal(false);
+
+    // Setting a value on a modified record applies to both baseline and current data, and
+    // leaves it modified
+
+    data = Immutable.fromJS({
+      foo: {
+        bar: 'a',
+        baz: 'x',
+      },
+    });
+
+    state = reducer(Immutable.fromJS({
+      [csid]: {
+        data: {
+          baseline: data,
+          current: data.setIn(['foo', 'baz'], 'y'),
+        },
+      },
+    }), {
+      type: SET_FIELD_VALUE,
+      payload: 'b',
+      meta: {
+        csid,
+        path: ['foo', 'bar'],
+        updateBaseline: true,
+      },
+    });
+
+    getData(state, csid).should.equal(Immutable.fromJS({
+      foo: {
+        bar: 'b',
+        baz: 'y',
+      },
+    }));
+
+    state.getIn([csid, 'data', 'baseline']).should.equal(Immutable.fromJS({
+      foo: {
+        bar: 'b',
+        baz: 'x',
+      },
+    }));
+
+    isModified(state, csid).should.equal(true);
+  });
+
   it('should handle RECORD_READ_STARTED', () => {
     const csid = '1234';
 


### PR DESCRIPTION
**What does this do?**
The Media Priority panel merges newly related media records into the priority list when a record is viewed. This was committed to the record's current data only, making the record appear modified and triggering the "Leave Record?" prompt on any object with related media.

setFieldValue now accepts an updateBaseline flag. When set, the value is applied to the baseline data as well as the current data, preserving reference equality when the record is unmodified. The panel's passive merge uses the flag. User edits (reorder, save) still mark the record modified.

**Why are we doing this? (with JIRA link)**
https://collectionspace.atlassian.net/browse/DRYD-2160

**How should this be tested? Do these changes have associated tests?**
1. Create a new Collection Object
2. Relate a MH record
3. Navigate away from the record editor
4. Confirm that the "Leave Record?" prompt does not appear
5. Navigate back to the record editor of the Collection Object and apply a change. It can also be a media handling reordering
6. Confirm that the "Leave Record?" prompt does appear

**Dependencies for merging? Releasing to production?**
No dependencies

**Has the application documentation been updated for these changes?**
No need for changelog change

**Did someone actually run this code to verify it works?**
@spirosdi ran it locally

**Have any new accessibility violations been handled?**
no new a11y issues